### PR TITLE
[OpenAI] Support logprobs and top_logprobs in ChatCompletion

### DIFF
--- a/examples/openai-api/src/openai_api.ts
+++ b/examples/openai-api/src/openai_api.ts
@@ -43,7 +43,9 @@ async function mainNonStreaming() {
       "13813": -100,
       "10319": 5,
       "7660": 5,
-    }
+    },
+    logprobs: true,
+    top_logprobs: 2,
   };
 
   const reply0 = await chat.chatCompletion(request);
@@ -79,6 +81,8 @@ async function mainStreaming() {
       { "role": "user", "content": "Two more please!" },
     ],
     temperature: 1.5,
+    logprobs: true,
+    top_logprobs: 2,
   };
 
   for await (const chunk of await chat.chatCompletion(request)) {

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -5,7 +5,12 @@ import { Tokenizer } from "@mlc-ai/web-tokenizers";
 import { ChatConfig, GenerationConfig } from "./config";
 import { getConversation, Conversation } from "./conversation";
 import { LogitProcessor } from "./types";
-import { ChatCompletionFinishReason } from "./openai_api_protocols/index"
+import { getTopProbs } from "./support";
+import {
+  ChatCompletionFinishReason,
+  ChatCompletionTokenLogprob,
+  TopLogprob,
+} from "./openai_api_protocols/index"
 
 export class LLMChatPipeline {
   private config: ChatConfig;
@@ -55,6 +60,10 @@ export class LLMChatPipeline {
   private slidingWindowCacheOffset = 0;
   // Whether we are using PagedKVCache (eventually this will become default)
   private usePagedKVCache = false;
+  // The logprob information of all tokens for this current round (cleared upon each prefillStep)
+  // Cleared & updated at the exact same spots as `outputMessage`. Only updated when
+  // `genConfig.logprobs` is true. Each entry corresponds to a single autoregressive step.
+  private tokenLogprobArray: Array<ChatCompletionTokenLogprob> = [];
 
   // stats
   private decodingTotalTime = 0;
@@ -300,6 +309,14 @@ export class LLMChatPipeline {
   }
 
   /**
+   * @returns tokenLogprobArray for this current round of autoregressive generation.
+   * Updated upon each sampled token, cleared upon each prefillStep().
+   */
+  getTokenLogprobArray(): Array<ChatCompletionTokenLogprob> {
+    return this.tokenLogprobArray;
+  }
+
+  /**
    * @returns Runtime stats information.
    */
   runtimeStatsText(): string {
@@ -343,8 +360,6 @@ export class LLMChatPipeline {
     return res;
   }
 
-
-
   async asyncLoadWebGPUPipelines() {
     await this.tvm.asyncLoadWebGPUPipelines(this.vm.getInternalModule());
   }
@@ -361,6 +376,7 @@ export class LLMChatPipeline {
     this.outputIds = [];
     this.appearedTokensFreq.clear();
     this.outputMessage = "";
+    this.tokenLogprobArray = [];
     this.stopTriggered = false;
     const conversation = this.conversation;
 
@@ -618,14 +634,18 @@ export class LLMChatPipeline {
     // 0. Get value of temperature, top_p, and various penalties, possibly overridden by genConfig
     // Also load other genConfig items like logit_bias. Consume all fields of `genConfig` here.
     function _hasValue(value: any): boolean {
+      // if we use `if value` directly, `value` being 0 evaluates to false, violating semantics
       return value !== undefined && value !== null;
     }
-    let temperature = this.config.temperature;
-    let top_p = this.config.top_p;
-    let repetition_penalty = this.config.repetition_penalty;
-    let frequency_penalty = undefined;
-    let presence_penalty = undefined;
-    let logit_bias = undefined;
+    let temperature: number = this.config.temperature;
+    let top_p: number = this.config.top_p;
+    let repetition_penalty: number = this.config.repetition_penalty;
+    let frequency_penalty: number | undefined = undefined;
+    let presence_penalty: number | undefined = undefined;
+    let logit_bias: Record<string, number> | undefined = undefined;
+    let logprobs: boolean | undefined = undefined;
+    let top_logprobs: number | undefined = undefined;
+
     if (genConfig !== undefined) {
       if (_hasValue(genConfig.temperature)) { temperature = genConfig.temperature!; }
       if (_hasValue(genConfig.top_p)) { top_p = genConfig.top_p!; }
@@ -635,7 +655,9 @@ export class LLMChatPipeline {
       // If only one of frequency or presence penatly is set, make the other one 0.0
       if (_hasValue(frequency_penalty) && !_hasValue(presence_penalty)) { presence_penalty = 0.0; }
       if (_hasValue(presence_penalty) && !_hasValue(frequency_penalty)) { frequency_penalty = 0.0; }
-      if (_hasValue(genConfig.logit_bias)) { logit_bias = genConfig.logit_bias; }
+      if (_hasValue(genConfig.logit_bias)) { logit_bias = genConfig.logit_bias!; }
+      if (_hasValue(genConfig.logprobs)) { logprobs = genConfig.logprobs!; }
+      if (_hasValue(genConfig.top_logprobs)) { top_logprobs = genConfig.top_logprobs!; }
     }
     // Check range validity
     if (top_p <= 0 || top_p >= 1) { throw new Error("Make sure 0 < `top_p` < 1."); }
@@ -678,7 +700,7 @@ export class LLMChatPipeline {
       this.logitsOnCPU.copyFrom(logitsOnCPUArray);
     }
 
-    // 3. Sample
+    // 3. Apply penalties to logits
     if (_hasValue(frequency_penalty) && _hasValue(presence_penalty)) {
       // 3.1. Use frequency and presence penalty
       this.tvm.beginScope();
@@ -710,9 +732,22 @@ export class LLMChatPipeline {
         this.logitsOnCPU, appeared_tokens_ndarray, repetition_penalty);
       this.tvm.endScope();
     }
-    const sampledToken = this.tvm.sampleTopPFromLogits(this.logitsOnCPU, temperature, top_p);
 
-    // 4. Update logit processor
+    // 4. Sample token from logits
+    // If logprobs, need the actual distribution via softmax, otherwise directly sample from logits
+    let sampledToken: number;
+    if (logprobs) {
+      // Inplace transform logitsOnCPU to a distribution
+      temperature = Math.max(1e-6, temperature);  // to prevent division by zero
+      this.tvm.applySoftmaxWithTemperature(this.logitsOnCPU, temperature);
+      sampledToken = this.tvm.sampleTopPFromProb(this.logitsOnCPU, top_p);
+      this.tokenLogprobArray.push(this.getTokenLogprob(sampledToken, top_logprobs!));
+    } else {
+      // temperature being 0 is allowed here, equivalent to argmax
+      sampledToken = this.tvm.sampleTopPFromLogits(this.logitsOnCPU, temperature, top_p);
+    }
+
+    // 5. Update logit processor
     this.logitProcessor?.processSampledToken(sampledToken);
 
     return sampledToken;
@@ -838,6 +873,51 @@ export class LLMChatPipeline {
       this.decodingTotalTokens += 1;
     }
     return nextToken;
+  }
+
+  /**
+   * Based on `sampledToken` and `this.logitsOnCPU`, which becomes a distribution after
+   * calling `this.tvm.applySoftmaxWithTemperature()`, generate `ChatCompletionTokenLogprob` and
+   * update `this.tokenLogprobArray`.
+   * 
+   * @param sampledToken The token ID sampled.
+   * @param top_logprobs Number of top tokens to include; `top_logprobs` in `ChatCompletionRequest`.
+   * 
+   * @return The `ChatCompletionTokenLogprob` for this single autoregressive step.
+   */
+  private getTokenLogprob(sampledToken: number, top_logprobs: number): ChatCompletionTokenLogprob {
+    if (this.logitsOnCPU == undefined) {
+      throw Error("logits should be assigned");
+    }
+    // Array of [token, prob] pairs, sorted with highest prob first.
+    const logitsOnCPUArray = <Float32Array>(this.logitsOnCPU.toArray())
+    const topLogprobs = getTopProbs(top_logprobs!, logitsOnCPUArray);
+
+    // Get entry for sampled token first
+    const textEncoder = new TextEncoder();
+    const tokenStr = this.tokenizer.decode(new Int32Array([sampledToken]));
+    const bytes: Array<number> = Array.from(textEncoder.encode(tokenStr));
+    const logprob = Math.log(logitsOnCPUArray[sampledToken]);
+
+    // Populate `top_logprobs`
+    const topLogprobArray: Array<TopLogprob> = [];
+    for (let i = 0; i < top_logprobs; i++) {
+      const tokenID_i = topLogprobs[i][0];
+      const prob_i = topLogprobs[i][1];
+      const tokenStr_i = this.tokenizer.decode(new Int32Array([tokenID_i]));
+      topLogprobArray.push({
+        token: tokenStr_i,
+        bytes: Array.from(textEncoder.encode(tokenStr_i)) as Array<number>,
+        logprob: Math.log(prob_i),
+      } as TopLogprob);
+    }
+
+    return {
+      token: tokenStr,
+      bytes: bytes,
+      logprob: logprob,
+      top_logprobs: topLogprobArray
+    } as ChatCompletionTokenLogprob;
   }
 
   async evaluate() {

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -119,6 +119,21 @@ export interface ChatCompletionRequestBase {
      */
     logit_bias?: Record<string, number> | null;
 
+    /**
+     * Whether to return log probabilities of the output tokens or not.
+     * 
+     * If true, returns the log probabilities of each output token returned in the `content` of
+     * `message`.
+     */
+    logprobs?: boolean | null;
+
+    /**
+     * An integer between 0 and 5 specifying the number of most likely tokens to return
+     * at each token position, each with an associated log probability. `logprobs` must
+     * be set to `true` if this parameter is used.
+     */
+    top_logprobs?: number | null;
+
     //////////////// BELOW FIELDS NOT SUPPORTED YET ////////////////
 
     /**
@@ -127,25 +142,6 @@ export interface ChatCompletionRequestBase {
      * @note Not supported. Instead call `ChatModule.reload(model)` before calling this API.
      */
     model?: string | null;
-
-    /**
-     * Whether to return log probabilities of the output tokens or not.
-     * 
-     * If true, returns the log probabilities of each output token returned in the `content` of
-     * `message`.
-     * 
-     * @note Not supported yet.
-     */
-    logprobs?: boolean | null;
-
-    /**
-     * An integer between 0 and 5 specifying the number of most likely tokens to return
-     * at each token position, each with an associated log probability. `logprobs` must
-     * be set to `true` if this parameter is used.
-     * 
-     * @note Not supported yet
-     */
-    top_logprobs?: number | null;
 
     /**
      * If specified, our system will make a best effort to sample deterministically, such that
@@ -306,15 +302,14 @@ export interface ChatCompletionChunk {
 
 export const ChatCompletionRequestUnsupportedFields: Array<string> = [
     "model",
-    "logprobs",
     "tool_choice",
     "tools",
     "response_format",
     "seed",
-    "top_logprobs"
 ];
 
 export function postInitAndCheckFields(request: ChatCompletionRequest): void {
+    // Generation-related checks and post inits are in `postInitAndCheckGenerationConfigValues()`
     // 1. Check unsupported fields in request
     const unsupported: Array<string> = [];
     ChatCompletionRequestUnsupportedFields.forEach((field) => {
@@ -623,7 +618,7 @@ export type ChatCompletionToolChoiceOption = 'none' | 'auto' | ChatCompletionNam
 
 //////////////////////////////// 3. OTHERS ////////////////////////////////
 
-//////////////////////////////// 3.1. LOG PROBS (NOT SUPPORTED YET) ////////////////////////////////
+//////////////////////////////// 3.1. LOG PROBS ////////////////////////////////
 export interface TopLogprob {
     /**
      * The token.
@@ -635,6 +630,9 @@ export interface TopLogprob {
      * Useful in instances where characters are represented by multiple tokens and
      * their byte representations must be combined to generate the correct text
      * representation. Can be `null` if there is no bytes representation for the token.
+     * 
+     * @note Encoded with `TextEncoder.encode()` and can be decoded with `TextDecoder.decode()`.
+     * For details, see https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode.
      */
     bytes: Array<number> | null;
 
@@ -655,6 +653,9 @@ export interface ChatCompletionTokenLogprob {
      * Useful in instances where characters are represented by multiple tokens and
      * their byte representations must be combined to generate the correct text
      * representation. Can be `null` if there is no bytes representation for the token.
+     * 
+     * @note Encoded with `TextEncoder.encode()` and can be decoded with `TextDecoder.decode()`.
+     * For details, see https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder/encode.
      */
     bytes: Array<number> | null;
 
@@ -737,8 +738,6 @@ export namespace ChatCompletion {
 
         /**
          * Log probability information for the choice.
-         * 
-         * @note Not supported yet.
          */
         logprobs: Choice.Logprobs | null;
 

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -241,6 +241,14 @@ export interface ChatCompletion {
     created: number;
 
     /**
+     * Usage statistics for the completion request.
+     * 
+     * @note If request is `stateful`, past usage not counted -- only corresponds to this request.
+     * If `n > 1`, all choices' generation usages combined.
+     */
+    usage?: CompletionUsage;
+
+    /**
      * This fingerprint represents the backend configuration that the model runs with.
      *
      * Can be used in conjunction with the `seed` request parameter to understand when
@@ -249,13 +257,6 @@ export interface ChatCompletion {
      * @note Not supported yet.
      */
     system_fingerprint?: string;
-
-    /**
-     * Usage statistics for the completion request.
-     * 
-     * @note Not supported yet.
-     */
-    usage?: CompletionUsage;
 }
 
 /**
@@ -704,6 +705,8 @@ export interface CompletionUsage {
 
     /**
      * Number of tokens in the prompt.
+     * 
+     * @note If `stateful` is true, only the new prompt is counted.
      */
     prompt_tokens: number;
 

--- a/src/support.ts
+++ b/src/support.ts
@@ -1,0 +1,50 @@
+/** Util methods. */
+
+/**
+ * Based on `p_prob` of size (vocabSize,) which becomes a distribution after calling
+ * `applySoftmaxWithTemperature()`, sample `top_logprobs` top-probable tokens.
+ * 
+ * @param num_top_probs: `top_logprobs` from ChatCompletionRequest
+ * @param p_prob: `logitsOnCPUArray`, being a distribution after `applySoftmaxWithTemperature()`.
+ * 
+ * Followed implementation of `ComputeTopProbsImpl()` from [https://github.com/mlc-ai/mlc-llm/blob/
+ * 5b8c529e9704abd09b0432da6dcb4b013fdf43b1/cpp/serve/sampler/cpu_sampler.cc].
+ * 
+ * @returns Arrays of (tokenID, prob) pairs, ranked from highest prob to least.
+ */
+export function getTopProbs(
+    num_top_probs: number, p_prob: Float32Array
+): Array<[number, number]> {
+    if (num_top_probs == 0) return [];
+    // Initialize to dummy values
+    const top_probs: Array<[number, number]> = [];
+    const ndata = p_prob.length;
+    for (let i = 0; i < num_top_probs; i++) {
+        top_probs.push([-1, -1.0]);
+    }
+
+    let sum_prob = 0.0;
+    // Selection argsort.
+    for (let p = 0; p < ndata; p++) {
+        let i = num_top_probs - 1;
+        for (; i >= 0; --i) {
+            if (p_prob[p] > top_probs[i][1]) {
+                if (i !== num_top_probs - 1) {
+                    top_probs[i + 1] = top_probs[i];
+                }
+            } else {
+                break;
+            }
+        }
+        if (i !== num_top_probs - 1) {
+            top_probs[i + 1] = [p, p_prob[p]];
+        }
+
+        // Early exit
+        sum_prob += p_prob[p];
+        if (1 - sum_prob <= top_probs[num_top_probs - 1][1]) {
+            break;
+        }
+    }
+    return top_probs;
+}

--- a/tests/generation_config.test.ts
+++ b/tests/generation_config.test.ts
@@ -34,6 +34,38 @@ describe('Check generation config illegal values', () => {
             postInitAndCheckGenerationConfigValues(genConfig)
         }).toThrow("Expect logit_bias's keys to be number represented in string");
     });
+
+    test('top_logprobs out of range', () => {
+        expect(() => {
+            const genConfig: GenerationConfig = {
+                logprobs: true,
+                top_logprobs: 6,
+                max_gen_len: 10
+            };
+            postInitAndCheckGenerationConfigValues(genConfig)
+        }).toThrow("`top_logprobs` should be in range [0,5]");
+    });
+
+    test('top_logprobs set without setting logprobs', () => {
+        expect(() => {
+            const genConfig: GenerationConfig = {
+                top_logprobs: 3,
+                max_gen_len: 10
+            };
+            postInitAndCheckGenerationConfigValues(genConfig)
+        }).toThrow("`logprobs` must be true if `top_logprobs` is set");
+    });
+
+    test('top_logprobs set though logprobs is false', () => {
+        expect(() => {
+            const genConfig: GenerationConfig = {
+                logprobs: false,
+                top_logprobs: 3,
+                max_gen_len: 10
+            };
+            postInitAndCheckGenerationConfigValues(genConfig)
+        }).toThrow("`logprobs` must be true if `top_logprobs` is set");
+    });
 });
 
 describe('Check generation post init', () => {
@@ -44,5 +76,24 @@ describe('Check generation post init', () => {
         };
         postInitAndCheckGenerationConfigValues(genConfig);
         expect(genConfig.presence_penalty).toBe(0.0);
+    });
+
+    test('Set logprobs without setting top_logprobs', () => {
+
+        const genConfig: GenerationConfig = {
+            logprobs: true,
+        };
+        postInitAndCheckGenerationConfigValues(genConfig);
+        expect(genConfig.top_logprobs).toBe(0);
+    });
+
+    test('Set both logprobs and top_logprobs', () => {
+
+        const genConfig: GenerationConfig = {
+            logprobs: true,
+            top_logprobs: 2,
+        };
+        postInitAndCheckGenerationConfigValues(genConfig);
+        expect(genConfig.top_logprobs).toBe(2);
     });
 });

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,0 +1,20 @@
+import { getTopProbs } from "../src/support"
+
+describe('Check getTopLogprobs correctness', () => {
+    test('Correctness test 1', () => {
+        const logitsOnCPUArray = new Float32Array([0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1]);
+        const actual = getTopProbs(3, logitsOnCPUArray);
+        const expected: Array<[number, number]> = [[2, 0.3], [5, 0.2], [3, 0.16]];
+        expect(actual.length).toBe(expected.length);
+        for (let i = 0; i < actual.length; i++) {
+            expect(actual[i][0]).toBe(expected[i][0]);
+            expect(actual[i][1]).toBeCloseTo(expected[i][1], 4);
+        }
+    });
+
+    test('Zero top_logprobs', () => {
+        const logitsOnCPUArray = new Float32Array([0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1]);
+        const topLogProbs = getTopProbs(0, logitsOnCPUArray);
+        expect(topLogProbs).toEqual([]);
+    });
+});


### PR DESCRIPTION
Support `logprobs` and `top_logprobs` for OpenAI API `ChatCompletion`. Subsequently, these are added to `GenerationConfig` as well. See [this link](https://platform.openai.com/docs/api-reference/chat/create) for reference.

Implementation-wise, since we need the actual distribution, we use `tvmjs.applySoftmaxWithTemperature()` and `tvmjs.sampleTopPFromProb()` instead of `tvmjs.sampleTopPFromLogits()`.

Performance-wise, despite all sampling being done on CPU, with `top_logprobs=2`, we observe no degradation with Llama-2-7b-q4f32 on M3 Macbook. Note that without `logprobs`, exact same behavior (hence performance) is maintained.

We also support `CompletionUsage` in this PR for token counting.