### PR TITLE
Enable KV cache reuse across conversations

### DIFF
--- a/build.py
+++ b/build.py
@@ -88,7 +88,7 @@ def get_models(config, model):
         for gv in mod.functions:
             func = mod[gv]
             if isinstance(func, relax.Function):
-                mod[gv] = func.with_attr("tir_var_upper_bound", {"n": config.max_sequence_length})
+                mod[gv] = func.with_attr("tir_var_upper_bound", {"n": config.max_sequence_length, "m": config.max_sequence_length})
 
         return mod
     else:

--- a/web/gh-page-config.json
+++ b/web/gh-page-config.json
@@ -5,7 +5,7 @@
         "dtype": "float32"
     },
     "wasmUrl": "dist/vicuna-7b-v1/vicuna-7b-v1_webgpu.wasm",
-    "cacheUrl": "https://huggingface.co/mlc-ai/web-lm/resolve/main/vicuna-0b/",
+    "cacheUrl": "https://huggingface.co/mlc-ai/web-lm/resolve/main/vicuna-7b-v1/",
     "tokenizer": "dist/vicuna-7b-v1/tokenizer.model",
     "maxGenLength": 512,
     "meanGenLength": 128,

--- a/web/local-config.json
+++ b/web/local-config.json
@@ -7,7 +7,7 @@
     "wasmUrl": "dist/vicuna-7b-v1/vicuna-7b-v1_webgpu.wasm",
     "cacheUrl": "vicuna-7b-v1-params/",
     "tokenizer": "dist/vicuna-7b-v1/tokenizer.model",
-    "maxGenLength": 512,
-    "meanGenLength": 128,
-    "maxWindowLength": 1024
+    "maxGenLength": 1024,
+    "meanGenLength": 256,
+    "maxWindowLength": 2048
 }


### PR DESCRIPTION
Currently, when user enter an input, the behavior is to clear KV cache and collect all previous conversation history as input prompt to the model. It becomes extremely slow when the history is large. But clearly, there exists some redundant kv computation for previous conversations. We could utilize the kv cache from the last round of conversation to avoid kv recomputation. This PR enables such optimization.