### PR TITLE
[Version] Bump version to 0.2.19

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.18",
+    "@mlc-ai/web-llm": "^0.2.19",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.18",
+    "@mlc-ai/web-llm": "^0.2.19",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18"
+        "@mlc-ai/web-llm": "^0.2.19"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18"
+        "@mlc-ai/web-llm": "^0.2.19"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18"
+        "@mlc-ai/web-llm": "^0.2.19"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -16,6 +16,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18"
+        "@mlc-ai/web-llm": "^0.2.19"
     }
 }

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18"
+        "@mlc-ai/web-llm": "^0.2.19"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.18",
+        "@mlc-ai/web-llm": "^0.2.19",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
The new version includes two main changes:
1. We now support models compiled with `PagedKVCache` (only Llama-variants for now)
  - This is breaking in the sense that, in order to use the update Llama WASMs, an update to the WebLLM npm is required
    - WASMs updated here: https://github.com/mlc-ai/binary-mlc-llm-libs/pull/90
  - For more see https://github.com/mlc-ai/web-llm/pull/293
2. We now support `GenerationConfig`, allowing configuring each generation (e.g. repetition penalty, temperature, etc.)
  - All WASMs needed to be recompiled since we included new function `ApplyPresenceAndRequencyPenalty()` in tvmjs
  - For more see https://github.com/mlc-ai/web-llm/pull/298

Other changes include: 
- https://github.com/mlc-ai/web-llm/pull/285