### PR TITLE
Fix stop token

### DIFF
--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.12",
+    "@mlc-ai/web-llm": "^0.2.13",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.12"
+        "@mlc-ai/web-llm": "^0.2.13"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.12"
+        "@mlc-ai/web-llm": "^0.2.13"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -16,6 +16,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.12"
+        "@mlc-ai/web-llm": "^0.2.13"
     }
 }

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.12"
+        "@mlc-ai/web-llm": "^0.2.13"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -319,12 +319,14 @@ export class LLMChatPipeline {
       throw Error("Cannot call process when it is stoppped");
     }
 
-    this.outputIds.push(nextToken);
-    this.appearedTokens.add(nextToken);
-
     // if there is a stop token
     if (this.stopTokens.includes(nextToken)) {
       this.stopTriggered = true;
+    }
+
+    if (!this.stopTriggered) {
+      this.outputIds.push(nextToken);
+      this.appearedTokens.add(nextToken);
     }
 
     let outputMessage = this.tokenizer.decode(new Int32Array(this.outputIds));


### PR DESCRIPTION
Due to recent change in https://github.com/mlc-ai/web-llm/pull/225, we now recognize stop token. However, we still add stop token to the output ids, leading to models like llama printing out `</s>` in response.

Bump version to 0.2.13 subsequently.