### PR TITLE
feat: custom conv_template

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -173,6 +173,8 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       add_bos: true,
       ...conv_config,
     });
+  } else if (conv_template == "custom") {
+    return new Conversation(conv_config as Required<ConvTemplateConfig>);
   } else {
     throw Error("Unknown conv template " + conv_template);
   }


### PR DESCRIPTION
In case we don't want to provide the `conv_template` name, we can use `custom` and pass every the entire ConvTemplateConfig data instead. 