### PR TITLE
[Version] Bump version to 0.2.30

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.29",
+    "@mlc-ai/web-llm": "^0.2.30",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.29",
+    "@mlc-ai/web-llm": "^0.2.30",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/get-started-rest/package.json
+++ b/examples/get-started-rest/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29"
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29"
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29"
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/examples/openai-api/package.json
+++ b/examples/openai-api/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "file:../.."
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -16,6 +16,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29"
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -14,6 +14,6 @@
         "typescript": "^4.9.5"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29"
+        "@mlc-ai/web-llm": "^0.2.30"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.29",
+      "version": "0.2.30",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.29",
+        "@mlc-ai/web-llm": "^0.2.30",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
Changes include:
- Expose `prebuiltAppConfig` to include all prebuilt model libraries, so all prebuilt models can be accessed from the npm package
  - Essentially the list of models in `gh-config.js` under `simple-chat`
- Add wasm versioning so 0.2.29 still works despite breaking changes in prebuilt model wasms
  - For more see https://github.com/mlc-ai/web-llm/pull/355
- Support json mode in `chatCompletion()`
  - For more see https://github.com/mlc-ai/web-llm/pull/350
- Update mistral models to use SWA with PagedKVCache, removed all backward compatibility code (since we now have wasm versioning)
  - https://github.com/mlc-ai/web-llm/pull/351

Updated WASMs in https://github.com/mlc-ai/binary-mlc-llm-libs/tree/main/web-llm-models/v0_2_30
- If you'd like to compile your own WASMs that is compatible with 0.2.30, Refer to the commit hash codes in https://github.com/mlc-ai/binary-mlc-llm-libs/pull/110 