### PR TITLE
Minor patch on the annotation and indents of TIR func dispatch

### DIFF
--- a/web_llm/transform/dispatch_tir_operator.py
+++ b/web_llm/transform/dispatch_tir_operator.py
@@ -1973,28 +1973,28 @@ def decode_sch_func(orig_func):
 
 @T.prim_func
 def fused_decode3_matmul1_before(lv2931: T.Buffer((T.int64(512), T.int64(32001)), "uint32"), lv2932: T.Buffer((T.int64(128), T.int64(32001)), "uint32"), lv1511: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float32"), var_matmul_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(32001)), "float32")):
-        T.func_attr({"tir.noalias": T.bool(True)})
-        # with T.block("root"):
-        var_decode_intermediate = T.alloc_buffer((T.int64(4096), T.int64(32001)))
-        for i, j in T.grid(T.int64(4096), T.int64(32001)):
-            with T.block("decode"):
-                v_i, v_j = T.axis.remap("SS", [i, j])
-                T.reads(lv2931[v_i // T.int64(8), v_j], lv2932[v_i // T.int64(32), v_j])
-                T.writes(var_decode_intermediate[v_i, v_j])
-                var_decode_intermediate[v_i, v_j] = T.Cast("float32", T.bitwise_and(T.shift_right(lv2931[v_i // T.int64(8), v_j], T.Cast("uint32", v_i % T.int64(8) * T.int64(4))), T.uint32(15))) * T.reinterpret("float32", T.shift_left(T.bitwise_and(lv2932[v_i // T.int64(32), v_j], T.uint32(65535)), T.uint32(16))) + T.reinterpret("float32", T.shift_left(T.bitwise_and(T.shift_right(lv2932[v_i // T.int64(32), v_j], T.uint32(16)), T.uint32(65535)), T.uint32(16)))
-        for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32001), T.int64(4096)):
-            with T.block("matmul"):
-                v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
-                T.reads(lv1511[v_i0, v_i1, v_k], var_decode_intermediate[v_k, v_i2])
-                T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
-                with T.init():
-                    var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float32(0)
-                var_matmul_intermediate[v_i0, v_i1, v_i2] = var_matmul_intermediate[v_i0, v_i1, v_i2] + lv1511[v_i0, v_i1, v_k] * var_decode_intermediate[v_k, v_i2]
+    T.func_attr({"tir.noalias": T.bool(True)})
+    # with T.block("root"):
+    var_decode_intermediate = T.alloc_buffer((T.int64(4096), T.int64(32001)))
+    for i, j in T.grid(T.int64(4096), T.int64(32001)):
+        with T.block("decode"):
+            v_i, v_j = T.axis.remap("SS", [i, j])
+            T.reads(lv2931[v_i // T.int64(8), v_j], lv2932[v_i // T.int64(32), v_j])
+            T.writes(var_decode_intermediate[v_i, v_j])
+            var_decode_intermediate[v_i, v_j] = T.Cast("float32", T.bitwise_and(T.shift_right(lv2931[v_i // T.int64(8), v_j], T.Cast("uint32", v_i % T.int64(8) * T.int64(4))), T.uint32(15))) * T.reinterpret("float32", T.shift_left(T.bitwise_and(lv2932[v_i // T.int64(32), v_j], T.uint32(65535)), T.uint32(16))) + T.reinterpret("float32", T.shift_left(T.bitwise_and(T.shift_right(lv2932[v_i // T.int64(32), v_j], T.uint32(16)), T.uint32(65535)), T.uint32(16)))
+    for i0, i1, i2, k in T.grid(T.int64(1), T.int64(1), T.int64(32001), T.int64(4096)):
+        with T.block("matmul"):
+            v_i0, v_i1, v_i2, v_k = T.axis.remap("SSSR", [i0, i1, i2, k])
+            T.reads(lv1511[v_i0, v_i1, v_k], var_decode_intermediate[v_k, v_i2])
+            T.writes(var_matmul_intermediate[v_i0, v_i1, v_i2])
+            with T.init():
+                var_matmul_intermediate[v_i0, v_i1, v_i2] = T.float32(0)
+            var_matmul_intermediate[v_i0, v_i1, v_i2] = var_matmul_intermediate[v_i0, v_i1, v_i2] + lv1511[v_i0, v_i1, v_k] * var_decode_intermediate[v_k, v_i2]
 
 
 @T.prim_func
 def fused_decode3_matmul1_after(lv1123: T.Buffer((T.int64(512), T.int64(32001)), "uint32"), lv1124: T.Buffer((T.int64(128), T.int64(32001)), "uint32"), lv1511: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float32"), var_matmul_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(32001)), "float32")):
-    T.func_attr({"global_symbol": "main", "tir.noalias": T.bool(True)})
+    T.func_attr({"global_symbol": "main", "tir.noalias": T.bool(True), "tir.is_scheduled": 1})
     # with T.block("root"):
     var_decode_intermediate_pad_local = T.alloc_buffer((T.int64(4096), T.int64(35072)), scope="local")
     var_matmul_intermediate_pad_local = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(35072)), scope="local")
@@ -2415,59 +2415,59 @@ def fused_decode6_fused_matmul9_add3_before(lv1623: T.Buffer((T.int64(1376), T.i
 
 @T.prim_func
 def fused_decode6_fused_matmul9_add3_after(lv1158: T.Buffer((T.int64(1376), T.int64(4096)), "uint32"), lv1159: T.Buffer((T.int64(344), T.int64(4096)), "uint32"), lv6: T.Buffer((T.int64(1), T.int64(1), T.int64(11008)), "float32"), lv4: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float32"), p_output0_intermediate: T.Buffer((T.int64(1), T.int64(1), T.int64(4096)), "float32")):
-        T.func_attr({"global_symbol": "main", "tir.noalias": T.bool(True)})
-        # with T.block("root"):
-        var_decode_intermediate_local = T.alloc_buffer((T.int64(11008), T.int64(4096)), scope="local")
-        var_matmul_intermediate_local = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(4096)), scope="local")
-        lv6_shared = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), scope="shared")
-        for i0_i1_i2_0_fused in T.thread_binding(T.int64(16), thread="blockIdx.x", annotations={"pragma_auto_unroll_max_step": 16, "pragma_unroll_explicit": 1}):
-            for i2_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
-                for i2_2 in T.thread_binding(T.int64(256), thread="threadIdx.x"):
-                    with T.block("matmul_init"):
-                        v_i0 = T.axis.spatial(T.int64(1), T.int64(0))
-                        v_i1 = T.axis.spatial(T.int64(1), T.int64(0))
-                        v_i2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_1 * T.int64(256) + i2_2)
-                        T.reads()
-                        T.writes(var_matmul_intermediate_local[v_i0, v_i1, v_i2])
-                        var_matmul_intermediate_local[v_i0, v_i1, v_i2] = T.float32(0)
-                    for k_0_0 in range(T.int64(2)):
-                        for ax0, ax1_ax2_fused_0 in T.grid(T.int64(1), T.int64(22)):
-                            for ax1_ax2_fused_1 in T.thread_binding(T.int64(256), thread="threadIdx.x"):
-                                with T.block("lv6_shared"):
-                                    v0 = T.axis.spatial(T.int64(1), ax0)
-                                    v1 = T.axis.spatial(T.int64(1), T.int64(0))
-                                    v2 = T.axis.spatial(T.int64(11008), k_0_0 * T.int64(5504) + (ax1_ax2_fused_0 * T.int64(256) + ax1_ax2_fused_1))
-                                    T.where(ax1_ax2_fused_0 * T.int64(256) + ax1_ax2_fused_1 < T.int64(5504))
-                                    T.reads(lv6[v0, v1, v2])
-                                    T.writes(lv6_shared[v0, v1, v2])
-                                    T.block_attr({"buffer_dim_align": [[0, 1, 32, 8]]})
-                                    lv6_shared[v0, v1, v2] = lv6[v0, v1, v2]
-                        for k_0_1 in range(T.int64(86)):
-                            for ax0_0 in range(T.int64(8)):
-                                for ax0_1 in T.unroll(T.int64(8)):
-                                    for ax1 in range(T.int64(1)):
-                                        with T.block("decode"):
-                                            v_j = T.axis.spatial(T.int64(11008), k_0_0 * T.int64(5504) + k_0_1 * T.int64(64) + ax0_0 * T.int64(8) + ax0_1)
-                                            v_i = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_2 + ax1)
-                                            T.reads(lv1158[v_j // T.int64(8), v_i], lv1159[v_j // T.int64(32), v_i])
-                                            T.writes(var_decode_intermediate_local[v_j, v_i])
-                                            var_decode_intermediate_local[v_j, v_i] = T.Cast("float32", T.bitwise_and(T.shift_right(lv1158[v_j // T.int64(8), v_i], T.Cast("uint32", v_j % T.int64(8) * T.int64(4))), T.uint32(15))) * T.reinterpret("float32", T.shift_left(T.bitwise_and(lv1159[v_j // T.int64(32), v_i], T.uint32(65535)), T.uint32(16))) + T.reinterpret("float32", T.shift_left(T.bitwise_and(T.shift_right(lv1159[v_j // T.int64(32), v_i], T.uint32(16)), T.uint32(65535)), T.uint32(16)))
-                            for k_0_2_k_1_fused in range(T.int64(64)):
-                                with T.block("matmul_update"):
-                                    v_i0 = T.axis.spatial(T.int64(1), T.int64(0))
-                                    v_i1 = T.axis.spatial(T.int64(1), T.int64(0))
-                                    v_i2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_1 * T.int64(256) + i2_2)
-                                    v_k = T.axis.reduce(T.int64(11008), k_0_0 * T.int64(5504) + k_0_1 * T.int64(64) + k_0_2_k_1_fused)
-                                    T.reads(var_matmul_intermediate_local[v_i0, v_i1, v_i2], lv6_shared[v_i0, v_i1, v_k], var_decode_intermediate_local[v_k, v_i2])
-                                    T.writes(var_matmul_intermediate_local[v_i0, v_i1, v_i2])
-                                    var_matmul_intermediate_local[v_i0, v_i1, v_i2] = var_matmul_intermediate_local[v_i0, v_i1, v_i2] + lv6_shared[v_i0, v_i1, v_k] * var_decode_intermediate_local[v_k, v_i2]
-                    for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(1)):
-                        with T.block("var_matmul_intermediate_local"):
-                            v0, v1 = T.axis.remap("SS", [ax0, ax1])
-                            v2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_2 + ax2)
-                            T.reads(lv4[v0, v1, v2], var_matmul_intermediate_local[v0, v1, v2])
-                            T.writes(p_output0_intermediate[v0, v1, v2])
-                            p_output0_intermediate[v0, v1, v2] = lv4[v0, v1, v2] + var_matmul_intermediate_local[v0, v1, v2]
+    T.func_attr({"global_symbol": "main", "tir.noalias": T.bool(True), "tir.is_scheduled": 1})
+    # with T.block("root"):
+    var_decode_intermediate_local = T.alloc_buffer((T.int64(11008), T.int64(4096)), scope="local")
+    var_matmul_intermediate_local = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(4096)), scope="local")
+    lv6_shared = T.alloc_buffer((T.int64(1), T.int64(1), T.int64(11008)), scope="shared")
+    for i0_i1_i2_0_fused in T.thread_binding(T.int64(16), thread="blockIdx.x", annotations={"pragma_auto_unroll_max_step": 16, "pragma_unroll_explicit": 1}):
+        for i2_1 in T.thread_binding(T.int64(1), thread="vthread.x"):
+            for i2_2 in T.thread_binding(T.int64(256), thread="threadIdx.x"):
+                with T.block("matmul_init"):
+                    v_i0 = T.axis.spatial(T.int64(1), T.int64(0))
+                    v_i1 = T.axis.spatial(T.int64(1), T.int64(0))
+                    v_i2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_1 * T.int64(256) + i2_2)
+                    T.reads()
+                    T.writes(var_matmul_intermediate_local[v_i0, v_i1, v_i2])
+                    var_matmul_intermediate_local[v_i0, v_i1, v_i2] = T.float32(0)
+                for k_0_0 in range(T.int64(2)):
+                    for ax0, ax1_ax2_fused_0 in T.grid(T.int64(1), T.int64(22)):
+                        for ax1_ax2_fused_1 in T.thread_binding(T.int64(256), thread="threadIdx.x"):
+                            with T.block("lv6_shared"):
+                                v0 = T.axis.spatial(T.int64(1), ax0)
+                                v1 = T.axis.spatial(T.int64(1), T.int64(0))
+                                v2 = T.axis.spatial(T.int64(11008), k_0_0 * T.int64(5504) + (ax1_ax2_fused_0 * T.int64(256) + ax1_ax2_fused_1))
+                                T.where(ax1_ax2_fused_0 * T.int64(256) + ax1_ax2_fused_1 < T.int64(5504))
+                                T.reads(lv6[v0, v1, v2])
+                                T.writes(lv6_shared[v0, v1, v2])
+                                T.block_attr({"buffer_dim_align": [[0, 1, 32, 8]]})
+                                lv6_shared[v0, v1, v2] = lv6[v0, v1, v2]
+                    for k_0_1 in range(T.int64(86)):
+                        for ax0_0 in range(T.int64(8)):
+                            for ax0_1 in T.unroll(T.int64(8)):
+                                for ax1 in range(T.int64(1)):
+                                    with T.block("decode"):
+                                        v_j = T.axis.spatial(T.int64(11008), k_0_0 * T.int64(5504) + k_0_1 * T.int64(64) + ax0_0 * T.int64(8) + ax0_1)
+                                        v_i = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_2 + ax1)
+                                        T.reads(lv1158[v_j // T.int64(8), v_i], lv1159[v_j // T.int64(32), v_i])
+                                        T.writes(var_decode_intermediate_local[v_j, v_i])
+                                        var_decode_intermediate_local[v_j, v_i] = T.Cast("float32", T.bitwise_and(T.shift_right(lv1158[v_j // T.int64(8), v_i], T.Cast("uint32", v_j % T.int64(8) * T.int64(4))), T.uint32(15))) * T.reinterpret("float32", T.shift_left(T.bitwise_and(lv1159[v_j // T.int64(32), v_i], T.uint32(65535)), T.uint32(16))) + T.reinterpret("float32", T.shift_left(T.bitwise_and(T.shift_right(lv1159[v_j // T.int64(32), v_i], T.uint32(16)), T.uint32(65535)), T.uint32(16)))
+                        for k_0_2_k_1_fused in range(T.int64(64)):
+                            with T.block("matmul_update"):
+                                v_i0 = T.axis.spatial(T.int64(1), T.int64(0))
+                                v_i1 = T.axis.spatial(T.int64(1), T.int64(0))
+                                v_i2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_1 * T.int64(256) + i2_2)
+                                v_k = T.axis.reduce(T.int64(11008), k_0_0 * T.int64(5504) + k_0_1 * T.int64(64) + k_0_2_k_1_fused)
+                                T.reads(var_matmul_intermediate_local[v_i0, v_i1, v_i2], lv6_shared[v_i0, v_i1, v_k], var_decode_intermediate_local[v_k, v_i2])
+                                T.writes(var_matmul_intermediate_local[v_i0, v_i1, v_i2])
+                                var_matmul_intermediate_local[v_i0, v_i1, v_i2] = var_matmul_intermediate_local[v_i0, v_i1, v_i2] + lv6_shared[v_i0, v_i1, v_k] * var_decode_intermediate_local[v_k, v_i2]
+                for ax0, ax1, ax2 in T.grid(T.int64(1), T.int64(1), T.int64(1)):
+                    with T.block("var_matmul_intermediate_local"):
+                        v0, v1 = T.axis.remap("SS", [ax0, ax1])
+                        v2 = T.axis.spatial(T.int64(4096), i0_i1_i2_0_fused * T.int64(256) + i2_2 + ax2)
+                        T.reads(lv4[v0, v1, v2], var_matmul_intermediate_local[v0, v1, v2])
+                        T.writes(p_output0_intermediate[v0, v1, v2])
+                        p_output0_intermediate[v0, v1, v2] = lv4[v0, v1, v2] + var_matmul_intermediate_local[v0, v1, v2]
 # fmt: on
 
 ################################################


### PR DESCRIPTION
This PR adds the function annotation to those TIR functions after scheduling, so that the default GPU schedule pass will skip them. These annotations are missed to add before.

This PR reindent some of the PrimFunc TVMScript to remove the redundant indents.