### PR TITLE
Allow configuring conversation

### DIFF
--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -50,7 +50,7 @@ export class ChatModule implements ChatInterface {
     const config = {
       ...(await (await configCache.fetchWithCache(configUrl)).json()),
       ...chatOpts
-  } as ChatConfig;
+    } as ChatConfig;
 
     const findWasmUrl = () => {
       if (appConfig?.model_lib_map !== undefined) {

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -47,10 +47,10 @@ export class ChatModule implements ChatInterface {
 
     // load config
     const configUrl = new URL("mlc-chat-config.json", modelUrl).href;
-    const config = await (
-      await configCache.fetchWithCache(configUrl)
-    ).json() as ChatConfig;
-
+    const config = {
+      ...(await (await configCache.fetchWithCache(configUrl)).json()),
+      ...chatOpts
+  } as ChatConfig;
 
     const findWasmUrl = () => {
       if (appConfig?.model_lib_map !== undefined) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface ChatConfig {
   local_id: string;
   model_lib: string;
   tokenizer_files: Array<string>;
+  conv_config?: Partial<ConvTemplateConfig>;
   conv_template: string;
   // additional metadata
   mean_gen_len: number;

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -111,7 +111,7 @@ export class Conversation {
   }
 }
 
-export function getConversation(conv_template: string): Conversation {
+export function getConversation(conv_template: string, conv_config?: Partial<ConvTemplateConfig>): Conversation {
   if (conv_template == "vicuna_v1.1") {
     return new Conversation({
       system: "A chat between a curious user and an artificial intelligence assistant. " +
@@ -121,6 +121,7 @@ export function getConversation(conv_template: string): Conversation {
       seps: [" ", "</s>"],
       separator_style: "Two",
       add_bos: true,
+      ...conv_config,
     });
   } else if (conv_template == "wizardlm") {
     return new Conversation({
@@ -130,6 +131,7 @@ export function getConversation(conv_template: string): Conversation {
       seps: ["\n\n", "</s>"],
       separator_style: "Two",
       add_bos: true,
+      ...conv_config,
     })
   } else if (conv_template == "redpajama_chat") {
     return new Conversation({
@@ -139,6 +141,7 @@ export function getConversation(conv_template: string): Conversation {
       seps: ["", ""],
       separator_style: "RedPajamaChat",
       add_bos: false,
+      ...conv_config,
     })
   } else {
     throw Error("Unknown conv template " + conv_template);

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -52,7 +52,7 @@ export class LLMChatPipeline {
     this.tokenizer = tokenizer;
     this.config = config;
 
-    this.conversation = getConversation(config.conv_template);
+    this.conversation = getConversation(config.conv_template, config.conv_config);
     this.stopStr = this.conversation.getStopStr();
 
     this.device = this.tvm.webgpu();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,10 @@
-import { AppConfig } from "./config"
+import { AppConfig, ChatConfig } from "./config"
 
 /**
  * Custom options that can be used to
  * override known config values.
  */
-export interface ChatOptions {
-  repetition_penalty?: number;
-  top_p?: number;
-  temperature?: number;
-}
+export interface ChatOptions extends Partial<ChatConfig> {}
 
 /**
  * Report during intialization.


### PR DESCRIPTION
I've added the ability to customize more configuration options, as well as the conversation options. I couldn't build the project as I had issues with it looking for `tvm_home`, so I have not tested this and would like some feedback on if this code makes sense.

I've created this as suggested in https://github.com/mlc-ai/web-llm/issues/115, fyi @tqchen.