### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,6 +17,6 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.6"
+    "@mlc-ai/web-llm": "^0.2.7"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.0",
@@ -1317,9 +1317,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.2.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.3.tgz",
-      "integrity": "sha512-pg9d0yC4rVNWQzX8U7xb4olIOFuuVL9za3bzMT2pu2SU0SNEi66i2qrvhE2qt0HvkhuCaWJu7pLNOt/Pj8BIrw==",
+      "version": "20.5.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
+      "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -7743,12 +7743,13 @@
     },
     "tvm_home/web": {
       "name": "tvmjs",
-      "version": "0.13.0-dev0",
+      "version": "0.14.0-dev0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
+        "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
         "@webgpu/types": "^0.1.24",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Bump the version to 0.2.7. Forgot to bump it in https://github.com/mlc-ai/web-llm/pull/180.

I've published this to https://www.npmjs.com/package/@mlc-ai/web-llm/v/0.2.7?activeTab=versions.