### PR TITLE
[Version] Bump version to 0.2.29

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.28",
+    "@mlc-ai/web-llm": "^0.2.29",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.28",
+    "@mlc-ai/web-llm": "^0.2.29",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28"
+        "@mlc-ai/web-llm": "^0.2.29"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28"
+        "@mlc-ai/web-llm": "^0.2.29"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28"
+        "@mlc-ai/web-llm": "^0.2.29"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -16,6 +16,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28"
+        "@mlc-ai/web-llm": "^0.2.29"
     }
 }

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28"
+        "@mlc-ai/web-llm": "^0.2.29"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.28",
+      "version": "0.2.29",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.28",
+        "@mlc-ai/web-llm": "^0.2.29",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
Two main changes in this new npm:
- `chatCompletion` now supports function calling: https://github.com/mlc-ai/web-llm/pull/321
- `Conversation` is revamped to support incoming updates of `mlc-chat-config.json` on HF: https://github.com/mlc-ai/web-llm/pull/339
  - This change is backward compatible (i.e. works with both new and old `mlc-chat-config.json`)
  - **Not forward compatible (i.e. when `mlc-chat-config.json` on HF is updated, you would have to update the npm to ^0.2.29)**

No change on TVMjs.