### PR TITLE
Fix call to fclearKVCaches with no arguments

### DIFF
--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -364,7 +364,7 @@ export class LLMChatPipeline {
     // need shift window and re-encode
     this.logger("need shift window")
     this.filledKVCacheLength = 0;
-    this.fclearKVCaches();
+    this.fclearKVCaches(this.kvCache);
 
     // abandon all tokens we collected
     if (this.conversation.config.add_bos) {


### PR DESCRIPTION
This is causing exceptions of the form

[FATAL] /Users/ruihang-macstudio/Workspace/tvm/include/tvm/runtime/packed_func.h:1731: Function vm.builtin.attention_kv_cache_array_clear(0: Array<relax.vm.AttentionKVCache>) -> void expects 1 arguments, but 0 were provided.