### PR TITLE
Add local server support for WebLLM

### DIFF
--- a/examples/get-started-rest/README.md
+++ b/examples/get-started-rest/README.md
@@ -1,0 +1,14 @@
+# WebLLM Get Started App
+
+This folder provides a minimum demo to show WebLLM API in a webapp setting.
+To try it out, you can do the following steps under this folder
+
+```bash
+npm install
+npm start
+```
+
+Note if you would like to hack WebLLM core package.
+You can change web-llm dependencies as `"file:../.."`, and follow the build from source
+instruction in the project to build webllm locally. This option is only recommended
+if you would like to hack WebLLM core package.

--- a/examples/get-started-rest/README.md
+++ b/examples/get-started-rest/README.md
@@ -1,7 +1,7 @@
-# WebLLM Get Started App
+# WebLLM Get Started App for Local Servers
 
 This folder provides a minimum demo to show WebLLM API in a webapp setting.
-To try it out, you can do the following steps under this folder
+To try it out, first start a local server using the steps outlined [here](https://mlc.ai/mlc-llm/docs/deploy/rest.html). Next, you can do the following steps under this folder
 
 ```bash
 npm install

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "get-started",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "start": "parcel src/get_started.html  --port 8888",
+        "build": "parcel build src/get_started.html --dist-dir lib"
+    },
+    "devDependencies": {
+        "buffer": "^5.7.1",
+        "parcel": "^2.8.3",
+        "process": "^0.11.10",
+        "tslib": "^2.3.1",
+        "typescript": "^4.9.5"
+    },
+    "dependencies": {
+        "@mlc-ai/web-llm": "file:../.."
+    }
+}

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "file:../.."
+        "@mlc-ai/web-llm": "^0.2.1"
     }
 }

--- a/examples/get-started-rest/src/get_started.html
+++ b/examples/get-started-rest/src/get_started.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <script>
+    webLLMGlobal = {}
+  </script>
+  <body>
+    <h2>WebLLM Test Page</h2>
+    Open console to see output
+   </br>
+   </br>
+    <label id="init-label"> </label>
+
+    <h3>Prompt</h3>
+    <label id="prompt-label"> </label>
+
+    <h3>Response</h3>
+    <label id="generate-label"> </label>
+  </br>
+    <label id="stats-label"> </label>
+
+    <script type="module" src="./get_started.ts"></script>
+</html>

--- a/examples/get-started-rest/src/get_started.ts
+++ b/examples/get-started-rest/src/get_started.ts
@@ -1,0 +1,31 @@
+import * as webllm from "@mlc-ai/web-llm";
+
+function setLabel(id: string, text: string) {
+  const label = document.getElementById(id);
+  if (label == null) {
+      throw Error("Cannot find label " + id);
+  }
+  label.innerText = text;
+}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+async function main() {
+  const chat = new webllm.ChatRestModule();
+  chat.resetChat();
+
+  chat.setInitProgressCallback((report: webllm.InitProgressReport) => {
+      setLabel("init-label", report.text);
+  });
+
+  const generateProgressCallback = (_step: number, message: string) => {
+      setLabel("generate-label", message);
+  };
+
+  const prompt0 = "Write a song about Pittsburgh.";
+  setLabel("prompt-label", prompt0);
+  const reply0 = await chat.generate(prompt0, generateProgressCallback);
+  console.log(reply0);
+
+  console.log(await chat.runtimeStatsText());
+}
+
+main();

--- a/examples/simple-chat/README.md
+++ b/examples/simple-chat/README.md
@@ -13,3 +13,5 @@ Note if you would like to hack WebLLM core package.
 You can change web-llm dependencies as `"file:../.."`, and follow the build from source
 instruction in the project to build webllm locally. This option is only recommended
 if you would like to hack WebLLM core package.
+
+If you are using the Local Server option, first start the local server using the steps outlined [here](https://mlc.ai/mlc-llm/docs/deploy/rest.html).

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -309,7 +309,7 @@ export class ChatRestModule implements ChatInterface {
                 const parsedData = JSON.parse(jsonString);
                 const delta = parsedData["choices"][0]["delta"]["content"] as string;
                 // Hack to ignore chunks once we get the EOS token
-                if (delta.includes("</")) {
+                if (delta.includes("<")) {
                     return;
                 }
                 msg += delta;

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -335,7 +335,7 @@ export class ChatRestModule implements ChatInterface {
     }
 
     async resetChat() {
-        await fetch('http://127.0.0.1:8000/chat/reset', {
+        await fetch('http://localhost:8000/chat/reset', {
           method: "POST"
         });
     }

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -278,12 +278,9 @@ export class ChatRestModule implements ChatInterface {
             })
             .then((response) => response.json())
             .then((json) => {
-                console.log(json);
-                let counter = 1;
                 let msg = json["choices"][0]["message"]["content"] as string;
-                if (counter % streamInterval == 0 && progressCallback !== undefined) {
-                    console.log("calling progress callback");
-                    progressCallback(counter, msg);
+                if (progressCallback !== undefined) {
+                    progressCallback(0, msg);
                 }
                 return msg;
             });
@@ -301,11 +298,10 @@ export class ChatRestModule implements ChatInterface {
             })
             .then((response) => {
               const reader = response.body!.getReader();
-              let counter = 1;
               reader.read().then(function pump({ done, value }): any {
                 if (done) {
-                  if (counter % streamInterval == 0 && progressCallback !== undefined) {
-                      progressCallback(counter, msg);
+                  if (progressCallback !== undefined) {
+                      progressCallback(0, msg);
                   }
                   return;
                 }
@@ -317,8 +313,8 @@ export class ChatRestModule implements ChatInterface {
                     return;
                 }
                 msg += delta;
-                if (counter % streamInterval == 0 && progressCallback !== undefined) {
-                    progressCallback(counter, msg);
+                if (progressCallback !== undefined) {
+                    progressCallback(0, msg);
                 }
                 return reader.read().then(pump);
               });

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
 
 export {
   ChatModule,
+  ChatRestModule
 } from "./chat_module";
 
 export {


### PR DESCRIPTION
This PR adds a new `ChatRestModule` that integrates with the Python REST server. It supports both streaming and non-streaming modes.

**Getting Started Demo:**
https://github.com/mlc-ai/web-llm/assets/11940172/24421ef7-f311-474f-a1c7-683515d3755a

**Simple Chat Demo:**
https://github.com/mlc-ai/web-llm/assets/11940172/b6c1a08f-8f72-4d1e-84d7-82fa79746354

