### PR TITLE
fix: error occurs if change model without initing, the model can't be sel…

### DIFF
--- a/web/llm_chat.html
+++ b/web/llm_chat.html
@@ -30,14 +30,6 @@
   </select>
 </form>
 
-<br />
-
-<form>
-  <div title="Temperature (> 0)">
-    <label for="temperature">Temperature:</label>
-    <input id="temperature" name="temperature" type="number" datatype="number" min="0.001" step="1" value="0.8"/>
-  </div>
-</form>
 <!-- <label>Pick a pre-compiled model or load your own model's mlc-chat-config.json:
   <input list="model-names" name="model" id="model"/></label>
 <datalist id="model-names">

--- a/web/llm_chat.html
+++ b/web/llm_chat.html
@@ -30,6 +30,14 @@
   </select>
 </form>
 
+<br />
+
+<form>
+  <div title="Temperature (> 0)">
+    <label for="temperature">Temperature:</label>
+    <input id="temperature" name="temperature" type="number" datatype="number" min="0.001" step="1" value="0.8"/>
+  </div>
+</form>
 <!-- <label>Pick a pre-compiled model or load your own model's mlc-chat-config.json:
   <input list="model-names" name="model" id="model"/></label>
 <datalist id="model-names">

--- a/web/llm_chat.js
+++ b/web/llm_chat.js
@@ -687,6 +687,7 @@ class LLMChatInstance {
 
   resetChat() {
     if (this.requestInProgress) return;
+    if (!this.uiChat) return;
     const clearTags = ["left", "right"];
     for (const tag of clearTags) {
       const matches = this.uiChat.getElementsByClassName(`msg ${tag}-msg`);

--- a/web/llm_chat.js
+++ b/web/llm_chat.js
@@ -495,7 +495,6 @@ class LLMChatInstance {
     this.logger = console.log;
     this.debugTest = false;
     this.model = "RedPajama-INCITE-Chat-3B-v1-q4f32_0";
-    this.temperature = undefined;
 
   }
 
@@ -600,9 +599,6 @@ class LLMChatInstance {
       this.config.cacheUrl = base_url + this.config.model_url;
     } else {
       this.config.cacheUrl = base_url;
-    }
-    if (this.temperature !== undefined) {
-      this.config.temperature = this.temperature;
     }
   }
 
@@ -793,20 +789,5 @@ function handle_model_change() {
   e.onchange = onChange;
 }
 
-function handle_temperature_change() {
-  var e = document.getElementById('temperature');
-  function onChange() {
-    localLLMChatIntance.temperature = e.value;
-    if (localLLMChatIntance.pipeline) {
-      localLLMChatIntance.pipeline.temperature = e.value;
-    }
-    localLLMChatIntance.logger("temperature changed to " + e.value);
-  }
-  e.onchange = onChange;
-}
-
-document.addEventListener("DOMContentLoaded", function() {
-  handle_model_change();
-  handle_temperature_change();
-});
+handle_model_change()
 

--- a/web/llm_chat.js
+++ b/web/llm_chat.js
@@ -495,6 +495,7 @@ class LLMChatInstance {
     this.logger = console.log;
     this.debugTest = false;
     this.model = "RedPajama-INCITE-Chat-3B-v1-q4f32_0";
+    this.temperature = undefined;
 
   }
 
@@ -599,6 +600,9 @@ class LLMChatInstance {
       this.config.cacheUrl = base_url + this.config.model_url;
     } else {
       this.config.cacheUrl = base_url;
+    }
+    if (this.temperature !== undefined) {
+      this.config.temperature = this.temperature;
     }
   }
 
@@ -789,5 +793,20 @@ function handle_model_change() {
   e.onchange = onChange;
 }
 
-handle_model_change()
+function handle_temperature_change() {
+  var e = document.getElementById('temperature');
+  function onChange() {
+    localLLMChatIntance.temperature = e.value;
+    if (localLLMChatIntance.pipeline) {
+      localLLMChatIntance.pipeline.temperature = e.value;
+    }
+    localLLMChatIntance.logger("temperature changed to " + e.value);
+  }
+  e.onchange = onChange;
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  handle_model_change();
+  handle_temperature_change();
+});
 


### PR DESCRIPTION
When change model without initing, error occurs:
```shell
Uncaught TypeError: Cannot read properties of undefined (reading 'getElementsByClassName')
    at LLMChatInstance.resetChat (llm_chat.js:693:35)
    at LLMChatInstance.reboot (llm_chat.js:502:10)
    at HTMLSelectElement.onChange (llm_chat.js:785:25)
```

<img width="1360" alt="截屏2023-05-22 23 04 58" src="https://github.com/mlc-ai/web-llm/assets/53991079/08ccac43-8517-491a-a99a-35e05198eeb6">

so the model can't be set correctly. check uichat element if occurs can fix it.