### PR TITLE
Show separators in chat model selector

### DIFF
--- a/examples/simple-chat/src/simple_chat.ts
+++ b/examples/simple-chat/src/simple_chat.ts
@@ -56,8 +56,12 @@ class ChatUI {
       opt.value = item.local_id;
       opt.innerHTML = item.local_id;
       opt.selected = (i == 0);
+      if (!modelSelector.lastChild?.textContent?.startsWith(opt.value.split('-')[0])) {
+        modelSelector.appendChild(document.createElement("hr"));
+      }
       modelSelector.appendChild(opt);
     }
+    modelSelector.appendChild(document.createElement("hr"));
     // Append local server option to the model selector
     const localServerOpt = document.createElement("option");
     localServerOpt.value = "Local Server";


### PR DESCRIPTION
This PR show separators in chat model selector so that it's easier to read for users.

![image](https://github.com/mlc-ai/web-llm/assets/634478/0766d282-4997-446a-9c64-7b6bbc1f3871)
