### PR TITLE
[SWA] Support SWA in pagedKVCache, remove backward compatible code

### DIFF
--- a/examples/logit-processor/src/logit_processor.ts
+++ b/examples/logit-processor/src/logit_processor.ts
@@ -30,7 +30,7 @@ async function main() {
   logitProcessorRegistry.set("Phi2-q4f32_1", myLogitProcessor);
 
   let chat: webllm.ChatInterface;
-  
+
   // Depending on whether we use a web worker, the code is slightly different
   if (USE_WEB_WORKER) {
     chat = new webllm.ChatWorkerClient(new Worker(
@@ -51,24 +51,24 @@ async function main() {
 
   // Below we demonstrate the usage of a low-level API `forwardTokensAndSample()`
   const prompt: Array<number> = [42];
-  let nextToken = await chat.forwardTokensAndSample(prompt, prompt.length, /*isPrefill=*/true);
+  let nextToken = await chat.forwardTokensAndSample(prompt, /*isPrefill=*/true);
   console.log(nextToken);
 
   let counter = prompt.length;
   while (counter < AUTOREGRESS_LIMIT) {
     counter += 1;
-    nextToken = await chat.forwardTokensAndSample([nextToken], counter, /*isPrefill=*/false);
+    nextToken = await chat.forwardTokensAndSample([nextToken], /*isPrefill=*/false);
     console.log(nextToken);
   }
 
   // By calling `chat.resetChat()`, we triggers MyLogitProcessor.resetState()
   chat.resetChat();
   counter = prompt.length;
-  nextToken = await chat.forwardTokensAndSample(prompt, prompt.length, /*isPrefill=*/true);
+  nextToken = await chat.forwardTokensAndSample(prompt, /*isPrefill=*/true);
   console.log(nextToken);
   while (counter < AUTOREGRESS_LIMIT) {
     counter += 1;
-    nextToken = await chat.forwardTokensAndSample([nextToken], counter, /*isPrefill=*/false);
+    nextToken = await chat.forwardTokensAndSample([nextToken], /*isPrefill=*/false);
     console.log(nextToken);
   }
 

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -447,10 +447,8 @@ export class ChatModule implements ChatInterface {
   //--------------------------
   // Lower level API
   //--------------------------
-  async forwardTokensAndSample(
-    inputIds: Array<number>, curPos: number, isPrefill: boolean
-  ): Promise<number> {
-    return this.getPipeline().forwardTokensAndSample(inputIds, curPos, isPrefill);
+  async forwardTokensAndSample(inputIds: Array<number>, isPrefill: boolean): Promise<number> {
+    return this.getPipeline().forwardTokensAndSample(inputIds, isPrefill);
   }
 
   /**
@@ -533,10 +531,10 @@ export class ChatModule implements ChatInterface {
   }
 
   private checkFunctionCallUsage(request: ChatCompletionRequest): string | null {
-    if (request.tools == undefined || 
-        (typeof request.tool_choice == "string" && request.tool_choice == "none")) {
-        this.getPipeline().overrideFunctionCalling(false, "");
-        return null;
+    if (request.tools == undefined ||
+      (typeof request.tool_choice == "string" && request.tool_choice == "none")) {
+      this.getPipeline().overrideFunctionCalling(false, "");
+      return null;
     }
 
     if (typeof request.tool_choice == "string" && request.tool_choice !== "auto") {
@@ -581,7 +579,7 @@ export class ChatModule implements ChatInterface {
     genConfig?: GenerationConfig
   ) {
     let input_str: string;
-    let input_role_str : string | undefined;
+    let input_role_str: string | undefined;
     if (typeof input === "string") {
       input_str = input;
     } else {
@@ -669,7 +667,7 @@ export class ChatRestModule implements ChatInterface {
   }
 
   async forwardTokensAndSample(
-    inputIds: Array<number>, curPos: number, isPrefill: boolean
+    inputIds: Array<number>, isPrefill: boolean
   ): Promise<number> {
     throw new Error("Method not supported.");
   }

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -22,13 +22,14 @@ export class LLMChatPipeline {
   private vm: tvmjs.VirtualMachine;
   private prefill: tvmjs.PackedFunc;
   private decoding: tvmjs.PackedFunc;
+  private embed: tvmjs.PackedFunc;
+  // Functions related to PagedKVCache
   private fclearKVCaches: tvmjs.PackedFunc;
-  // Functions for PagedKVCache only
-  private embed?: tvmjs.PackedFunc = undefined;
-  private fKVCacheAddSequence?: tvmjs.PackedFunc = undefined;
-  private fKVCacheRemoveSequence?: tvmjs.PackedFunc = undefined;
-  private fKVCacheBeginForward?: tvmjs.PackedFunc = undefined;
-  private fKVCacheEndForward?: tvmjs.PackedFunc = undefined;
+  private fKVCacheAddSequence: tvmjs.PackedFunc;
+  private fKVCacheRemoveSequence: tvmjs.PackedFunc;
+  private fKVCacheBeginForward: tvmjs.PackedFunc;
+  private fKVCacheEndForward: tvmjs.PackedFunc;
+  private fKVCacheEnableSlidingWindowForSeq: tvmjs.PackedFunc;
 
   // parameter states
   private params: tvmjs.TVMObject;
@@ -54,12 +55,6 @@ export class LLMChatPipeline {
   // frequency of appeared token ids till now (refresh after PrefillStep); token_id mapped to freq
   private appearedTokensFreq = new Map<number, number>();
   private conversation: Conversation;
-  // Whether sink is in action
-  private sinkTriggered = false;
-  // sliding window cache offset (Next position to be overridden on the rolling kv cache.)
-  private slidingWindowCacheOffset = 0;
-  // Whether we are using PagedKVCache (eventually this will become default)
-  private usePagedKVCache = false;
   // The logprob information of all tokens for this current round (cleared upon each prefillStep)
   // Cleared & updated at the exact same spots as `outputMessage`. Only updated when
   // `genConfig.logprobs` is true. Each entry corresponds to a single autoregressive step.
@@ -104,62 +99,35 @@ export class LLMChatPipeline {
     this.prefill = this.tvm.detachFromCurrentScope(
       this.vm.getFunction("prefill")
     );
-    try {
-      // We expect to find `embed` if we usePagedKVCache
-      this.embed = this.tvm.detachFromCurrentScope(
-        this.vm.getFunction("embed")
-      );
-    } catch {
-      // Do nothing
-    }
+    this.embed = this.tvm.detachFromCurrentScope(
+      this.vm.getFunction("embed")
+    );
     this.decoding = this.tvm.detachFromCurrentScope(
       this.vm.getFunction("decode")
     );
 
     // 2. Get json stored in the vm's metadata function
-    let fgetMetadata;
-    let useSLIM = false;  // SLIM is the new workflow
-    try {
-      fgetMetadata = this.vm.getFunction("get_metadata");
-    } catch (err) {
-      fgetMetadata = this.vm.getFunction("_metadata");
-      useSLIM = true;
-    }
+    const fgetMetadata = this.vm.getFunction("_metadata");
     const ret_value = fgetMetadata();
     const metadataStr = this.tvm.detachFromCurrentScope(ret_value).toString();
     const metadata = JSON.parse(metadataStr);
 
-    // 3. Load parameters
-    if (useSLIM) {
-      // Under SLIM workflow, we load parameters by name
-      const paramNames: string[] = [];
-      metadata.params.forEach((param: any) => { paramNames.push(param.name) });
-      this.params = this.tvm.detachFromCurrentScope(
-        this.tvm.getParamsFromCacheByName(paramNames)
-      );
-    } else {
-      // Backward compatibility -- load parameters by ids
-      this.params = this.tvm.detachFromCurrentScope(
-        this.tvm.getParamsFromCache("param", -1)
-      );
-    }
+    // 3. Load parameters by name
+    const paramNames: string[] = [];
+    metadata.params.forEach((param: any) => { paramNames.push(param.name) });
+    this.params = this.tvm.detachFromCurrentScope(
+      this.tvm.getParamsFromCacheByName(paramNames)
+    );
 
     // 4. Read in compilation configurations from metadata
-    if (metadata.hasOwnProperty("prefill_chunk_size")) {
-      this.prefillChunkSize = metadata.prefill_chunk_size;
-      this.logger("Using prefillChunkSize: ", this.prefillChunkSize);
-      if (this.prefillChunkSize <= 0) {
-        throw Error("Prefill chunk size needs to be positive.");
-      }
-    } else {
-      throw Error("Cannot find `prefill_chunk_size` in metadta; make sure the wasm is up to date.");
+    this.prefillChunkSize = metadata.prefill_chunk_size;
+    this.logger("Using prefillChunkSize: ", this.prefillChunkSize);
+    if (this.prefillChunkSize <= 0) {
+      throw Error("Prefill chunk size needs to be positive.");
     }
     // Only use one of slidingWindowSize and maxWindowLength
     if (metadata.hasOwnProperty("sliding_window_size") && metadata.sliding_window_size != -1) {
       this.slidingWindowSize = metadata.sliding_window_size;
-      if (this.prefillChunkSize <= 0) {
-        throw Error("Need to specify prefill chunk size if using sliding window attention.");
-      }
       this.logger("Using slidingWindowSize: ", this.slidingWindowSize);
       // Parse attention sink size
       if (metadata.hasOwnProperty("attention_sink_size") && metadata.attention_sink_size >= 0) {
@@ -172,104 +140,48 @@ export class LLMChatPipeline {
           "Use `attention_sink_size=0` for default sliding window."
         );
       }
+    } else if (metadata.hasOwnProperty("context_window_size") && metadata.context_window_size != -1) {
+      this.maxWindowLength = metadata.context_window_size;
+      this.logger("Using maxWindowLength: ", this.maxWindowLength);
     } else {
-      // Depending on when the model is compiled, it can be either called
-      // `context_window_size` or `max_window_size`
-      if (metadata.hasOwnProperty("context_window_size") && metadata.context_window_size != -1) {
-        this.maxWindowLength = metadata.context_window_size;
-        this.logger("Using maxWindowLength: ", this.maxWindowLength);
-      } else if (metadata.hasOwnProperty("max_window_size") && metadata.max_window_size != -1) {
-        this.maxWindowLength = metadata.max_window_size;
-        this.logger("Using maxWindowLength: ", this.maxWindowLength);
-      } else {
-        throw Error("Need to specify either sliding window size or max window size.");
-      }
+      throw Error("Need to specify either sliding window size or max window size.");
     }
 
     // 5. Create cache
-    // Use `fcreateCache` to determine whether we are using the new KVCache implementation
-    let fcreateCache;
-    try {
-      if (useSLIM) {
-        fcreateCache = this.vm.getFunction("_initialize_effect");
-      } else {
-        fcreateCache = this.vm.getFunction("create_kv_cache");
-      }
-    } catch (err) {
-      // If we cannot find function above, it means that we are using the new PagedKVCache
-      this.usePagedKVCache = true;
-      fcreateCache = this.vm.getFunction("create_tir_paged_kv_cache");
-      console.log("Using Paged KVCache");
-      if (this.embed === undefined) {
-        throw Error("If using paged KVCache, method `embed()` needs to be defined.");
-      }
-    }
-
     // Load cache functions and instantiate KVCache
-    if (this.usePagedKVCache) {
-      try {
-        this.fclearKVCaches = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.kv_state_clear")
-        );
-        this.fKVCacheAddSequence = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.kv_state_add_sequence")
-        );
-        this.fKVCacheRemoveSequence = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.kv_state_remove_sequence")
-        );
-        this.fKVCacheBeginForward = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.kv_state_begin_forward")
-        );
-        this.fKVCacheEndForward = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.kv_state_end_forward")
-        );
-      } catch (err) {
-        // If we cannot find the functions above, it means we are using an older build of binary
-        // TODO: Remove this when all prebuilts are updated
-        this.fclearKVCaches = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.paged_attention_kv_cache_clear")
-        );
-        this.fKVCacheAddSequence = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.paged_attention_kv_cache_add_sequence")
-        );
-        this.fKVCacheRemoveSequence = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.paged_attention_kv_cache_remove_sequence")
-        );
-        this.fKVCacheBeginForward = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.paged_attention_kv_cache_begin_forward")
-        );
-        this.fKVCacheEndForward = this.tvm.detachFromCurrentScope(
-          this.tvm.getGlobalFunc("vm.builtin.paged_attention_kv_cache_end_forward")
-        );
-      }
+    this.fclearKVCaches = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.kv_state_clear")
+    );
+    this.fKVCacheAddSequence = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.kv_state_add_sequence")
+    );
+    this.fKVCacheRemoveSequence = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.kv_state_remove_sequence")
+    );
+    this.fKVCacheBeginForward = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.kv_state_begin_forward")
+    );
+    this.fKVCacheEndForward = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.kv_state_end_forward")
+    );
+    this.fKVCacheEnableSlidingWindowForSeq = this.tvm.detachFromCurrentScope(
+      this.tvm.getGlobalFunc("vm.builtin.attention_kv_cache_enable_sliding_window_for_seq")
+    );
 
-      // Create PagedKVCache; we do not expose KVCache config for now
-      const defaultPageSize = 16;
-      const defaultMaxNumSequence = 1;
-      try {
-        this.kvCache = this.tvm.detachFromCurrentScope(fcreateCache(
-          this.tvm.makeShapeTuple([defaultMaxNumSequence]),  // max_num_sequence
-          this.tvm.makeShapeTuple([this.maxWindowLength]),  // max_total_sequence_length
-          this.tvm.makeShapeTuple([this.prefillChunkSize]),  // prefill_chunk_size
-          this.tvm.makeShapeTuple([defaultPageSize]),  // page_size, hard coded for now
-          this.tvm.makeShapeTuple([this.slidingWindowSize != -1 ? 1 : 0]),
-        ));
-      } catch (err) {
-        // If we cannot find the functions above, it means we are using an older build of binary
-        // TODO: Remove this when all prebuilts are updated
-        this.kvCache = this.tvm.detachFromCurrentScope(fcreateCache(
-          this.tvm.makeShapeTuple([defaultMaxNumSequence]),  // max_num_sequence
-          this.tvm.makeShapeTuple([this.maxWindowLength]),  // max_total_sequence_length
-          this.tvm.makeShapeTuple([this.prefillChunkSize]),  // prefill_chunk_size
-          this.tvm.makeShapeTuple([defaultPageSize]),  // page_size, hard coded for now
-        ));
-      }
-    } else {
-      this.fclearKVCaches = this.tvm.detachFromCurrentScope(
-        this.tvm.getGlobalFunc("vm.builtin.attention_kv_cache_array_clear")
-      );
-      this.kvCache = this.tvm.detachFromCurrentScope(fcreateCache());
-    }
+    // Create PagedKVCache; we do not expose KVCache config for now
+    const fcreateCache = this.vm.getFunction("create_tir_paged_kv_cache");
+    const defaultPageSize = 16;
+    const defaultMaxNumSequence = 1;
+    const maxTotalSeqLen =
+      this.slidingWindowSize != -1 ? this.slidingWindowSize : this.maxWindowLength;
+    this.kvCache = this.tvm.detachFromCurrentScope(fcreateCache(
+      this.tvm.makeShapeTuple([defaultMaxNumSequence]),  // max_num_sequence
+      this.tvm.makeShapeTuple([maxTotalSeqLen]),  // max_total_sequence_length
+      this.tvm.makeShapeTuple([this.prefillChunkSize]),  // prefill_chunk_size
+      this.tvm.makeShapeTuple([defaultPageSize]),  // page_size, hard coded for now
+      this.tvm.makeShapeTuple([this.slidingWindowSize != -1 ? 1 : 0]),
+    ));
+
     this.filledKVCacheLength = 0;
     this.resetChat();  // especially needed for PagedKVCache as we need to call fKVCacheAddSequence
     tvm.endScope();
@@ -308,15 +220,15 @@ export class LLMChatPipeline {
    * Reset the chat history
    */
   resetChat(keepStats = false) {
+    this.tvm.beginScope();
     this.conversation.reset();
     if (!keepStats) {
       this.resetRuntimeStats();
     }
     this.resetKVCache();
     this.filledKVCacheLength = 0;
-    this.sinkTriggered = false;
-    this.slidingWindowCacheOffset = 0;
     this.logitProcessor?.resetState();
+    this.tvm.endScope();
   }
 
   /**
@@ -324,8 +236,14 @@ export class LLMChatPipeline {
    */
   resetKVCache() {
     this.fclearKVCaches(this.kvCache);
-    if (this.usePagedKVCache) {
-      this.fKVCacheAddSequence!(this.kvCache, new tvmjs.Scalar(0, "int64"));
+    this.fKVCacheAddSequence!(this.kvCache, new tvmjs.Scalar(0, "int64"));
+    if (this.slidingWindowSize != -1) {
+      this.fKVCacheEnableSlidingWindowForSeq(
+        this.kvCache,
+        new tvmjs.Scalar(0, "int64"),
+        new tvmjs.Scalar(this.slidingWindowSize, "int32"),
+        new tvmjs.Scalar(this.attentionSinkSize, "int32")
+      );
     }
   }
 
@@ -404,7 +322,7 @@ export class LLMChatPipeline {
    * @param use_function_calling 
    * @param function_string 
    */
-  overrideFunctionCalling(use_function_calling: boolean, function_string: string) : void {
+  overrideFunctionCalling(use_function_calling: boolean, function_string: string): void {
     this.conversation.use_function_calling = use_function_calling;
     this.conversation.function_string = function_string;
   }
@@ -462,25 +380,12 @@ export class LLMChatPipeline {
     for (let begin = 0; begin < tokenLen; begin += this.prefillChunkSize) {
       const end = Math.min(tokenLen, begin + this.prefillChunkSize);
       const chunk = promptTokens.slice(begin, end);
-      const inputData = this.tvm.empty([1, chunk.length], "int32", this.device);
+      const inputData = this.tvm.empty([chunk.length], "int32", this.device);
       inputData.copyFrom(chunk);
       newSeqLen += chunk.length;
       logits = this.tvm.detachFromCurrentScope(
-        this.forward(inputData, newSeqLen)
+        this.forward(inputData)
       );
-
-      // Update window cache offset (prefill)
-      if (this.slidingWindowSize != -1) {
-        if (this.sinkTriggered) {
-          this.slidingWindowCacheOffset = Math.max(
-            (this.slidingWindowCacheOffset + chunk.length) % this.slidingWindowSize,
-            this.attentionSinkSize
-          )
-        } else {
-          this.slidingWindowCacheOffset += chunk.length;
-          this.sinkTriggered = this.slidingWindowCacheOffset >= this.attentionSinkSize;
-        }
-      }
     }
     if (newSeqLen != this.filledKVCacheLength + tokenLen) {
       throw Error("Expect chunking process all tokens.")
@@ -507,26 +412,13 @@ export class LLMChatPipeline {
     const tstart = performance.now();
 
     this.tvm.beginScope();
-    const inputData = this.tvm.empty([1, 1], "int32", this.device);
+    const inputData = this.tvm.empty([1], "int32", this.device);
     inputData.copyFrom(this.outputIds.slice(this.outputIds.length - 1));
 
     const logits = this.tvm.detachFromCurrentScope(
-      this.forward(inputData, this.filledKVCacheLength + 1)
+      this.forward(inputData)
     );
     this.filledKVCacheLength += 1;
-
-    // Update window cache offset (decoding)
-    if (this.slidingWindowSize != -1) {
-      if (this.sinkTriggered) {
-        this.slidingWindowCacheOffset = Math.max(
-          (this.slidingWindowCacheOffset + 1) % this.slidingWindowSize,
-          this.attentionSinkSize
-        )
-      } else {
-        this.slidingWindowCacheOffset += 1;
-        this.sinkTriggered = this.slidingWindowCacheOffset >= this.attentionSinkSize;
-      }
-    }
     this.tvm.endScope();
 
     // sample from logits
@@ -620,61 +512,21 @@ export class LLMChatPipeline {
     }
   }
 
-  private forward(inputs: tvmjs.NDArray, curPos: number): tvmjs.NDArray {
+  private forward(inputs: tvmjs.NDArray): tvmjs.NDArray {
     this.tvm.beginScope();
     let retValue;
-    const seqLen = inputs.shape[1];  // Num input tokens
-    const seqLenShape = this.tvm.makeShapeTuple([curPos]);
+    const seqLen = inputs.shape[0];  // Num input tokens
+    const seqIdsTuple = this.tvm.makeShapeTuple([0]);
+    const inputLenShape = this.tvm.makeShapeTuple([seqLen]);
+    this.fKVCacheBeginForward!(this.kvCache, seqIdsTuple, inputLenShape);
+    let embed = this.embed!(inputs, this.params);
+    embed = embed.view([1].concat(embed.shape));  // Reshape to [1, seqLen, hiddenSize]
     if (seqLen > 1) {
-      // Prefill
-      if (this.slidingWindowSize == -1) {
-        if (this.usePagedKVCache) {
-          const seqIdsTuple = this.tvm.makeShapeTuple([0]);
-          const inputLenShape = this.tvm.makeShapeTuple([seqLen]);
-          this.fKVCacheBeginForward!(this.kvCache, seqIdsTuple, inputLenShape);
-          const embed = this.embed!(inputs, this.params);
-          retValue = this.prefill(embed, this.kvCache, this.params);
-          this.fKVCacheEndForward!(this.kvCache);
-        } else {
-          retValue = this.prefill(inputs, seqLenShape, this.kvCache, this.params);
-        }
-      } else {
-        // Sliding window attention needs extra shape parameters
-        const cacheLen = Math.min(this.slidingWindowSize, curPos - seqLen);  // Num elements in the cache
-        const cacheLenShape = this.tvm.makeShapeTuple([cacheLen]);
-        const kvSeqLenShape = this.tvm.makeShapeTuple([cacheLen + seqLen]);
-        // Next position to be overridden on the rolling kv cache.
-        const slidingWindowCacheOffsetShape = this.tvm.makeShapeTuple([this.slidingWindowCacheOffset]);
-        retValue = this.prefill(
-          inputs, cacheLenShape, kvSeqLenShape, slidingWindowCacheOffsetShape, this.kvCache, this.params
-        );
-      }
+      retValue = this.prefill(embed, this.kvCache, this.params);
     } else {
-      // Decode
-      if (this.slidingWindowSize == -1) {
-        if (this.usePagedKVCache) {
-          const seqIdsTuple = this.tvm.makeShapeTuple([0]);
-          const appendLength = this.tvm.makeShapeTuple([1]);
-          this.fKVCacheBeginForward!(this.kvCache, seqIdsTuple, appendLength);
-          const embed = this.embed!(inputs, this.params);
-          retValue = this.decoding(embed, this.kvCache, this.params);
-          this.fKVCacheEndForward!(this.kvCache);
-        } else {
-          retValue = this.decoding(inputs, seqLenShape, this.kvCache, this.params);
-        }
-      } else {
-        // Same logic as above; keeping this if-else structure to match mlc-llm's llm_chat.cc
-        const seqLen = inputs.shape[1];  // Num input tokens
-        const cacheLen = Math.min(this.slidingWindowSize, curPos - seqLen);  // Num elements in the cache
-        const cacheLenShape = this.tvm.makeShapeTuple([cacheLen]);
-        const kvSeqLenShape = this.tvm.makeShapeTuple([cacheLen + seqLen]);
-        // Next position to be overridden on the rolling kv cache.
-        const slidingWindowCacheOffsetShape = this.tvm.makeShapeTuple([this.slidingWindowCacheOffset]);
-        retValue = this.decoding(
-          inputs, cacheLenShape, kvSeqLenShape, slidingWindowCacheOffsetShape, this.kvCache, this.params
-        );
-      }
+      retValue = this.decoding(embed, this.kvCache, this.params);
     }
+    this.fKVCacheEndForward!(this.kvCache);
     const logits = this.tvm.detachFromCurrentScope(retValue.get(0));
     this.tvm.endScope();
     this.tvm.attachToCurrentScope(logits);
@@ -917,17 +769,15 @@ export class LLMChatPipeline {
     return tokens;
   }
 
-  async forwardTokensAndSample(
-    inputIds: Array<number>, curPos: number, isPrefill: boolean
-  ): Promise<number> {
+  async forwardTokensAndSample(inputIds: Array<number>, isPrefill: boolean): Promise<number> {
     // 1. Convert input to NDArray
     const tstart = performance.now();
     this.tvm.beginScope();
-    const inputData = this.tvm.empty([1, inputIds.length], "int32", this.device);
+    const inputData = this.tvm.empty([inputIds.length], "int32", this.device);
     inputData.copyFrom(inputIds);
 
     // 2. Forward tokens and get logits
-    const logitsOnGPU: tvmjs.NDArray = this.forward(inputData, curPos);
+    const logitsOnGPU: tvmjs.NDArray = this.forward(inputData);
     const nextToken = await this.sampleTokenFromLogits(logitsOnGPU);
     this.tvm.endScope();
 
@@ -1005,18 +855,18 @@ export class LLMChatPipeline {
     }
 
     this.tvm.beginScope();
-    const inputData = this.tvm.empty([1, tokens.length], "int32", this.device);
+    const inputData = this.tvm.empty([tokens.length], "int32", this.device);
     inputData.copyFrom(tokens);
     const prefillStart = performance.now();
-    this.forward(inputData, tokens.length);
+    this.forward(inputData);
     this.tvm.endScope();
     await this.device.sync();
 
     const decodingStart = performance.now();
 
     this.tvm.beginScope();
-    const firstSampleToken = this.tvm.empty([1, 1], "int32", this.device).copyFrom([6234]);
-    const logitsOnCPU = this.updateLogitsOnCPU(this.forward(firstSampleToken, tokens.length + 1));
+    const firstSampleToken = this.tvm.empty([1], "int32", this.device).copyFrom([6234]);
+    const logitsOnCPU = this.updateLogitsOnCPU(this.forward(firstSampleToken));
     await this.device.sync();
     this.tvm.endScope();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,12 +161,10 @@ export interface ChatInterface {
    * This function has side effects as the model will update its KV cache.
    *
    * @param inputIds The input tokens.
-   * @param curPos Total number of tokens processed, including the inputIds (i.e.
-   * number of tokens in KV cache plus number of tokens in inputIds).
    * @param isPrefill True if prefill, false if decode; only used for statistics.
    * @returns Next token sampled.
    * @note This is an async function.
    */
-  forwardTokensAndSample(inputIds: Array<number>, curPos: number, isPrefill: boolean): Promise<number>;
+  forwardTokensAndSample(inputIds: Array<number>, isPrefill: boolean): Promise<number>;
 }
 

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -50,7 +50,6 @@ interface GenerateProgressCallbackParams {
 
 interface ForwardTokensAndSampleParams {
   inputIds: Array<number>;
-  curPos: number;
   isPrefill: boolean;
 }
 
@@ -178,7 +177,7 @@ export class ChatWorkerHandler {
       case "forwardTokensAndSample": {
         this.handleTask(msg.uuid, async () => {
           const params = msg.content as ForwardTokensAndSampleParams;
-          return await this.chat.forwardTokensAndSample(params.inputIds, params.curPos, params.isPrefill);
+          return await this.chat.forwardTokensAndSample(params.inputIds, params.isPrefill);
         })
         return;
       }
@@ -423,15 +422,12 @@ export class ChatWorkerClient implements ChatInterface {
     await this.getPromise<null>(msg);
   }
 
-  async forwardTokensAndSample(
-    inputIds: Array<number>, curPos: number, isPrefill: boolean
-  ): Promise<number> {
+  async forwardTokensAndSample(inputIds: Array<number>, isPrefill: boolean): Promise<number> {
     const msg: WorkerMessage = {
       kind: "forwardTokensAndSample",
       uuid: crypto.randomUUID(),
       content: {
         inputIds: inputIds,
-        curPos: curPos,
         isPrefill: isPrefill
       }
     };


### PR DESCRIPTION
This PR supports SWA under PagedKVCache, and with this, now all models running on WebLLM will be compiled with PagedKVCache (rather than the old KVCache that is no longer maintained).

Hence, we removed codes in `llm_chat.ts` that were for backward compatibility. However, old wasms would still work with npm <= 0.2.29 since wasm versioning will be introduced with 0.2.30.

Note that API for `forwardTokensAndSample()` is changed since we no longer need `curPos`.

Relevant PRs:
- https://github.com/mlc-ai/mlc-llm/pull/1967
- https://github.com/apache/tvm/pull/16729