### PR TITLE
feat: change tsconfig file for mordern typescript package publish

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "outDir": "lib",
     "declarationMap": true,
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true
   },
   "typeRoots": [ "./node_modules/@webgpu/types", "./node_modules/@types"],
   "include": ["src"],


### PR DESCRIPTION
I have changed `tsconfig.json` file to fix the warning caused by unspecified `moduleResolution` field. 

The following is a wildly used and strongly typed package. The author has comment on the config file on each field why he did what

https://github.com/reduxjs/redux-toolkit/blob/master/packages/toolkit/tsconfig.base.json

The original tsconfig.json will cause the following error:

![image](https://github.com/mlc-ai/web-llm/assets/37259750/94bdca9d-5c63-4641-9b2a-43e2e459ce94)


