### PR TITLE
[SLIM] Make web-llm compatible with SLIM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async function main() {
   chat.setInitProgressCallback((report: webllm.InitProgressReport) => {
     setLabel("init-label", report.text);
   });
-  // You can also try out "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
+  // You can also try out "RedPajama-INCITE-Chat-3B-v1-q4f32_1"
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const generateProgressCallback = (_step: number, message: string) => {
@@ -162,7 +162,7 @@ and make sure the `mlc-chat-config.json` in the model url has a model lib
 that points to a prebuilt version, right now the prebuilt lib includes
 
 - `Llama-2-7b-chat-hf-q4f32_1`: llama-7b models.
-- `RedPajama-INCITE-Chat-3B-v1-q4f32_0`: RedPajama-3B variant.
+- `RedPajama-INCITE-Chat-3B-v1-q4f32_1`: RedPajama-3B variant.
 
 ## Use WebLLM Package
 

--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -15,7 +15,7 @@ async function main() {
     setLabel("init-label", report.text);
   });
 
-  await chat.reload("vicuna-v1-7b-q4f32_0");
+  await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const generateProgressCallback = (_step: number, message: string) => {
     setLabel("generate-label", message);

--- a/examples/next-simple-chat/src/utils/chat_ui.ts
+++ b/examples/next-simple-chat/src/utils/chat_ui.ts
@@ -58,15 +58,15 @@ export default class ChatUI {
         this.chat.setInitProgressCallback(initProgressCallback);
 
         try {
-            await this.chat.reload("vicuna-v1-7b-q4f32_0", undefined, {
+            await this.chat.reload("Llama-2-7b-chat-hf-q4f32_1", undefined, {
                 "model_list": [
                     {
-                        "model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
-                        "local_id": "vicuna-v1-7b-q4f32_0"
+                        "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1/resolve/main/",
+                        "local_id": "Llama-2-7b-chat-hf-q4f32_1"
                     },
                 ],
                 "model_lib_map": {
-                    "vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
+                    "Llama-2-7b-chat-hf-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
                 },
             });
         } catch (err: unknown) {

--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -104,8 +104,8 @@ export default {
 		"WizardMath-7B-V1.0-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
 		"WizardMath-13B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
 		"WizardMath-70B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
-		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1-sw4096_cs1024-webgpu.wasm",
-		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1-sw4096_cs1024-webgpu.wasm",
+		"Mistral-7B-Instruct-v0.1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f16_1-sw4k_cs1k-webgpu.wasm",
+		"Mistral-7B-Instruct-v0.1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Mistral-7B-Instruct-v0.1-q4f32_1-sw4k_cs1k-webgpu.wasm",
 		// Models below fit for 128MB buffer limit (e.g. webgpu on Android)
 		"Llama-2-7b-chat-hf-q4f16_1-1k": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f16_1-1k-webgpu.wasm",
 		"RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-1k-webgpu.wasm",

--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -33,10 +33,6 @@ export default {
 			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_1"
 		},
 		{
-			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
-			"local_id": "vicuna-v1-7b-q4f32_0"
-		},
-		{
 			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-WizardCoder-15B-V1.0-q4f16_1/resolve/main/",
 			"local_id": "WizardCoder-15B-V1.0-q4f16_1",
 			"required_features": ["shader-f16"],
@@ -95,7 +91,6 @@ export default {
 		"Llama-2-7b-chat-hf-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f16_1-webgpu.wasm",
 		"Llama-2-13b-chat-hf-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-13b-chat-hf-q4f16_1-webgpu.wasm",
 		"Llama-2-70b-chat-hf-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-70b-chat-hf-q4f16_1-webgpu.wasm",
-		"vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
 		"RedPajama-INCITE-Chat-3B-v1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm",
 		"RedPajama-INCITE-Chat-3B-v1-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm",
 		"WizardCoder-15B-V1.0-q4f16_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/WizardCoder-15B-V1.0-q4f16_1-webgpu.wasm",

--- a/examples/simple-chat/src/mlc-local-config.js
+++ b/examples/simple-chat/src/mlc-local-config.js
@@ -3,12 +3,12 @@
 export default {
   "model_list": [
     {
-      "model_url": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f32_0/params/",
-      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
+      "model_url": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f32_1/params/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_1"
     },
     {
-      "model_url": "http://localhost:8000/vicuna-v1-7b-q4f32_0/params/",
-      "local_id": "vicuna-v1-7b-q4f32_0"
+      "model_url": "http://localhost:8000/Llama-2-7b-chat-hf-q4f32_1/params/",
+      "local_id": "Llama-2-7b-chat-hf-q4f32_1"
     },
     // fp16 options are enabled through chrome canary flags
     // chrome --enable-dawn-features=enable_unsafe_apis
@@ -19,9 +19,9 @@ export default {
     }
   ],
   "model_lib_map": {
-    "vicuna-v1-7b-q4f32_0": "http://localhost:8000/vicuna-v1-7b-q4f32_0/vicuna-v1-7b-q4f32_0-webgpu.wasm",
-    "RedPajama-INCITE-Chat-3B-v1-q4f32_0": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f32_0/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu.wasm",
-    "RedPajama-INCITE-Chat-3B-v1-q4f16_0": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_0-webgpu.wasm"
+    "Llama-2-7b-chat-hf-q4f32_1": "http://localhost:8000/Llama-2-7b-chat-hf-q4f32_1/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
+    "RedPajama-INCITE-Chat-3B-v1-q4f32_1": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f32_1/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm",
+    "RedPajama-INCITE-Chat-3B-v1-q4f16_1": "http://localhost:8000/RedPajama-INCITE-Chat-3B-v1-q4f16_0/RedPajama-INCITE-Chat-3B-v1-q4f16_1-webgpu.wasm"
   },
   "use_web_worker": true
 }

--- a/examples/web-worker/src/main.ts
+++ b/examples/web-worker/src/main.ts
@@ -12,14 +12,14 @@ async function main() {
   // Use a chat worker client instead of ChatModule here
   const chat = new webllm.ChatWorkerClient(new Worker(
     new URL('./worker.ts', import.meta.url),
-    {type: 'module'}
+    { type: 'module' }
   ));
 
   chat.setInitProgressCallback((report: webllm.InitProgressReport) => {
     setLabel("init-label", report.text);
   });
 
-  await chat.reload("vicuna-v1-7b-q4f32_0");
+  await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const generateProgressCallback = (_step: number, message: string) => {
     setLabel("generate-label", message);

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,16 +49,16 @@ export interface AppConfig {
 export const prebuiltAppConfig: AppConfig = {
   model_list: [
     {
-      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0/resolve/main/",
-      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_1/resolve/main/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_1"
     },
     {
-      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
-      "local_id": "vicuna-v1-7b-q4f32_0"
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-Llama-2-7b-chat-hf-q4f32_1/resolve/main/",
+      "local_id": "Llama-2-7b-chat-hf-q4f32_1"
     }
   ],
   model_lib_map: {
-    "vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
-    "RedPajama-INCITE-Chat-3B-v1-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu-v1.wasm"
+    "Llama-2-7b-chat-hf-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/Llama-2-7b-chat-hf-q4f32_1-webgpu.wasm",
+    "RedPajama-INCITE-Chat-3B-v1-q4f32_1": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_1-webgpu.wasm"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface ConvTemplateConfig {
   offset: number;
   stop_str: string;
   add_bos: boolean;
+  stop_tokens: Array<number>;
 }
 
 /**
@@ -45,17 +46,17 @@ export interface AppConfig {
 /**
  * default libmap used in prebuilt
  */
-export const prebuiltAppConfig : AppConfig = {
-	model_list: [
-		{
-			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0/resolve/main/",
-			"local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
-		},
-		{
-			"model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
-			"local_id": "vicuna-v1-7b-q4f32_0"
-		}
-	],
+export const prebuiltAppConfig: AppConfig = {
+  model_list: [
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-RedPajama-INCITE-Chat-3B-v1-q4f32_0/resolve/main/",
+      "local_id": "RedPajama-INCITE-Chat-3B-v1-q4f32_0"
+    },
+    {
+      "model_url": "https://huggingface.co/mlc-ai/mlc-chat-vicuna-v1-7b-q4f32_0/resolve/main/",
+      "local_id": "vicuna-v1-7b-q4f32_0"
+    }
+  ],
   model_lib_map: {
     "vicuna-v1-7b-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/vicuna-v1-7b-q4f32_0-webgpu-v1.wasm",
     "RedPajama-INCITE-Chat-3B-v1-q4f32_0": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/RedPajama-INCITE-Chat-3B-v1-q4f32_0-webgpu-v1.wasm"

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -88,6 +88,10 @@ export class Conversation {
     throw Error("Unknown separator style " + this.config.separator_style);
   }
 
+  getStopTokens() {
+    return this.config.stop_tokens;
+  }
+
   appendMessage(role: string, message: string) {
     if (this.messages.length != 0 &&
       this.messages[this.messages.length - 1][1] == undefined) {
@@ -125,6 +129,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "Two",
       stop_str: "[INST]",
       add_bos: true,
+      stop_tokens: [2],
       ...conv_config,
     });
   } else if (conv_template == "vicuna_v1.1") {
@@ -137,6 +142,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "Two",
       stop_str: "</s>",
       add_bos: true,
+      stop_tokens: [2],
       ...conv_config,
     });
   } else if (conv_template == "wizardlm") {
@@ -148,6 +154,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "Two",
       stop_str: "\n\n",
       add_bos: true,
+      stop_tokens: [2],
       ...conv_config,
     });
   } else if (conv_template == "redpajama_chat") {
@@ -159,6 +166,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "RedPajamaChat",
       stop_str: "<human>",
       add_bos: false,
+      stop_tokens: [0],
       ...conv_config,
     });
   } else if (conv_template == "wizard_coder_or_math") {
@@ -171,6 +179,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "Two",
       stop_str: "</s>",
       add_bos: true,
+      stop_tokens: [0],
       ...conv_config,
     });
   } else if (conv_template == "mistral_default") {
@@ -184,6 +193,7 @@ export function getConversation(conv_template: string, conv_config?: Partial<Con
       separator_style: "Two",
       stop_str: "</s>",
       add_bos: true,
+      stop_tokens: [2],
       ...conv_config,
     });
   } else if (conv_template == "custom") {


### PR DESCRIPTION
Make web-llm runtime compatible with SLIM models, a new workflow in mlc-llm. This depends on https://github.com/apache/tvm/pull/16198 and is currently not backward-compatible with non-SLIM model, since we introduced a new global function to TVM.

The main difference is reading the metadata and loading the parameters.

Besides, we now read stop_tokens from the conversation template instead of relying on metadata.