### PR TITLE
[KVCache] Add implicit KVCache reuse, disable stateful option for chatCompletion

### DIFF
--- a/examples/openai-api/src/openai_api.ts
+++ b/examples/openai-api/src/openai_api.ts
@@ -94,45 +94,66 @@ async function mainStreaming() {
 }
 
 /**
- * We domnstrate stateful chat completion, where chat history is preserved across requests.
+ * We domnstrate multiround chatting. Though users are required to maintain chat history, internally
+ * we compare provided `messages` with the internal chat history. If it matches, we will reuse KVs
+ * and hence save computation -- essentially an implicit internal optimization.
  */
-async function mainStateful() {
+async function mainMultiroundChat() {
   const chat: webllm.ChatInterface = new webllm.ChatModule();
-
   chat.setInitProgressCallback((report: webllm.InitProgressReport) => {
     setLabel("init-label", report.text);
   });
 
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
+  // Round 0
+  const messages: webllm.ChatCompletionMessageParam[] = [
+    {
+      "role": "system",
+      "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+        "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+    },
+    { "role": "user", "content": "Provide me three US states." },
+  ];
+
   const request0: webllm.ChatCompletionRequest = {
-    stateful: true,
-    // stream: true, // works with and without streaming
-    messages: [
-      {
-        "role": "system",
-        "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
-          "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
-      },
-      { "role": "user", "content": "Provide me three US states." },
-    ],
+    stream: false,  // can be streaming, same behavior
+    messages: messages,
   };
 
   const reply0 = await chat.chatCompletion(request0);
+  const replyMessage0 = await chat.getMessage();
   console.log(reply0);
-  console.log(await chat.getMessage());
+  console.log(replyMessage0);
+
+  // Round 1
+  // Append generated response to messages
+  messages.push({ "role": "assistant", "content": replyMessage0 });
+  // Append new user input
+  messages.push({ "role": "user", "content": "Two more please!" });
+  // Below line would cause an internal reset (clear KV cache, etc.) since the history no longer
+  // matches the new request
+  // messages[0].content = "Another system prompt";
 
   const request1: webllm.ChatCompletionRequest = {
-    stateful: true,
-    // stream: true, // works with and without streaming
-    messages: [
-      { "role": "user", "content": "Two more please!" },
-    ],
+    stream: false,  // can be streaming, same behavior
+    messages: messages
   };
 
   const reply1 = await chat.chatCompletion(request1);
+  const replyMessage1 = await chat.getMessage();
   console.log(reply1);
-  console.log(await chat.getMessage());
+  console.log(replyMessage1);
+
+  // If we used multiround chat, request1 should only prefill a small number of tokens
+  const prefillTokens0 = reply0.usage?.prompt_tokens;
+  const prefillTokens1 = reply1.usage?.prompt_tokens;
+  console.log("Requset 0 prompt tokens: ", prefillTokens0);
+  console.log("Requset 1 prompt tokens: ", prefillTokens1);
+  if (prefillTokens0 === undefined || prefillTokens1 === undefined ||
+    prefillTokens1 > prefillTokens0) {
+    throw Error("Multi-round chat is not triggered as expected.");
+  }
 
   console.log(await chat.runtimeStatsText());
 }
@@ -195,4 +216,5 @@ async function mainFunctionCalling() {
 // Run one of the functions
 // mainNonStreaming();
 // mainStreaming();
-mainFunctionCalling();
+// mainFunctionCalling();
+mainMultiroundChat();

--- a/examples/web-worker/src/main.ts
+++ b/examples/web-worker/src/main.ts
@@ -62,7 +62,6 @@ async function mainOpenAIAPINonStreaming() {
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const request: webllm.ChatCompletionRequest = {
-    // stateful: true,  // set this optionally to preserve chat history
     messages: [
       {
         "role": "system",
@@ -102,7 +101,6 @@ async function mainOpenAIAPIStreaming() {
   await chat.reload("Llama-2-7b-chat-hf-q4f32_1");
 
   const request: webllm.ChatCompletionRequest = {
-    // stateful: true,  // set this optionally to preserve chat history
     stream: true,
     messages: [
       {

--- a/src/chat_module.ts
+++ b/src/chat_module.ts
@@ -7,8 +7,7 @@ import {
   prebuiltAppConfig,
   GenerationConfig,
   postInitAndCheckGenerationConfigValues,
-  ModelRecord,
-  Role
+  Role,
 } from "./config";
 import { LLMChatPipeline } from "./llm_chat"
 import {
@@ -30,6 +29,7 @@ import {
   GenerateProgressCallback,
   LogitProcessor
 } from "./types";
+import { Conversation, compareConversationObject, getConversation } from "./conversation"
 
 /**
  * This is the main interface to the chat module.
@@ -43,6 +43,7 @@ export class ChatModule implements ChatInterface {
   private initProgressCallback?: InitProgressCallback;
   private interruptSignal = false;
   private deviceLostIsError = false;  // whether device.lost is due to actual error or model reload
+  private config?: ChatConfig;
 
   constructor(logitProcessorRegistry?: Map<string, LogitProcessor>) {
     this.logitProcessorRegistry = logitProcessorRegistry;
@@ -80,7 +81,7 @@ export class ChatModule implements ChatInterface {
 
     // load config
     const configUrl = new URL("mlc-chat-config.json", modelUrl).href;
-    const config = {
+    this.config = {
       ...(await (await configCache.fetchWithCache(configUrl)).json()),
       ...chatOpts
     } as ChatConfig;
@@ -155,10 +156,10 @@ export class ChatModule implements ChatInterface {
       }
     });
     this.deviceLostIsError = true;
-    const tokenizer = await this.asyncLoadTokenizer(modelUrl, config);
+    const tokenizer = await this.asyncLoadTokenizer(modelUrl, this.config);
     await tvm.fetchNDArrayCache(modelUrl, tvm.webgpu(), "webllm/model");
 
-    this.pipeline = new LLMChatPipeline(tvm, tokenizer, config, this.logitProcessor);
+    this.pipeline = new LLMChatPipeline(tvm, tokenizer, this.config, this.logitProcessor);
     await this.pipeline?.asyncLoadWebGPUPipelines();
     const tend = performance.now();
 
@@ -174,7 +175,7 @@ export class ChatModule implements ChatInterface {
   }
 
   async generate(
-    input: string | Array<ChatCompletionMessageParam>,
+    input: string | ChatCompletionRequestNonStreaming,
     progressCallback?: GenerateProgressCallback,
     streamInterval = 1,
     genConfig?: GenerationConfig,
@@ -213,9 +214,6 @@ export class ChatModule implements ChatInterface {
     if (request.seed !== null && request.seed !== undefined) {
       this.getPipeline().setSeed(request.seed);
     }
-    if (!request.stateful) {
-      await this.resetChat();
-    }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const model = this.currentModelId!;
     const created = Date.now();
@@ -248,7 +246,7 @@ export class ChatModule implements ChatInterface {
       return chunk;
     }
 
-    await this.prefill(request.messages, genConfig);
+    await this.prefill(request, genConfig);
     yield await _getChunk(this);  // prefill produces a chunk
 
     while (!this.stopped()) {
@@ -286,8 +284,7 @@ export class ChatModule implements ChatInterface {
    * @param request A OpenAI-style ChatCompletion request.
    * 
    * @note For each choice (i.e. `n`), a request is defined by a single `prefill()` and mulitple
-   * `decode()`. This is important as it determines the behavior of various fields including
-   * `stateful` and `seed`.
+   * `decode()`. This is important as it determines the behavior of various fields including `seed`.
    */
   async chatCompletion(
     request: ChatCompletionRequestNonStreaming
@@ -319,11 +316,6 @@ export class ChatModule implements ChatInterface {
       response_format: request.response_format,
     }
 
-    const error_msg = this.checkFunctionCallUsage(request);
-    if (error_msg) {
-      throw new Error(error_msg);
-    }
-
     // 1. If request is streaming, return an AsyncIterable (an iterable version of `generate()`)
     if (request.stream) {
       return this.chatCompletionAsyncChunkGenerator(request, genConfig);
@@ -339,9 +331,6 @@ export class ChatModule implements ChatInterface {
     let completion_tokens = 0;
     let prompt_tokens = 0;
     for (let i = 0; i < n; i++) {
-      if (!request.stateful) {
-        await this.resetChat();
-      }
       let outputMessage: string;
       if (this.interruptSignal) {
         // A single interrupt signal should stop all choices' generations
@@ -349,7 +338,7 @@ export class ChatModule implements ChatInterface {
         outputMessage = "";
       } else {
         outputMessage = await this.generate(
-          request.messages,
+          request,
           /*progressCallback=*/undefined,
           /*streamInterval=*/1,
           /*genConfig=*/genConfig
@@ -476,42 +465,44 @@ export class ChatModule implements ChatInterface {
   }
 
   /**
-   * Modify this.getPipeline().conversation according to the user provided messages.
-   * This include modifying `Conversation.messges` and `Conversation.config.system`.
+   * Get a new Conversation object based on the chat completion request.
    * 
-   * @param input The messages from ChatCompletionRequest
-   * @note `input[-1]` is not included as it would be treated as a normal input to `prefill()`.
+   * @param request The incoming ChatCompletionRequest
+   * @note `request.messages[-1]` is not included as it would be treated as a normal input to
+   * `prefill()`.
    */
-  private updateConversationWithChatCompletionMessages(
-    input: Array<ChatCompletionMessageParam>
-  ): void {
-    let hasHistory = false;
-    if (this.getPipeline().getConversationMessages().length > 0) {
-      hasHistory = true;
-    }
+  private getConversationFromChatCompletionRequest(
+    request: ChatCompletionRequest,
+    config: ChatConfig
+  ): Conversation {
+    // 0. Instantiate a new Conversation object
+    const conversation = getConversation(config.conv_template, config.conv_config);
+
+    // 1. Populate function-calling-related fields
+    const functionCallUsage = this.getFunctionCallUsage(request);
+    conversation.function_string = functionCallUsage;
+    conversation.use_function_calling = functionCallUsage === "";
+
+    // 2. Populate conversation.messages
+    const input = request.messages;
     const lastId = input.length - 1;
     if (input[lastId].role !== "user" || typeof input[lastId].content !== "string") {
       // TODO(Charlie): modify condition after we support multimodal inputs
       throw Error("The last message should be a string from the `user`.")
     }
-    // We prepare to override the message history
-    const roles: Array<string> = this.getPipeline().getRoles();
     for (let i = 0; i < input.length - 1; i++) {
-      const message = input[i];
+      const message: ChatCompletionMessageParam = input[i];
       if (message.role === "system") {
         if (i !== 0) {
           throw new Error("System prompt should always be the first one in `messages`.");
         }
-        if (hasHistory) {
-          throw new Error("Can only modify system prompt in the first chat completion request.");
-        }
-        this.getPipeline().overrideSystemPrompt(message.content);
+        conversation.override_system_message = message.content;
       } else if (message.role === "user") {
         if (typeof message.content !== "string") {
           // TODO(Charlie): modify condition after we support multimodal inputs
           throw new Error("Last messages should be a string from the `user`.");
         }
-        this.getPipeline().appendConversationMessage(
+        conversation.appendMessage(
           Role.user,
           message.content,
           message.name
@@ -520,7 +511,7 @@ export class ChatModule implements ChatInterface {
         if (typeof message.content !== "string") {
           throw new Error("Assistant message should have string content.");
         }
-        this.getPipeline().appendConversationMessage(
+        conversation.appendMessage(
           Role.assistant,
           message.content,
           message.name
@@ -529,65 +520,86 @@ export class ChatModule implements ChatInterface {
         throw new Error("Unsupported role: " + message.role);
       }
     }
+    return conversation;
   }
 
-  private checkFunctionCallUsage(request: ChatCompletionRequest): string | null {
+  /**
+   * Returns the function string based on the request.tools and request.tool_choice, raises erros if
+   * encounter invalid request.
+   * 
+   * @param request The chatCompletionRequest we are about to prefill for.
+   * @returns The string used to set Conversatoin.function_string
+   */
+  private getFunctionCallUsage(request: ChatCompletionRequest): string {
     if (request.tools == undefined ||
       (typeof request.tool_choice == "string" && request.tool_choice == "none")) {
-      this.getPipeline().overrideFunctionCalling(false, "");
-      return null;
+      return "";
     }
-
     if (typeof request.tool_choice == "string" && request.tool_choice !== "auto") {
-      return `Invalid tool choice value: ${request.tool_choice}`;
+      throw Error(`Invalid tool choice value: ${request.tool_choice}`);
     }
-
-    if (typeof request.tool_choice !== "string" && request.tool_choice?.type) {
-      return "Only 'function' tool choice is supported";
+    if (typeof request.tool_choice !== "string" && request.tool_choice?.type !== "function") {
+      throw Error("Only 'function' tool choice is supported");
     }
 
     const singleFunctionToCall = typeof request.tool_choice !== "string" && request.tool_choice?.function?.name;
-
     if (singleFunctionToCall) {
       for (const f of request.tools) {
         if (singleFunctionToCall == f.function.name) {
-          this.getPipeline().overrideFunctionCalling(true, JSON.stringify([f.function]));
-          return null;
+          return JSON.stringify([f.function]);
         }
       }
-
-      return `The tool choice function ${singleFunctionToCall} is not found in the tools list`;
+      throw Error(`The tool choice function ${singleFunctionToCall} is not found in the tools list`);
     }
 
-    let function_list = [];
+    const function_list = [];
     for (const f of request.tools) {
       if (f.type !== "function") {
-        return "Only 'function' tool type is supported";
+        throw Error("Only 'function' tool type is supported");
       }
-
       function_list.push(f.function);
     }
-    this.getPipeline().overrideFunctionCalling(true, JSON.stringify(function_list));
-    return null;
+    return JSON.stringify(function_list);
   }
 
   /**
    * Run a prefill step with a given input.
+   * 
+   * If `input` is a chatCompletionRequest, we treat `input.messages[-1]` as the usual user input.
+   * We then convert `input.messages[:-1]` to a `Conversation` object, representing a conversation
+   * history.
+   * 
+   * If the new `Conversation` object matches the current one loaded, it means we are
+   * performing multi-round chatting, so we do not reset, hence reusing KV cache. Otherwise, we
+   * reset every thing, treating the request as something completely new.
+   * 
    * @param input The input prompt, or `messages` in OpenAI-like APIs.
    */
   async prefill(
-    input: string | Array<ChatCompletionMessageParam>,
+    input: string | ChatCompletionRequest,
     genConfig?: GenerationConfig
   ) {
+    if (this.config === undefined) {
+      throw Error("Expect this.config to be initialized. Did you call `reload()`?");
+    }
     let input_str: string;
     let input_role_str: string | undefined;
     if (typeof input === "string") {
       input_str = input;
     } else {
-      // Process ChatCompletionMessageParam
-      // We treat the last message as our usual input
-      this.updateConversationWithChatCompletionMessages(input);
-      const last_msg = input[input.length - 1] as ChatCompletionUserMessageParam;
+      // 1. Get new conversation based on request, determine if we are in multiround chatting
+      const oldConv = this.getPipeline().getConversationObject();
+      const newConv = this.getConversationFromChatCompletionRequest(input, this.config);
+      if (!compareConversationObject(oldConv, newConv)) {
+        // Not the same conversation, so not multiround chatting, reset everything (KV cache, etc.)
+        this.resetChat();
+        this.getPipeline().setConversation(newConv);
+      } else {
+        console.log("Multiround chatting, reuse KVCache.");
+      }
+
+      // 2. Treat the last message as the usual input
+      const last_msg = input.messages[input.messages.length - 1] as ChatCompletionUserMessageParam;
       input_str = last_msg.content as string;
       input_role_str = last_msg.name ? last_msg.name : undefined;
     }
@@ -689,7 +701,7 @@ export class ChatRestModule implements ChatInterface {
   }
 
   async generate(
-    input: string | Array<ChatCompletionMessageParam>,
+    input: string | ChatCompletionRequestNonStreaming,
     progressCallback?: GenerateProgressCallback,
     streamInterval = 1,
     genConfig?: GenerationConfig,

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -326,45 +326,17 @@ export class LLMChatPipeline {
 
   // Getters and setters for this.conversation.
   /**
-   * Overrides the system prompt.
+   * @returns The conversation object (not a deep copy).
    */
-  overrideSystemPrompt(system: string): void {
-    this.conversation.config.system_message = system;
+  getConversationObject(): Conversation {
+    return this.conversation;
   }
 
   /**
-   * Append a new message to `this.conversation`.
+   * Set this.conversation to a new conversation object.
    */
-  appendConversationMessage(role: Role, input: string, role_name?: string): void {
-    this.conversation.appendMessage(role, input, role_name);
-  }
-
-  /**
-   * Override this.conversation.use_function_calling and
-   * this.conversation.function_string
-   * 
-   * @param use_function_calling 
-   * @param function_string 
-   */
-  overrideFunctionCalling(use_function_calling: boolean, function_string: string): void {
-    this.conversation.use_function_calling = use_function_calling;
-    this.conversation.function_string = function_string;
-  }
-
-  /**
-   * Get this.conversation.messages.
-   */
-  getConversationMessages(): Array<[Role, string, string | undefined]> {
-    // TODO(Charlie): Do we need to make a deep copy here?
-    return this.conversation.messages;
-  }
-
-  /**
-   * @returns the roles of this.conversation's conversation template of lengths of two.
-   */
-  getRoles(): Array<string> {
-    const roles = this.conversation.config.roles;
-    return [roles[Role.user], roles[Role.assistant]];
+  setConversation(newConv: Conversation) {
+    this.conversation = newConv;
   }
 
   async asyncLoadWebGPUPipelines() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,14 +85,14 @@ export interface ChatInterface {
   /**
    * Generate a response for a given input.
    *
-   * @param input The input prompt or an array of OpenAI-like `ChatCompletionMessageParam`.
+   * @param input The input prompt or a non-streaming ChatCompletionRequest.
    * @param progressCallback Callback that is being called to stream intermediate results.
    * @param streamInterval callback interval to call progresscallback
    * @param genConfig Configuration for this single generation that overrides pre-existing configs.
    * @returns The final result.
    */
   generate: (
-    input: string | Array<ChatCompletionMessageParam>,
+    input: string | ChatCompletionRequestNonStreaming,
     progressCallback?: GenerateProgressCallback,
     streamInterval?: number,
     genConfig?: GenerationConfig,
@@ -100,6 +100,12 @@ export interface ChatInterface {
 
   /**
    * OpenAI-style API. Generate a chat completion response for the given conversation and configuration.
+   * 
+   * The API is completely functional in behavior. That is, a previous request would not affect
+   * the current request's result. Thus, for multi-round chatting, users are responsible for
+   * maintaining the chat history. With that being said, as an implicit internal optimization, if we
+   * detect that the user is performing multiround chatting, we will preserve the KV cache and only
+   * prefill the new tokens.
    */
   chatCompletion(
     request: ChatCompletionRequestNonStreaming

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -34,7 +34,7 @@ interface ReloadParams {
 }
 
 interface GenerateParams {
-  input: string | Array<ChatCompletionMessageParam>,
+  input: string | ChatCompletionRequestNonStreaming,
   streamInterval?: number;
   genConfig?: GenerationConfig;
 }
@@ -364,7 +364,7 @@ export class ChatWorkerClient implements ChatInterface {
   }
 
   async generate(
-    input: string | Array<ChatCompletionMessageParam>,
+    input: string | ChatCompletionRequestNonStreaming,
     progressCallback?: GenerateProgressCallback,
     streamInterval?: number,
     genConfig?: GenerationConfig,

--- a/tests/function_calling.test.ts
+++ b/tests/function_calling.test.ts
@@ -11,7 +11,7 @@ describe('Test conversation template', () => {
         const conv = getConversation("gorilla");
         conv.appendMessage(Role.user, "Call me an Uber ride type \"Plus\" in Berkeley at zipcode 94704 in 10 minutes", "Tom");
         const prompt_array = conv.getPromptArray();
-        
+
         expect(prompt_array).toEqual([
             "A chat between a curious user and an artificial intelligence assistant. " +
             "The assistant gives helpful, detailed, and polite answers to the user's questions.\n",
@@ -26,14 +26,14 @@ describe('Test conversation template', () => {
             "name": "Uber Carpool",
             "api_name": "uber.ride",
             "description": "Find suitable ride for customers given the location, type of ride, and the amount of time the customer is willing to wait as parameters",
-            "parameters":  [
-                {"name": "loc", "description": "Location of the starting place of the Uber ride"},
-                {"name": "type", "enum": ["plus", "comfort", "black"], "description": "Types of Uber ride user is ordering"},
-                {"name": "time", "description": "The amount of time in minutes the customer is willing to wait"}
+            "parameters": [
+                { "name": "loc", "description": "Location of the starting place of the Uber ride" },
+                { "name": "type", "enum": ["plus", "comfort", "black"], "description": "Types of Uber ride user is ordering" },
+                { "name": "time", "description": "The amount of time in minutes the customer is willing to wait" }
             ]
         }]);
         const prompt_array = conv.getPromptArray();
-        
+
         expect(prompt_array).toEqual([
             "A chat between a curious user and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the user's questions.\n",
             "USER: <<question>> Call me an Uber ride type \"Plus\" in Berkeley at zipcode 94704 in 10 minutes <<function>> [{\"name\":\"Uber Carpool\",\"api_name\":\"uber.ride\",\"description\":\"Find suitable ride for customers given the location, type of ride, and the amount of time the customer is willing to wait as parameters\",\"parameters\":[{\"name\":\"loc\",\"description\":\"Location of the starting place of the Uber ride\"},{\"name\":\"type\",\"enum\":[\"plus\",\"comfort\",\"black\"],\"description\":\"Types of Uber ride user is ordering\"},{\"name\":\"time\",\"description\":\"The amount of time in minutes the customer is willing to wait\"}]}]\n"
@@ -42,7 +42,7 @@ describe('Test conversation template', () => {
 });
 
 describe('Test ChatModule', () => {
-    test('Test checkFunctionCallUsage none', () => {
+    test('Test getFunctionCallUsage none', () => {
         const chat_module = new ChatModule();
 
         const request: ChatCompletionRequest = {
@@ -53,25 +53,16 @@ describe('Test ChatModule', () => {
             ],
             tool_choice: 'none',
             tools: [
-              { type: 'function', function: { description: 'A', name: 'fn_A', parameters: { foo: 'bar' } } },
-              { type: 'function', function: { description: 'B', name: 'fn_B', parameters: { foo: 'bar' } } },
-              { type: 'function', function: { description: 'C', name: 'fn_C', parameters: { foo: 'bar' } } },
+                { type: 'function', function: { description: 'A', name: 'fn_A', parameters: { foo: 'bar' } } },
+                { type: 'function', function: { description: 'B', name: 'fn_B', parameters: { foo: 'bar' } } },
+                { type: 'function', function: { description: 'C', name: 'fn_C', parameters: { foo: 'bar' } } },
             ],
         };
 
-        jest.spyOn(chat_module as any, "getPipeline")
-            .mockImplementation(() => {
-                return {
-                    overrideFunctionCalling: jest.fn((use_fn_calling, fn_str) => {
-                        expect(use_fn_calling).toBe(false);
-                        expect(fn_str).toEqual("");
-                    })
-                };
-            });
-        (chat_module as any).checkFunctionCallUsage(request);
+        expect((chat_module as any).getFunctionCallUsage(request)).toEqual("");
     });
 
-    test('Test checkFunctionCallUsage auto', () => {
+    test('Test getFunctionCallUsage auto', () => {
         const chat_module = new ChatModule();
 
         const request: ChatCompletionRequest = {
@@ -87,20 +78,10 @@ describe('Test ChatModule', () => {
                 { type: 'function', function: { description: 'C', name: 'fn_C', parameters: { foo: 'bar' } } },
             ],
         };
-
-        jest.spyOn(chat_module as any, "getPipeline")
-            .mockImplementation(() => {
-                return {
-                    overrideFunctionCalling: jest.fn((use_fn_calling, fn_str) => {
-                        expect(use_fn_calling).toBe(true);
-                        expect(fn_str).toEqual("[{\"description\":\"A\",\"name\":\"fn_A\",\"parameters\":{\"foo\":\"bar\"}},{\"description\":\"B\",\"name\":\"fn_B\",\"parameters\":{\"foo\":\"bar\"}},{\"description\":\"C\",\"name\":\"fn_C\",\"parameters\":{\"foo\":\"bar\"}}]");
-                    })
-                };
-            });
-        (chat_module as any).checkFunctionCallUsage(request);
+        expect((chat_module as any).getFunctionCallUsage(request)).toEqual("[{\"description\":\"A\",\"name\":\"fn_A\",\"parameters\":{\"foo\":\"bar\"}},{\"description\":\"B\",\"name\":\"fn_B\",\"parameters\":{\"foo\":\"bar\"}},{\"description\":\"C\",\"name\":\"fn_C\",\"parameters\":{\"foo\":\"bar\"}}]");
     });
 
-    test('Test checkFunctionCallUsage function', () => {
+    test('Test getFunctionCallUsage function', () => {
         const chat_module = new ChatModule();
 
         const request: ChatCompletionRequest = {
@@ -121,16 +102,7 @@ describe('Test ChatModule', () => {
                 { type: 'function', function: { description: 'C', name: 'fn_C', parameters: { foo: 'bar' } } },
             ],
         };
+        expect((chat_module as any).getFunctionCallUsage(request)).toEqual("[{\"description\":\"B\",\"name\":\"fn_B\",\"parameters\":{\"foo\":\"bar\"}}]");
 
-        jest.spyOn(chat_module as any, "getPipeline")
-            .mockImplementation(() => {
-                return {
-                    overrideFunctionCalling: jest.fn((use_fn_calling, fn_str) => {
-                        expect(use_fn_calling).toBe(true);
-                        expect(fn_str).toEqual("[{\"description\":\"B\",\"name\":\"fn_B\",\"parameters\":{\"foo\":\"bar\"}}]");
-                    })
-                };
-            });
-        (chat_module as any).checkFunctionCallUsage(request);
     });
 });

--- a/tests/multi_round_chat.test.ts
+++ b/tests/multi_round_chat.test.ts
@@ -1,0 +1,223 @@
+
+import { describe, expect, test } from '@jest/globals';
+
+import {
+    ChatCompletionMessageParam,
+    ChatCompletionRequest,
+    ChatCompletionUserMessageParam,
+} from "../src/openai_api_protocols/chat_completion";
+import { ChatModule } from '../src/chat_module';
+import { Conversation, compareConversationObject } from '../src/conversation';
+import { ChatConfig, Role } from '../src/config';
+
+const configStr = "{" +
+    "  \"conv_template\": {" +
+    "    \"name\": \"llama-2\"," +
+    "    \"system_template\": \"[INST] <<SYS>>\\n{system_message}\\n<</SYS>>\\n\\n\"," +
+    "    \"system_message\": \"You are a helpful, respectful and honest assistant.\"," +
+    "    \"system_prefix_token_ids\": [" +
+    "      1" +
+    "    ]," +
+    "    \"add_role_after_system_message\": false," +
+    "    \"roles\": {" +
+    "      \"user\": \"[INST]\"," +
+    "      \"assistant\": \"[/INST]\"," +
+    "      \"tool\": \"[INST]\"" +
+    "    }," +
+    "    \"role_templates\": {" +
+    "      \"user\": \"{user_message}\"," +
+    "      \"assistant\": \"{assistant_message}\"," +
+    "      \"tool\": \"{tool_message}\"" +
+    "    }," +
+    "    \"messages\": []," +
+    "    \"seps\": [" +
+    "      \" \"" +
+    "    ]," +
+    "    \"role_content_sep\": \" \"," +
+    "    \"role_empty_sep\": \" \"," +
+    "    \"stop_str\": [" +
+    "      \"[INST]\"" +
+    "    ]," +
+    "    \"stop_token_ids\": [" +
+    "      2" +
+    "    ]," +
+    "    \"function_string\": \"\"," +
+    "    \"use_function_calling\": false" +
+    "  }" +
+    "}";
+
+describe('Test multi-round chatting', () => {
+    test('Test is multi-round', () => {
+        // Setups
+        const config_json = JSON.parse(configStr);
+        const chatConfig = { ...config_json } as ChatConfig;
+        const chatModule = new ChatModule();
+
+        // Simulate request0
+        const messages: ChatCompletionMessageParam[] = [
+            {
+                "role": "system",
+                "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+                    "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+            },
+            { "role": "user", "content": "Provide me three US states." },
+        ];
+        const request0: ChatCompletionRequest = {
+            messages: messages,
+        };
+
+        // Simulate processing of request0, appending response to convA (done by LLMChatPipeline)
+        const conv0: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request0, chatConfig));
+        conv0.appendMessage(Role.user, "Provide me three US states.");
+        const reply0 = "California, New York, Nevada.";
+        conv0.appendMessage(Role.assistant, reply0);  // simulated response
+
+        // Simulate request1, where user maintain the chat history, appending the resposne
+        const newMessages = [...messages];
+        newMessages.push({ "role": "assistant", "content": reply0 });
+        newMessages.push({ "role": "user", "content": "Two more please" });  // next input
+
+        const request1: ChatCompletionRequest = {
+            messages: newMessages,
+        }
+        const conv1: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request1, chatConfig));
+
+        expect(compareConversationObject(conv0, conv1)).toBe(true);
+    });
+
+    test('Test is NOT multi-round due to multiple new inputs', () => {
+        // Setups
+        const config_json = JSON.parse(configStr);
+        const chatConfig = { ...config_json } as ChatConfig;
+        const chatModule = new ChatModule();
+
+        // Simulate request0
+        const messages: ChatCompletionMessageParam[] = [
+            {
+                "role": "system",
+                "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+                    "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+            },
+            { "role": "user", "content": "Provide me three US states." },
+        ];
+        const request0: ChatCompletionRequest = {
+            messages: messages,
+        };
+
+        // Simulate processing of request0, appending response to convA (done by LLMChatPipeline)
+        const conv0: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request0, chatConfig));
+        conv0.appendMessage(Role.user, "Provide me three US states.");
+        const reply0 = "California, New York, Nevada.";
+        conv0.appendMessage(Role.assistant, reply0);  // simulated response
+
+        // Simulate request1, where user maintain the chat history, appending the resposne
+        const newMessages = [...messages];
+        newMessages.push({ "role": "assistant", "content": reply0 });
+        newMessages.push({ "role": "user", "content": "Two more please" });  // next input
+
+        // Code above same as previous tests
+        // Add one more round of chat history
+        newMessages.push({ "role": "assistant", "content": "Pennsylvania, Florida" });  // next response
+        newMessages.push({ "role": "user", "content": "Thank you!" });  // next input
+
+        const request1: ChatCompletionRequest = {
+            messages: newMessages,
+        }
+        const conv1: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request1, chatConfig));
+
+        expect(compareConversationObject(conv0, conv1)).toBe(false);
+    });
+
+    test('Test is NOT multi-round due to change in system prompt', () => {
+        // Setups
+        const config_json = JSON.parse(configStr);
+        const chatConfig = { ...config_json } as ChatConfig;
+        const chatModule = new ChatModule();
+
+        // Simulate request0
+        const messages: ChatCompletionMessageParam[] = [
+            {
+                "role": "system",
+                "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+                    "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+            },
+            { "role": "user", "content": "Provide me three US states." },
+        ];
+        const request0: ChatCompletionRequest = {
+            messages: messages,
+        };
+
+        // Simulate processing of request0, appending response to convA (done by LLMChatPipeline)
+        const conv0: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request0, chatConfig));
+        conv0.appendMessage(Role.user, "Provide me three US states.");
+        const reply0 = "California, New York, Nevada.";
+        conv0.appendMessage(Role.assistant, reply0);  // simulated response
+
+        // Simulate request1, where user maintain the chat history, appending the resposne
+        const newMessages = [...messages];
+        newMessages.push({ "role": "assistant", "content": reply0 });
+        newMessages.push({ "role": "user", "content": "Two more please" });  // next input
+
+        // Code above same as previous tests
+        // Changed system prompt, should be false
+        newMessages[0].content = "No system prompt";
+
+        const request1: ChatCompletionRequest = {
+            messages: newMessages,
+        }
+        const conv1: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request1, chatConfig));
+
+        expect(compareConversationObject(conv0, conv1)).toBe(false);
+    });
+
+    test('Test is NOT multi-round due to change in role name', () => {
+        // Setups
+        const config_json = JSON.parse(configStr);
+        const chatConfig = { ...config_json } as ChatConfig;
+        const chatModule = new ChatModule();
+
+        // Simulate request0
+        const messages: ChatCompletionMessageParam[] = [
+            {
+                "role": "system",
+                "content": "[INST] <<SYS>>\n\nYou are a helpful, respectful and honest assistant. " +
+                    "Be as happy as you can when speaking please.\n<</SYS>>\n\n "
+            },
+            { "role": "user", "content": "Provide me three US states." },
+        ];
+        const request0: ChatCompletionRequest = {
+            messages: messages,
+        };
+
+        // Simulate processing of request0, appending response to convA (done by LLMChatPipeline)
+        const conv0: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request0, chatConfig));
+        conv0.appendMessage(Role.user, "Provide me three US states.");
+        const reply0 = "California, New York, Nevada.";
+        conv0.appendMessage(Role.assistant, reply0);  // simulated response
+
+        // Simulate request1, where user maintain the chat history, appending the resposne
+        const newMessages = [...messages];
+        newMessages.push({ "role": "assistant", "content": reply0 });
+        newMessages.push({ "role": "user", "content": "Two more please" });  // next input
+
+        // Code above same as previous tests
+        // Changed system prompt, should be false
+        (newMessages[1] as ChatCompletionUserMessageParam).name = "Bob";
+
+        const request1: ChatCompletionRequest = {
+            messages: newMessages,
+        }
+        const conv1: Conversation =
+            ((chatModule as any).getConversationFromChatCompletionRequest(request1, chatConfig));
+
+        expect(compareConversationObject(conv0, conv1)).toBe(false);
+    });
+
+})

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -55,19 +55,6 @@ describe('Check chat completion unsupported requests', () => {
         }).toThrow("When streaming, `n` cannot be > 1.");
     });
 
-    test('When stateful `n` needs to be 1', () => {
-        expect(() => {
-            const request: ChatCompletionRequest = {
-                stateful: true,
-                n: 2,
-                messages: [
-                    { role: "user", content: "Hello! " },
-                ],
-            };
-            postInitAndCheckFields(request)
-        }).toThrow("If the request is stateful, `n` cannot be > 1.");
-    });
-
     test('Non-integer seed', () => {
         expect(() => {
             const request: ChatCompletionRequest = {


### PR DESCRIPTION
We introduced the field `stateful` in `chatCompletion()` earlier to allow easier multi-round chatting in https://github.com/mlc-ai/web-llm/pull/330.

However, this is not ideal since we would prefer APIs that are functional in behavior, giving us various benefits (e.g. better fault tolerance for future use cases). 

Therefore, in this PR:
- We disable `chatCompletionRequest.stateful`, and ask users to maintain the chat history explicitly
- Instead, we introduce implicit KVCache reuse for multi-round chatting
  - When we detect users are doing multi-round chatting, we will not reset the KV cache, so only the new message will be prefilled
- To detect multi-round chatting, we instantiate a `Conversation` instance for each request, and compare it with the current internal `Conversation`. If they match, it means that we can safely not reset the internal state, and only prefill the new input.

To see the behavior, check out `mainMultiroundChat()` in `examples/openai-api/src/openai_api.ts`.

Implementation details:
- Instantiate `Conversation` object in `ChatModule.prefill()`, since this is the place where various workflows meet (streaming, non-streaming, n > 1, etc.)
  - The object's state is determined by system prompt, message history, and function calling usages
- Inside `prefill()`, we then compare the two objects with `compareConversationObject()`, reset all internal states if false
- Another detail is that, instead of overriding `conversation.config.system_message`, we add a field `conversation.override_system_message`, making `conversation.config` protected
- We further remove all methods in `ChatModule` that overrides `this.getPipeline().conversation` by changing `updateConversationWithChatCompletionMessages()` to `getConversationFromChatCompletionRequest()`, keeping things more functional internally