### PR TITLE
[LLMChat] Make llm_chat compatible with PagedKVCache

### DIFF
--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -81,7 +81,8 @@ export class ChatModule implements ChatInterface {
         return await fetch(new URL(wasmUrl, baseUrl).href);
       } else {
         // use cache
-        return await wasmCache.fetchWithCache(wasmUrl);
+        // return await wasmCache.fetchWithCache(wasmUrl);
+        return await fetch(wasmUrl);
       }
     };
     const wasmSource = await (await fetchWasmSource()).arrayBuffer();
@@ -135,11 +136,14 @@ export class ChatModule implements ChatInterface {
     });
     this.deviceLostIsError = true;
     const tokenizer = await this.asyncLoadTokenizer(modelUrl, config);
+    console.log("CHARLIE 1")
     await tvm.fetchNDArrayCache(modelUrl, tvm.webgpu(), "webllm/model");
+    console.log("CHARLIE 2")
 
     this.pipeline = new LLMChatPipeline(tvm, tokenizer, config, this.logitProcessor);
+    console.log("CHARLIE 3")
     await this.pipeline?.asyncLoadWebGPUPipelines();
-
+    console.log("CHARLIE 4")
     const tend = performance.now();
 
     if (this.initProgressCallback !== undefined) {

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -81,8 +81,7 @@ export class ChatModule implements ChatInterface {
         return await fetch(new URL(wasmUrl, baseUrl).href);
       } else {
         // use cache
-        // return await wasmCache.fetchWithCache(wasmUrl);
-        return await fetch(wasmUrl);
+        return await wasmCache.fetchWithCache(wasmUrl);
       }
     };
     const wasmSource = await (await fetchWasmSource()).arrayBuffer();
@@ -136,14 +135,10 @@ export class ChatModule implements ChatInterface {
     });
     this.deviceLostIsError = true;
     const tokenizer = await this.asyncLoadTokenizer(modelUrl, config);
-    console.log("CHARLIE 1")
     await tvm.fetchNDArrayCache(modelUrl, tvm.webgpu(), "webllm/model");
-    console.log("CHARLIE 2")
 
     this.pipeline = new LLMChatPipeline(tvm, tokenizer, config, this.logitProcessor);
-    console.log("CHARLIE 3")
     await this.pipeline?.asyncLoadWebGPUPipelines();
-    console.log("CHARLIE 4")
     const tend = performance.now();
 
     if (this.initProgressCallback !== undefined) {


### PR DESCRIPTION
PagedKVCache is introduced in MLC-LLM a while back to unite the interface for KVCache. This PR makes WebLLM compatible with the new PagedKVCache interface, encapsulating it with the goal that WebLLM users will not notice any difference.

This PR is equivalent to the changes to `llm_chat.cc` in https://github.com/mlc-ai/mlc-llm/pull/1651, and should address issues like https://github.com/mlc-ai/mlc-llm/issues/1628.

There are still existing model compilation issues regarding `workgroup_size` (since WebGPU, unlike most other backends, can only support 256 number of threads). We will address this issue more elegantly soon; for now, compiling llama-based models require manually changing kernel sizes as shown in [this branch](https://github.com/CharlieFRuan/mlc-llm/tree/local-workgroupSize-webLLM-kvCache).

This PR is also largely dependent on https://github.com/apache/tvm/pull/16554. 