### PR TITLE
[Version] Bump version to 0.2.31

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.30",
+    "@mlc-ai/web-llm": "^0.2.31",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.30",
+    "@mlc-ai/web-llm": "^0.2.31",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.30",
+    "@mlc-ai/web-llm": "^0.2.31",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30"
+        "@mlc-ai/web-llm": "^0.2.31"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.30",
+      "version": "0.2.31",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.30",
+        "@mlc-ai/web-llm": "^0.2.31",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
### Changes
- Enable `webllm.AppConfig.useIndexedDBCache` so that user can choose between the Cache API and IndexedDB Cache
  - https://github.com/mlc-ai/web-llm/pull/352
- Refactor `ChatModule` to `Engine`, finalize OpenAI API to `engine.chat.completions.create()` to match that of OpenAI
  - https://github.com/mlc-ai/web-llm/pull/361
- Add deprecation warning of `engine.generate()`, suggesting user to use `engine.chat.completions.create()`
- Subsequently, support implicit KVCache reuse for multi-round chat usage
  - Though `chat.completions.create()` is functional, hence requiring users to maintain all chat history, we will reuse KVs if we detect multi-round chat, hence not sacrificing any performance
  - See https://github.com/mlc-ai/web-llm/pull/359 and `examples/multi-round-chat`

### WASM Version

WASMs are still `v0_2_30` as no compile-time changes are required.

### tvmjs
Updated tvmjs to:
- https://github.com/mlc-ai/relax/commit/c7bdcabd602f3d882e764232692d1d1eb449d07b
  - i.e. https://github.com/apache/tvm/commit/d1e24ca721d0c8110fab3e7db6b7375ebfeb8ac5