### PR TITLE
[Mistral][SWA] Add Mistral sliding window support

### DIFF
--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -63,6 +63,15 @@ export default {
 			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-WizardMath-70B-V1.0-q4f16_1/resolve/main/",
 			"local_id": "WizardMath-70B-V1.0-q4f16_1",
 			"required_features": ["shader-f16"],
+		},
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q4f16_1/resolve/main/",
+			"local_id": "Mistral-7B-Instruct-v0.1-q4f16_1",
+			"required_features": ["shader-f16"],
+		},
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q4f32_1/resolve/main/",
+			"local_id": "Mistral-7B-Instruct-v0.1-q4f32_1",
 		}
 	],
 	"model_lib_map": {
@@ -76,10 +85,12 @@ export default {
 		"RedPajama-INCITE-Chat-3B-v1-q4f16_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu-v1.wasm",
 		"WizardCoder-15B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardCoder-15B-V1.0-q4f16_1-webgpu.wasm",
 		"WizardCoder-15B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardCoder-15B-V1.0-q4f32_1-webgpu.wasm",
-		"WizardMath-7B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardMath-7B-V1.0-q4f16_1-webgpu.wasm",
-		"WizardMath-7B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardMath-7B-V1.0-q4f32_1-webgpu.wasm",
-		"WizardMath-13B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardMath-13B-V1.0-q4f16_1-webgpu.wasm",
-		"WizardMath-70B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardMath-70B-V1.0-q4f16_1-webgpu.wasm"
+		"WizardMath-7B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f16_1-webgpu.wasm",
+		"WizardMath-7B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
+		"WizardMath-13B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
+		"WizardMath-70B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
+		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1_sw2048-webgpu.wasm",
+		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1_sw2048-webgpu.wasm"
 	},
 	"use_web_worker": true
 }

--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -89,8 +89,8 @@ export default {
 		"WizardMath-7B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
 		"WizardMath-13B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
 		"WizardMath-70B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
-		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1_sw2048-webgpu.wasm",
-		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1_sw2048-webgpu.wasm"
+		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1-sw4096_cs1024-webgpu.wasm",
+		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1-sw4096_cs1024-webgpu.wasm"
 	},
 	"use_web_worker": true
 }

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -173,6 +173,19 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       add_bos: true,
       ...conv_config,
     });
+  } else if (conv_template == "mistral_default") {
+    return new Conversation({
+      system: "[INST] Always assist with care, respect, and truth. Respond with utmost utility yet " +
+        "securely. Avoid harmful, unethical, prejudiced, or negative content. Ensure replies " +
+        "promote fairness and positivity.",
+      roles: ["[INST]", "[/INST]"],
+      offset: 0,
+      seps: [" ", " "],
+      separator_style: "Two",
+      stop_str: "</s>",
+      add_bos: true,
+      ...conv_config,
+    });
   } else if (conv_template == "custom") {
     return new Conversation(conv_config as Required<ConvTemplateConfig>);
   } else {


### PR DESCRIPTION
This PR adds support for Mistral. The implementation follows [the Mistral paper](https://arxiv.org/abs/2310.06825), specifically including sliding window attention (SWA), rolling buffer cache, and chunking, as discussed in Section 2 in the paper. 

This PR is largely analogous to the changes in `llm_chat.cc` in mlc-llm's PR https://github.com/mlc-ai/mlc-llm/pull/1087.

Different from the approaches in https://github.com/mlc-ai/web-llm/issues/202, this PR's implementation takes advantage of SWA, so that there is no max window size anymore--one of the main benefits of Mistral.

Tested:
- Works well with:
  - 4096 sliding window size, with 1024 chunk size
    - Note that the small chunk size has no effect on generated output, but only less memory requirement with slower speed
  - 2048 sliding window size with 2048 chunk size
- Tested with prompts that are multiple times in length of the sliding window size / chunk size

Irrelevantly, we also make wizard models reuse llama model libraries given the dynamic vocab size support (updated just now due to shuffle support).

cc @tqchen 