### PR TITLE
Update model lib map for latest prebuilt wasm

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ export interface ModelRecord {
   required_features?: Array<string>;
 }
 /**
- * Extra configuration taht can be
+ * Extra configuration that can be
  * passed to the load
  */
 export interface AppConfig {
@@ -56,7 +56,7 @@ export const prebuiltAppConfig : AppConfig = {
 		}
 	],
   model_lib_map: {
-    "vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu.wasm",
-    "RedPajama-INCITE-Chat-3B-v1-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu.wasm"
+    "vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
+    "RedPajama-INCITE-Chat-3B-v1-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu-v1.wasm"
   }
 }


### PR DESCRIPTION
We recently rebuilt the prebuilt model weights and wasm libraries per some latest changes in Relax VM and MLC-LLM. This PR updates the lib map to point to the latest wasm libraries.