### PR TITLE
Change scrollbar track color in chat UI

### DIFF
--- a/examples/simple-chat/src/llm_chat.css
+++ b/examples/simple-chat/src/llm_chat.css
@@ -65,7 +65,7 @@ s .chatui-header {
 }
 
 .chatui-chat::-webkit-scrollbar-track {
-    background: #f1f1f1;
+    background: #1F2027;
 }
 
 .chatui-chat::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Due to previously neglecting to check the scrollbar's appearance during long conversations, I discovered that its color remained white, which didn't quite fit with the overall theme. Therefore, I have made a small adjustment to the color.
FROM
![image](https://github.com/mlc-ai/web-llm/assets/68688494/fc252b69-1817-43cc-837c-b062c5e9d3fe)
TO
![image](https://github.com/mlc-ai/web-llm/assets/68688494/ee5040a0-9d12-4250-ae87-d205b654b03e)
