### PR TITLE
Reset kvCacheLength on #clearKVCache

### DIFF
--- a/web/llm_chat.js
+++ b/web/llm_chat.js
@@ -178,6 +178,7 @@ class LLMChatPipeline {
 
   #clearKVCache() {
     this.fclearKVCaches(this.kvCache);
+    this.kvCacheLength = 0;
   }
 
   #forward(inputs, curPos) {


### PR DESCRIPTION
After `asyncOnReset` I was getting an error when trying to start a new conversation. After some trial and error I've found that `kvCacheLength` being reset to `0` fixed the issue. Based on the discussion in https://github.com/mlc-ai/web-llm/issues/83 I have created this PR to upstream the fix that worked for me.