### PR TITLE
[SimpleChat] Check vendor to determine mobile environment

### DIFF
--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -210,6 +210,15 @@ export class ChatModule implements ChatInterface {
     return maxStorageBufferBindingSize;
   }
 
+  async getGPUVendor(): Promise<string> {
+    // First detect GPU
+    const gpuDetectOutput = await tvmjs.detectGPUDevice();
+    if (gpuDetectOutput == undefined) {
+      throw Error("Cannot find WebGPU in the environment");
+    }
+    return gpuDetectOutput.adapterInfo.vendor;
+  }
+
   //--------------------------
   // Lower level API
   //--------------------------
@@ -291,6 +300,10 @@ export class ChatRestModule implements ChatInterface {
   }
 
   async getMaxStorageBufferBindingSize(): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getGPUVendor(): Promise<string> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,5 +91,11 @@ export interface ChatInterface {
    * has limited resources like an Android phone.
    */
   getMaxStorageBufferBindingSize(): Promise<number>;
+
+  /**
+   * Returns the device's gpu vendor (e.g. arm, qualcomm, apple) if available. Otherwise return
+   * an empty string.
+   */
+  getGPUVendor(): Promise<string>;
 }
 

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -14,7 +14,8 @@ type RequestKind = (
   "return" | "throw" |
   "reload" | "generate" | "runtimeStatsText" |
   "interruptGenerate" | "unload" | "resetChat" |
-  "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize"
+  "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
+  "getGPUVendor"
 );
 
 interface ReloadParams {
@@ -160,6 +161,12 @@ export class ChatWorkerHandler {
         });
         return;
       }
+      case "getGPUVendor": {
+        this.handleTask(msg.uuid, async () => {
+          return await this.chat.getGPUVendor();
+        });
+        return;
+      }
       default: {
         throw Error("Invalid kind, msg=" + msg);
       }
@@ -243,6 +250,15 @@ export class ChatWorkerClient implements ChatInterface {
       content: null
     };
     return this.getPromise<number>(msg);
+  }
+
+  async getGPUVendor(): Promise<string> {
+    const msg: WorkerMessage = {
+      kind: "getGPUVendor",
+      uuid: crypto.randomUUID(),
+      content: null
+    };
+    return this.getPromise<string>(msg);
   }
 
   async generate(


### PR DESCRIPTION
As a follow-up to https://github.com/mlc-ai/web-llm/pull/256, which fails to detect that we are using low-resource device as some Android phones have 2GB `maxStorageBufferBindingSize` (e.g. Pixel 7), this PR use the vendor shown in https://webgpureport.org/ to determine whether we are on low-resource device, hence limiting the selectable models.

For now, we have `qualcomm` and `arm`, which should at least cover most Pixel and most Samsung Galaxy S.