### PR TITLE
[OpenAI] Support stateful chat completion

### DIFF
--- a/examples/openai-api/src/openai_api.ts
+++ b/examples/openai-api/src/openai_api.ts
@@ -8,6 +8,11 @@ function setLabel(id: string, text: string) {
   label.innerText = text;
 }
 
+// There are four demonstrations, pick one from below to run
+
+/**
+ * We domnstrate chat completion without streaming, where we get the entire response at once.
+ */
 async function mainNonStreaming() {
   const chat: webllm.ChatInterface = new webllm.ChatModule();
 
@@ -36,10 +41,15 @@ async function mainNonStreaming() {
 
   const reply0 = await chat.chatCompletion(request);
   console.log(reply0);
+  console.log(await chat.getMessage());  // the final response
 
   console.log(await chat.runtimeStatsText());
 }
 
+
+/**
+ * We domnstrate chat completion with streaming, where delta is sent while generating response.
+ */
 async function mainStreaming() {
   const chat: webllm.ChatInterface = new webllm.ChatModule();
 
@@ -68,9 +78,55 @@ async function mainStreaming() {
     console.log(chunk);
   }
 
+  console.log(await chat.getMessage());  // the final response
+  console.log(await chat.runtimeStatsText());
+}
+
+/**
+ * We domnstrate stateful chat completion, where chat history is preserved across requests.
+ */
+async function mainStateful() {
+  const chat: webllm.ChatInterface = new webllm.ChatModule();
+
+  chat.setInitProgressCallback((report: webllm.InitProgressReport) => {
+    setLabel("init-label", report.text);
+  });
+
+  await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
+
+  const request0: webllm.ChatCompletionRequest = {
+    stateful: true,
+    // stream: true, // works with and without streaming
+    messages: [
+      {
+        "role": "system",
+        "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+          "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+      },
+      { "role": "user", "content": "Provide me three US states." },
+    ],
+  };
+
+  const reply0 = await chat.chatCompletion(request0);
+  console.log(reply0);
+  console.log(await chat.getMessage());
+
+  const request1: webllm.ChatCompletionRequest = {
+    stateful: true,
+    // stream: true, // works with and without streaming
+    messages: [
+      { "role": "user", "content": "Two more please!" },
+    ],
+  };
+
+  const reply1 = await chat.chatCompletion(request1);
+  console.log(reply1);
+  console.log(await chat.getMessage());
+
   console.log(await chat.runtimeStatsText());
 }
 
 // Run one of the functions
 // mainNonStreaming();
-mainStreaming();
+// mainStreaming();
+mainStateful();

--- a/examples/web-worker/src/main.ts
+++ b/examples/web-worker/src/main.ts
@@ -8,6 +8,11 @@ function setLabel(id: string, text: string) {
   label.innerText = text;
 }
 
+// There are three demonstrations, simply pick one from below
+
+/**
+ * We domnstrate using WebLLM with `genereate()`.
+ */
 async function mainGenerate() {
   console.log("Using ChatModule.generate()");
   // Use a chat worker client instead of ChatModule here
@@ -39,6 +44,9 @@ async function mainGenerate() {
   console.log(await chat.runtimeStatsText());
 }
 
+/**
+ * Chat completion (OpenAI style) without streaming, where we get the entire response at once.
+ */
 async function mainOpenAIAPINonStreaming() {
   console.log("Using ChatModule.chatCompletion() without streaming.");
   // Use a chat worker client instead of ChatModule here
@@ -54,6 +62,7 @@ async function mainOpenAIAPINonStreaming() {
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const request: webllm.ChatCompletionRequest = {
+    // stateful: true,  // set this optionally to preserve chat history
     messages: [
       {
         "role": "system",
@@ -75,6 +84,9 @@ async function mainOpenAIAPINonStreaming() {
   console.log(await chat.runtimeStatsText());
 }
 
+/**
+ * Chat completion (OpenAI style) with streaming, where delta is sent while generating response.
+ */
 async function mainOpenAIAPIStreaming() {
   console.log("Using ChatModule.chatCompletion() with streaming.");
   // Use a chat worker client instead of ChatModule here
@@ -90,6 +102,7 @@ async function mainOpenAIAPIStreaming() {
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const request: webllm.ChatCompletionRequest = {
+    // stateful: true,  // set this optionally to preserve chat history
     stream: true,
     messages: [
       {
@@ -113,6 +126,7 @@ async function mainOpenAIAPIStreaming() {
     setLabel("generate-label", message);
     // chat.interruptGenerate();  // works with interrupt as well
   }
+  console.log("Final message:\n", await chat.getMessage());  // the concatenated message
   console.log(await chat.runtimeStatsText());
 }
 

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -318,15 +318,14 @@ export class LLMChatPipeline {
   }
 
   /**
-   * Override this.conversation.messages.
+   * Append a new message to `this.conversation`.
    */
-  overrideConversationMessages(messages: Array<[string, string | undefined]>): void {
-    // TODO(Charlie): Do we need to make a deep copy here?
-    this.conversation.messages = messages;
+  appendConversationMessage(role: string, input: string): void {
+    this.conversation.appendMessage(role, input);
   }
 
   /**
-   * Get this.conversation.messages.
+   * Get `this.conversation.messages`.
    */
   getConversationMessages(): Array<[string, string | undefined]> {
     // TODO(Charlie): Do we need to make a deep copy here?

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -29,6 +29,16 @@
  */
 export interface ChatCompletionRequestBase {
     /**
+     * Whether we keep previous chat history before completing this request.
+     * 
+     * That is, if `stateful` is `false` or unspecified, we will clear chat history prior to
+     * generating the response. If `stateful` is `true`, we keep the chat history.
+     * 
+     * @note When `stateful` is `true`, `n` has to be 1, similar to having a multiround chat.
+     */
+    stateful?: boolean | null;
+
+    /**
      * A list of messages comprising the conversation so far.
      */
     messages: Array<ChatCompletionMessageParam>;
@@ -40,7 +50,6 @@ export interface ChatCompletionRequestBase {
 
     /**
      * How many chat completion choices to generate for each input message.
-     * 
      */
     n?: number | null;
 
@@ -340,7 +349,12 @@ export function postInitAndCheckFields(request: ChatCompletionRequest): void {
 
     // 4. If streaming, n cannot be > 1, since we cannot manage multiple sequences at once
     if (request.stream && request.n && request.n > 1) {
-        throw new Error("When streaming, `n` cannot be > 1.")
+        throw new Error("When streaming, `n` cannot be > 1.");
+    }
+
+    // 5. If stateful, n cannot be > 1, since the behavior is hard to define
+    if (request.stateful && request.n && request.n > 1) {
+        throw new Error("If the request is stateful, `n` cannot be > 1.");
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,7 +111,7 @@ export interface ChatInterface {
   ): Promise<AsyncIterable<ChatCompletionChunk> | ChatCompletion>;
   chatCompletion(
     request: ChatCompletionRequest
-  ): Promise<AsyncIterable<ChatCompletionChunk> | ChatCompletion>
+  ): Promise<AsyncIterable<ChatCompletionChunk> | ChatCompletion>;
 
   /**
    * @returns A text summarizing the runtime stats.
@@ -134,6 +134,13 @@ export interface ChatInterface {
    * @param keepStats: If True, do not reset the statistics.
    */
   resetChat: (keepStats?: boolean) => Promise<void>;
+
+  /**
+   * Get the current generated response.
+   *
+   * @returns The current output message.
+   */
+  getMessage: () => Promise<string>;
 
   /**
    * Returns the device's maxStorageBufferBindingSize, can be used to guess whether the device

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -23,7 +23,7 @@ type RequestKind = (
   "reload" | "generate" | "runtimeStatsText" |
   "interruptGenerate" | "unload" | "resetChat" |
   "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
-  "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" |
+  "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" | "getMessage" |
   "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest"
 );
 
@@ -252,6 +252,12 @@ export class ChatWorkerHandler {
         });
         return;
       }
+      case "getMessage": {
+        this.handleTask(msg.uuid, async () => {
+          return await this.chat.getMessage();
+        });
+        return;
+      }
       case "customRequest": {
         return;
       }
@@ -343,6 +349,15 @@ export class ChatWorkerClient implements ChatInterface {
   async getGPUVendor(): Promise<string> {
     const msg: WorkerMessage = {
       kind: "getGPUVendor",
+      uuid: crypto.randomUUID(),
+      content: null
+    };
+    return await this.getPromise<string>(msg);
+  }
+
+  async getMessage(): Promise<string> {
+    const msg: WorkerMessage = {
+      kind: "getMessage",
       uuid: crypto.randomUUID(),
       content: null
     };

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -55,6 +55,19 @@ describe('Check chat completion unsupported requests', () => {
         }).toThrow("When streaming, `n` cannot be > 1.");
     });
 
+    test('When stateful `n` needs to be 1', () => {
+        expect(() => {
+            const request: ChatCompletionRequest = {
+                stateful: true,
+                n: 2,
+                messages: [
+                    { role: "user", content: "Hello! " },
+                ],
+            };
+            postInitAndCheckFields(request)
+        }).toThrow("If the request is stateful, `n` cannot be > 1.");
+    });
+
     // Remove when we support image input (e.g. LlaVA model)
     test('Image input is unsupported', () => {
         expect(() => {


### PR DESCRIPTION
This PR adds the `stateful` option to `ChatCompletionRequest`. When set to true, we preserve previous chat history, allowing multi-round chat, essentially behaving like `generate()`. Note that a stateful chat can only have `n=1`.

In addition, we expose `getMessage()` to `ChatInterface`. This allows streaming chat completion requests to extract the final response more easily (rather than manually concatenating the deltas).