### PR TITLE
Add cleanup script to remove import from index.js

### DIFF
--- a/cleanup-index-js.sh
+++ b/cleanup-index-js.sh
@@ -1,0 +1,9 @@
+# Remove instances of string "const{createRequire:createRequire}=await import('module');"
+# This is required to allow background workers packaged with Parcel for the chrome extension
+# to run the `ChatModule`.
+sed -e s/"const{createRequire:createRequire}=await import('module');"//g -i .backup lib/index.js
+sed -e s/"const{createRequire:createRequire}=await import('module');"//g -i .backup lib/index.js.map
+
+# Cleanup backup files
+rm lib/index.js.backup
+rm lib/index.js.map.backup

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "lib/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && ./cleanup-index-js.sh",
     "lint": "npx eslint ."
   },
   "files": [


### PR DESCRIPTION
The string `const{createRequire:createRequire}=await import('module');` needs to be removed from `index.js` and `index.js.map` when running `npm run build`, so that the background worker in the chrome extension can run the `ChatModule`. 

