### PR TITLE
[SimpleChat] Limit model selections with maxStorageBufferBindingSize

### DIFF
--- a/examples/simple-chat/src/gh-config.js
+++ b/examples/simple-chat/src/gh-config.js
@@ -80,6 +80,7 @@ export default {
 			"model_lib_url": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/gemma-2b-it/gemma-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
 			"vram_required_MB": 1476.52,
 			"low_resource_required": false,
+			"buffer_size_required_bytes": 262144000,
 			"required_features": ["shader-f16"],
 		},
 		{
@@ -88,6 +89,7 @@ export default {
 			"model_lib_url": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/gemma-2b-it/gemma-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
 			"vram_required_MB": 1750.66,
 			"low_resource_required": false,
+			"buffer_size_required_bytes": 262144000,
 		},
 		{
 			"model_url": "https://huggingface.co/mlc-ai/gemma-2b-it-q4f16_1-MLC/resolve/main/",
@@ -95,6 +97,7 @@ export default {
 			"model_lib_url": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/gemma-2b-it/gemma-2b-it-q4f16_1-ctx1k_cs1k-webgpu.wasm",
 			"vram_required_MB": 1476.52,
 			"low_resource_required": true,
+			"buffer_size_required_bytes": 262144000,
 			"required_features": ["shader-f16"],
 		},
 		{
@@ -103,6 +106,7 @@ export default {
 			"model_lib_url": "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/gemma-2b-it/gemma-2b-it-q4f32_1-ctx1k_cs1k-webgpu.wasm",
 			"vram_required_MB": 1750.66,
 			"low_resource_required": true,
+			"buffer_size_required_bytes": 262144000,
 		},
 		// RedPajama
 		{

--- a/examples/simple-chat/src/simple_chat.ts
+++ b/examples/simple-chat/src/simple_chat.ts
@@ -87,7 +87,12 @@ class ChatUI {
       opt.value = item.local_id;
       opt.innerHTML = item.local_id;
       opt.selected = (i == 0);
-      if (restrictModels && (item.low_resource_required === undefined || !item.low_resource_required)) {
+      if (
+        (restrictModels && (item.low_resource_required === undefined || !item.low_resource_required)) ||
+        (item.buffer_size_required_bytes && maxStorageBufferBindingSize < item.buffer_size_required_bytes)
+      ) {
+        // Either on a low-resource device and not a low-resource model
+        // Or device's maxStorageBufferBindingSize does not satisfy the model's need (if specified)
         const params = new URLSearchParams(location.search);
         opt.disabled = !params.has("bypassRestrictions");
         opt.selected = false;

--- a/src/config.ts
+++ b/src/config.ts
@@ -117,6 +117,7 @@ export function postInitAndCheckGenerationConfigValues(config: GenerationConfig)
  * @param vram_required_MB: amount of vram in MB required to run the model (can use
  *    `utils/vram_requirements` to calculate).
  * @param low_resource_required: whether the model can run on limited devices (e.g. Android phone).
+ * @param buffer_size_required_bytes: required `maxStorageBufferBindingSize`, different for each device.
  * @param required_features: feature needed to run this model (e.g. shader-f16).
  */
 export interface ModelRecord {
@@ -125,6 +126,7 @@ export interface ModelRecord {
   model_lib_url: string;
   vram_required_MB?: number;
   low_resource_required?: boolean;
+  buffer_size_required_bytes?: number;
   required_features?: Array<string>;
 }
 


### PR DESCRIPTION
While `gemma` work on some mobile devices (e.g. Pxiel 7 Pro), other devices that have smaller `maxStorageBufferBindingSize` do not. We add the specific limit to the model record. While VRAM requirement states the total VRAM needed, buffer binding size is different such that it specifies the limit for a single storage buffer. See more at https://www.w3.org/TR/webgpu/#dom-supported-limits-maxstoragebufferbindingsize