### PR TITLE
Add 128MB buffer size friendly models

### DIFF
--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -24,17 +24,17 @@ export default {
 			"required_features": ["shader-f16"],
 		},
 		{
-			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0/resolve/main/",
-			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1/resolve/main/",
+			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1",
+			"required_features": ["shader-f16"],
+		},
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_1/resolve/main/",
+			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_1"
 		},
 		{
 			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
 			"local_id": "vicuna-v1-7b-q4f32_0"
-		},
-		{
-			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_0/resolve/main/",
-			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_0",
-			"required_features": ["shader-f16"],
 		},
 		{
 			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1/resolve/main/",
@@ -72,7 +72,22 @@ export default {
 		{
 			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-Mistral-7B-Instruct-v0.1-q4f32_1/resolve/main/",
 			"local_id": "Mistral-7B-Instruct-v0.1-q4f32_1",
-		}
+		},
+		// Models below fit for 128MB buffer limit (e.g. webgpu on Android)
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f16_1-1k/resolve/main/",
+			"local_id": "Llama-2-7b-chat-hf-q4f16_1-1k",
+			"required_features": ["shader-f16"],
+		},
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k/resolve/main/",
+			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k",
+			"required_features": ["shader-f16"],
+		},
+		{
+			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k/resolve/main/",
+			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k"
+		},
 	],
 	"model_lib_map": {
 		"Llama-2-7b-chat-hf-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
@@ -81,8 +96,8 @@ export default {
 		"Llama-2-13b-chat-hf-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
 		"Llama-2-70b-chat-hf-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
 		"vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
-		"RedPajama-INCITE-Chat-3B-v1-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu-v1.wasm",
-		"RedPajama-INCITE-Chat-3B-v1-q4f16_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu-v1.wasm",
+		"RedPajama-INCITE-Chat-3B-v1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm",
+		"RedPajama-INCITE-Chat-3B-v1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm",
 		"WizardCoder-15B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardCoder-15B-V1.0-q4f16_1-webgpu.wasm",
 		"WizardCoder-15B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardCoder-15B-V1.0-q4f32_1-webgpu.wasm",
 		"WizardMath-7B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f16_1-webgpu.wasm",
@@ -90,7 +105,11 @@ export default {
 		"WizardMath-13B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
 		"WizardMath-70B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
 		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1-sw4096_cs1024-webgpu.wasm",
-		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1-sw4096_cs1024-webgpu.wasm"
+		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1-sw4096_cs1024-webgpu.wasm",
+		// Models below fit for 128MB buffer limit (e.g. webgpu on Android)
+		"Llama-2-7b-chat-hf-q4f16_1-1k": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f16_1-1k-webgpu.wasm",
+		"RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k-webgpu.wasm",
+		"RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k-webgpu.wasm",
 	},
 	"use_web_worker": true
 }

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -97,6 +97,23 @@ export class ChatModule implements ChatInterface {
     if (gpuDetectOutput == undefined) {
       throw Error("Cannot find WebGPU in the environment");
     }
+
+    // check whether maxStorageBufferBindingSize falls from 1GB to 128MB
+    const computeMB = (value: number) => {
+      return Math.ceil(value  / (1 << 20)) + "MB";
+    }
+    const defaultRequiredMaxStorageBufferBindingSize = 1 << 30;  // 1GB
+    if (gpuDetectOutput.device.limits.maxStorageBufferBindingSize < defaultRequiredMaxStorageBufferBindingSize) {
+      console.log(
+        `WARNING: the current maxStorageBufferBindingSize ` + 
+        `(${computeMB(gpuDetectOutput.device.limits.maxStorageBufferBindingSize)}) ` + 
+        `may only work for a limited number of models, e.g.: \n` +
+        `- Llama-2-7b-chat-hf-q4f16_1-1k \n` +
+        `- RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k \n` +
+        `- RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k`
+      );
+    }
+
     let gpuLabel = "WebGPU";
     if (gpuDetectOutput.adapterInfo.description.length != 0) {
       gpuLabel += " - " + gpuDetectOutput.adapterInfo.description;


### PR DESCRIPTION
This PR adds three models with 1k context length that can be run by devices with `maxStorageBufferBindingSize = 128MB`:
- `Llama-2-7b-chat-hf-q4f16_1-1k`
- `RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k`
- `RedPajama-INCITE-Chat-3B-v1-q4f32_1-1k`

This is enabled by https://github.com/apache/tvm/pull/16108, and offers a temporary solution for https://github.com/mlc-ai/web-llm/issues/209 and the discussion in https://github.com/apache/tvm/pull/14640.

Irrelevantly, we also update RedPajama models from `_0` quantization to `_1`.

cc: @tqchen @beaufortfrancois @DustinBrett