### PR TITLE
Use arrow function to avoid new `this` binding

### DIFF
--- a/web/llm_chat.js
+++ b/web/llm_chat.js
@@ -466,9 +466,8 @@ class LLMChatInstance {
     }
     this.appendMessage("init", "");
     this.tvm = tvm;
-    self = this;
-    function initProgressCallback(report) {
-      self.updateLastMessage("init", report.text);
+    const initProgressCallback = (report) => {
+      this.updateLastMessage("init", report.text);
     }
     tvm.registerInitProgressCallback(initProgressCallback);
     if (!cacheUrl.startsWith("http")) {


### PR DESCRIPTION
While integrating this into a Next.js project I noticed that when it tried to run `self.updateLastMessage` it would crash Webpack in general and nothing else would load. Converting this to an arrow function to maintain the existing `this` binding fixed my issue. I'd reported this in https://github.com/mlc-ai/web-llm/issues/52.