### PR TITLE
Add ServiceWorkerEngine support. Migrate chrome extention example to use ServiceWorkerEngine

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.31",
+    "@mlc-ai/web-llm": "file:../..",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/src/background.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/background.ts
@@ -1,54 +1,15 @@
-import { EngineInterface, CreateEngine, InitProgressReport, ChatCompletionMessageParam } from "@mlc-ai/web-llm";
+import { ServiceWorkerEngineHandler, Engine } from "@mlc-ai/web-llm";
 
-let model_loaded = false;
+// Hookup an engine to a service worker handler
+const engine = new Engine();
+let handler;
 
-let engine: EngineInterface;
-const chatHistory: ChatCompletionMessageParam[] = [];
-
-let context = "";
-chrome.runtime.onMessage.addListener(async function (request) {
-    // check if the request contains a message that the user sent a new message
-    if (request.input) {
-        let inp = request.input;
-        if (context.length > 0) {
-            inp = "Use only the following context when answering the question at the end. Don't use any other knowledge.\n" + context + "\n\nQuestion: " + request.input + "\n\nHelpful Answer: ";
-        }
-        console.log("Input:", inp);
-        chatHistory.push({ "role": "user", "content": inp });
-
-        let curMessage = "";
-        const completion = await engine.chat.completions.create({ stream: true, messages: chatHistory });
-        for await (const chunk of completion) {
-            const curDelta = chunk.choices[0].delta.content;
-            if (curDelta) {
-                curMessage += curDelta;
-            }
-            chrome.runtime.sendMessage({ answer: curMessage });
-        }
-        chatHistory.push({ "role": "assistant", "content": await engine.getMessage() });
-    }
-    if (request.context) {
-        context = request.context;
-        console.log("Got context:", context);
-    }
-    if (request.reload) {
-        if (!model_loaded) {
-            const appConfig = request.reload;
-            console.log("Got appConfig: ", appConfig);
-            const initProgressCallback = (report: InitProgressReport) => {
-                console.log(report.text, report.progress);
-                chrome.runtime.sendMessage({ initProgressReport: report.progress });
-            }
-            // const selectedModel = "TinyLlama-1.1B-Chat-v0.4-q4f16_1-1k";
-            const selectedModel = "Mistral-7B-Instruct-v0.2-q4f16_1";
-            engine = await CreateEngine(
-                selectedModel,
-                { appConfig: appConfig, initProgressCallback: initProgressCallback }
-            );
-            console.log("Model loaded");
-            model_loaded = true;
-        } else {
-            chrome.runtime.sendMessage({ initProgressReport: 1.0 });
-        }
-    }
+chrome.runtime.onConnect.addListener(function (port) {
+  console.assert(port.name === "web_llm_service_worker");
+  if (handler === undefined) {
+    handler = new ServiceWorkerEngineHandler(engine, port);
+  } else {
+    handler.setPort(port);
+  }
+  port.onMessage.addListener(handler.onmessage.bind(handler));
 });

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -1,14 +1,20 @@
-'use strict';
+"use strict";
 
 // This code is partially adapted from the openai-chatgpt-chrome-extension repo:
 // https://github.com/jessedi0n/openai-chatgpt-chrome-extension
 
-import './popup.css';
+import "./popup.css";
 
-import { AppConfig } from "@mlc-ai/web-llm";
-import { prebuiltAppConfig } from '@mlc-ai/web-llm';
+import {
+  ChatCompletionMessageParam,
+  CreateServiceWorkerEngine,
+  EngineInterface,
+  InitProgressReport,
+} from "@mlc-ai/web-llm";
+import { prebuiltAppConfig } from "@mlc-ai/web-llm";
 import { ProgressBar, Line } from "progressbar.js";
 
+/***************** UI elements *****************/
 // Whether or not to use the content from the active tab as the context
 const useContext = false;
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -16,125 +22,147 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const queryInput = document.getElementById("query-input")!;
 const submitButton = document.getElementById("submit-button")!;
 
-
 let isLoadingParams = false;
-
 
 (<HTMLButtonElement>submitButton).disabled = true;
 
-const progressBar: ProgressBar = new Line('#loadingContainer', {
-    strokeWidth: 4,
-    easing: 'easeInOut',
-    duration: 1400,
-    color: '#ffd166',
-    trailColor: '#eee',
-    trailWidth: 1,
-    svgStyle: { width: '100%', height: '100%' }
+const progressBar: ProgressBar = new Line("#loadingContainer", {
+  strokeWidth: 4,
+  easing: "easeInOut",
+  duration: 1400,
+  color: "#ffd166",
+  trailColor: "#eee",
+  trailWidth: 1,
+  svgStyle: { width: "100%", height: "100%" },
 });
 
-const appConfig: AppConfig = prebuiltAppConfig;
+/***************** Web-LLM Engine Configuration *****************/
+const initProgressCallback = (report: InitProgressReport) => {
+  progressBar.animate(report.progress, {
+    duration: 50,
+  });
+  if (report.progress == 1.0) {
+    enableInputs();
+  }
+};
 
-chrome.runtime.sendMessage({ reload: appConfig });
-chrome.runtime.onMessage.addListener(function (request) {
-    if (request.initProgressReport) {
-        progressBar.animate(request.initProgressReport, {
-            duration: 50
-        });
-        if (request.initProgressReport == 1.0) {
-            enableInputs();
-        }
-    }
-});
+const engine: EngineInterface = await CreateServiceWorkerEngine(
+  "Mistral-7B-Instruct-v0.2-q4f16_1",
+  { initProgressCallback: initProgressCallback }
+);
+const chatHistory: ChatCompletionMessageParam[] = [];
 
 isLoadingParams = true;
 
 function enableInputs() {
-    if (isLoadingParams) {
-        sleep(500);
-        (<HTMLButtonElement>submitButton).disabled = false;
-        const loadingBarContainer = document.getElementById("loadingContainer")!;
-        loadingBarContainer.remove();
-        queryInput.focus();
-        isLoadingParams = false;
-    }
+  if (isLoadingParams) {
+    sleep(500);
+    (<HTMLButtonElement>submitButton).disabled = false;
+    const loadingBarContainer = document.getElementById("loadingContainer")!;
+    loadingBarContainer.remove();
+    queryInput.focus();
+    isLoadingParams = false;
+  }
 }
+
+/***************** Event Listeners *****************/
 
 // Disable submit button if input field is empty
 queryInput.addEventListener("keyup", () => {
-    if ((<HTMLInputElement>queryInput).value === "") {
-        (<HTMLButtonElement>submitButton).disabled = true;
-    } else {
-        (<HTMLButtonElement>submitButton).disabled = false;
-    }
+  if ((<HTMLInputElement>queryInput).value === "") {
+    (<HTMLButtonElement>submitButton).disabled = true;
+  } else {
+    (<HTMLButtonElement>submitButton).disabled = false;
+  }
 });
 
 // If user presses enter, click submit button
 queryInput.addEventListener("keyup", (event) => {
-    if (event.code === "Enter") {
-        event.preventDefault();
-        submitButton.click();
-    }
+  if (event.code === "Enter") {
+    event.preventDefault();
+    submitButton.click();
+  }
 });
 
 // Listen for clicks on submit button
 async function handleClick() {
-    // Get the message from the input field
-    const message = (<HTMLInputElement>queryInput).value;
-    console.log("message", message);
-    chrome.runtime.sendMessage({ input: message });
+  // Get the message from the input field
+  const message = (<HTMLInputElement>queryInput).value;
+  console.log("message", message);
+  chatHistory.push({ role: "user", content: message });
 
-    // Clear the answer
-    document.getElementById("answer")!.innerHTML = "";
-    // Hide the answer
-    document.getElementById("answerWrapper")!.style.display = "none";
-    // Show the loading indicator
-    document.getElementById("loading-indicator")!.style.display = "block";
+  // Clear the answer
+  document.getElementById("answer")!.innerHTML = "";
+  // Hide the answer
+  document.getElementById("answerWrapper")!.style.display = "none";
+  // Show the loading indicator
+  document.getElementById("loading-indicator")!.style.display = "block";
+
+  // Send the chat completion message to the engine
+  let curMessage = "";
+  const completion = await engine.chat.completions.create({
+    stream: true,
+    messages: chatHistory,
+  });
+
+  // Update the answer as the model generates more text
+  for await (const chunk of completion) {
+    const curDelta = chunk.choices[0].delta.content;
+    if (curDelta) {
+      curMessage += curDelta;
+    }
+    updateAnswer(curMessage);
+  }
+  chatHistory.push({ role: "assistant", content: await engine.getMessage() });
 }
+
 submitButton.addEventListener("click", handleClick);
 
-// Listen for messages from the background script
-chrome.runtime.onMessage.addListener(({ answer, error }) => {
-    if (answer) {
-        updateAnswer(answer);
-    }
-});
-
 function updateAnswer(answer: string) {
-    // Show answer
-    document.getElementById("answerWrapper")!.style.display = "block";
-    const answerWithBreaks = answer.replace(/\n/g, '<br>');
-    document.getElementById("answer")!.innerHTML = answerWithBreaks;
-    // Add event listener to copy button
-    document.getElementById("copyAnswer")!.addEventListener("click", () => {
-        // Get the answer text
-        const answerText = answer;
-        // Copy the answer text to the clipboard
-        navigator.clipboard.writeText(answerText)
-            .then(() => console.log("Answer text copied to clipboard"))
-            .catch((err) => console.error("Could not copy text: ", err));
-    });
-    const options: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit' };
-    const time = new Date().toLocaleString('en-US', options);
-    // Update timestamp
-    document.getElementById("timestamp")!.innerText = time;
-    // Hide loading indicator
-    document.getElementById("loading-indicator")!.style.display = "none";
+  // Show answer
+  document.getElementById("answerWrapper")!.style.display = "block";
+  const answerWithBreaks = answer.replace(/\n/g, "<br>");
+  document.getElementById("answer")!.innerHTML = answerWithBreaks;
+  // Add event listener to copy button
+  document.getElementById("copyAnswer")!.addEventListener("click", () => {
+    // Get the answer text
+    const answerText = answer;
+    // Copy the answer text to the clipboard
+    navigator.clipboard
+      .writeText(answerText)
+      .then(() => console.log("Answer text copied to clipboard"))
+      .catch((err) => console.error("Could not copy text: ", err));
+  });
+  const options: Intl.DateTimeFormatOptions = {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  };
+  const time = new Date().toLocaleString("en-US", options);
+  // Update timestamp
+  document.getElementById("timestamp")!.innerText = time;
+  // Hide loading indicator
+  document.getElementById("loading-indicator")!.style.display = "none";
 }
 
 function fetchPageContents() {
-    chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
-        var port = chrome.tabs.connect(tabs[0].id, { name: "channelName" });
-        port.postMessage({});
-        port.onMessage.addListener(function (msg) {
-            console.log("Page contents:", msg.contents);
-            chrome.runtime.sendMessage({ context: msg.contents });
-        });
-    });
+  chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {
+    if (tabs[0]?.id) {
+      var port = chrome.tabs.connect(tabs[0].id, { name: "channelName" });
+      port.postMessage({});
+      port.onMessage.addListener(function (msg) {
+        console.log("Page contents:", msg.contents);
+        chrome.runtime.sendMessage({ context: msg.contents });
+      });
+    }
+  });
 }
 
 // Grab the page contents when the popup is opened
 window.onload = function () {
-    if (useContext) {
-        fetchPageContents();
-    }
-}
+  if (useContext) {
+    fetchPageContents();
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@mlc-ai/web-tokenizers": "^0.1.3",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
+        "@types/chrome": "^0.0.266",
         "@types/jest": "^29.5.11",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
@@ -1424,10 +1425,35 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chrome": {
+      "version": "0.0.266",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.266.tgz",
+      "integrity": "sha512-QSQWJTL7NjZElvq/6/E5C1+pHgEP8UAJzwoz7M4vSJ7AECt6NNehJ+tU6snnvuTqZOBjFCivvitYo5+8tNPmhg==",
+      "dev": true,
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
       "dev": true
     },
     "node_modules/@types/graceful-fs": {
@@ -1438,6 +1464,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
+      "integrity": "sha512-RpQH4rXLuvTXKR0zqHq3go0RVXYv/YVqv4TnPH95VbwUxZdQlK1EtcMvQvMpDngHbt13Csh9Z4qT9AbkiQH5BA==",
+      "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@mlc-ai/web-tokenizers": "^0.1.3",
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
+    "@types/chrome": "^0.0.266",
     "@types/jest": "^29.5.11",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -81,6 +81,10 @@ export class Engine implements EngineInterface {
     this.initProgressCallback = initProgressCallback;
   }
 
+  getInitProgressCallback() {
+    return this.initProgressCallback;
+  }
+
   setLogitProcessorRegistry(logitProcessorRegistry?: Map<string, LogitProcessor>) {
     this.logitProcessorRegistry = logitProcessorRegistry;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,18 @@ export {
 export {
   EngineWorkerHandler,
   WebWorkerEngine,
-  WorkerMessage,
-  CustomRequestParams,
   CreateWebWorkerEngine
 } from "./web_worker";
+
+export {
+  WorkerMessage,
+  CustomRequestParams
+} from "./message"
+
+export {
+  ServiceWorkerEngineHandler,
+  ServiceWorkerEngine,
+  CreateServiceWorkerEngine,
+} from "./service_worker";
 
 export * from './openai_api_protocols/index';

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,0 +1,77 @@
+import { AppConfig, ChatOptions, GenerationConfig } from "./config";
+import { InitProgressReport } from "./types";
+import {
+  ChatCompletionRequestStreaming,
+  ChatCompletionRequestNonStreaming,
+  ChatCompletion,
+  ChatCompletionChunk
+} from "./openai_api_protocols/index";
+
+/**
+ * Message kind used by worker
+ */
+type RequestKind = (
+  "return" | "throw" |
+  "reload" | "generate" | "runtimeStatsText" |
+  "interruptGenerate" | "unload" | "resetChat" | "init" |
+  "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
+  "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" | "getMessage" |
+  "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest");
+export interface ReloadParams {
+  modelId: string;
+  chatOpts?: ChatOptions;
+  appConfig?: AppConfig;
+}
+export interface GenerateParams {
+  input: string | ChatCompletionRequestNonStreaming;
+  streamInterval?: number;
+  genConfig?: GenerationConfig;
+}
+export interface ResetChatParams {
+  keepStats: boolean;
+}
+export interface GenerateProgressCallbackParams {
+  step: number;
+  currentMessage: string;
+}
+export interface ForwardTokensAndSampleParams {
+  inputIds: Array<number>;
+  isPrefill: boolean;
+}
+export interface ChatCompletionNonStreamingParams {
+  request: ChatCompletionRequestNonStreaming;
+}
+export interface ChatCompletionStreamInitParams {
+  request: ChatCompletionRequestStreaming;
+}
+
+export interface CustomRequestParams {
+  requestName: string;
+  requestMessage: string;
+}
+export type MessageContent =
+  GenerateProgressCallbackParams |
+  ReloadParams |
+  GenerateParams |
+  ResetChatParams |
+  ForwardTokensAndSampleParams |
+  ChatCompletionNonStreamingParams |
+  ChatCompletionStreamInitParams |
+  CustomRequestParams |
+  InitProgressReport |
+  string |
+  null |
+  number |
+  ChatCompletion |
+  ChatCompletionChunk |
+  void;
+/**
+ * The message used in exchange between worker
+ * and the main thread.
+ */
+
+export interface WorkerMessage {
+  kind: RequestKind;
+  uuid: string;
+  content: MessageContent;
+}

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -1,0 +1,231 @@
+import * as tvmjs from "tvmjs";
+import { AppConfig, ChatOptions, EngineConfig } from "./config";
+import { ReloadParams, WorkerMessage } from "./message";
+import { EngineInterface } from "./types";
+import {
+  ChatWorker,
+  EngineWorkerHandler,
+  WebWorkerEngine,
+  PostMessageHandler,
+} from "./web_worker";
+
+/**
+ * A post message handler that sends messages to a chrome.runtime.Port.
+ */
+export class PortPostMessageHandler implements PostMessageHandler {
+  port: chrome.runtime.Port;
+  enabled: boolean = true;
+
+  constructor(port: chrome.runtime.Port) {
+    this.port = port;
+  }
+
+  /**
+   * Close the PortPostMessageHandler. This will prevent any further messages
+   */
+  close() {
+    this.enabled = false;
+  }
+
+  postMessage(event: any) {
+    if (this.enabled) {
+      this.port.postMessage(event);
+    }
+  }
+}
+
+/**
+ * Worker handler that can be used in a ServiceWorker.
+ * 
+ * @example
+ * 
+ * const engine = new Engine();
+ * let handler;
+ * chrome.runtime.onConnect.addListener(function (port) {
+ *   if (handler === undefined) {
+ *     handler = new ServiceWorkerEngineHandler(engine, port);
+ *   } else {
+ *     handler.setPort(port);
+ *   }
+ *   port.onMessage.addListener(handler.onmessage.bind(handler));
+ * });
+ */
+export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
+  modelId?: string;
+  chatOpts?: ChatOptions;
+  appConfig?: AppConfig;
+
+  constructor(engine: EngineInterface, port: chrome.runtime.Port) {
+    let portHandler = new PortPostMessageHandler(port);
+    super(engine, portHandler);
+
+    port.onDisconnect.addListener(() => {
+      portHandler.close();
+    });
+  }
+
+  setPort(port: chrome.runtime.Port) {
+    let portHandler = new PortPostMessageHandler(port);
+    this.setPostMessageHandler(portHandler);
+    port.onDisconnect.addListener(() => {
+      portHandler.close();
+    });
+  }
+
+  onmessage(event: any): void {
+    if (event.type === "keepAlive") {
+      return;
+    }
+
+    const msg = event as WorkerMessage;
+    if (msg.kind === "init") {
+      this.handleTask(msg.uuid, async () => {
+        const params = msg.content as ReloadParams;
+        // If the modelId, chatOpts, and appConfig are the same, immediately return
+        if (
+          this.modelId === params.modelId &&
+          this.chatOpts === params.chatOpts &&
+          this.appConfig === params.appConfig
+        ) {
+          console.log("Already loaded the model. Skip loading");
+          const gpuDetectOutput = await tvmjs.detectGPUDevice();
+          if (gpuDetectOutput == undefined) {
+            throw Error("Cannot find WebGPU in the environment");
+          }
+          let gpuLabel = "WebGPU";
+          if (gpuDetectOutput.adapterInfo.description.length != 0) {
+            gpuLabel += " - " + gpuDetectOutput.adapterInfo.description;
+          } else {
+            gpuLabel += " - " + gpuDetectOutput.adapterInfo.vendor;
+          }
+          this.engine.getInitProgressCallback()?.({
+            progress: 1,
+            timeElapsed: 0,
+            text: "Finish loading on " + gpuLabel,
+          });
+          return null;
+        }
+
+        await this.engine.reload(
+          params.modelId,
+          params.chatOpts,
+          params.appConfig
+        );
+        this.modelId = params.modelId;
+        this.chatOpts = params.chatOpts;
+        this.appConfig = params.appConfig;
+        return null;
+      });
+      return;
+    }
+    super.onmessage(event);
+  }
+}
+
+/**
+ * Create a ServiceWorkerEngine.
+ * 
+ * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
+ * `engineConfig.appConfig`.
+ * @param engineConfig Optionally configures the engine, see `webllm.EngineConfig` for more.
+ * @param keepAliveMs The interval to send keep alive messages to the service worker.
+ * See [Service worker lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle#idle-shutdown)
+ * The default is 10s.
+ * @returns An initialized `WebLLM.ServiceWorkerEngine` with `modelId` loaded.
+ */
+export async function CreateServiceWorkerEngine(
+  modelId: string,
+  engineConfig?: EngineConfig,
+  keepAliveMs: number = 10000
+): Promise<ServiceWorkerEngine> {
+  const serviceWorkerEngine = new ServiceWorkerEngine();
+  serviceWorkerEngine.setInitProgressCallback(
+    engineConfig?.initProgressCallback
+  );
+  await serviceWorkerEngine.init(
+    modelId,
+    engineConfig?.chatOpts,
+    engineConfig?.appConfig
+  );
+  setInterval(() => {
+    serviceWorkerEngine.keepAlive();
+  }, keepAliveMs);
+  return serviceWorkerEngine;
+}
+
+class PortAdapter implements ChatWorker {
+  port: chrome.runtime.Port;
+  private _onmessage!: (message: any) => void;
+
+  constructor(port: chrome.runtime.Port) {
+    this.port = port;
+    this.port.onMessage.addListener(this.handleMessage.bind(this));
+  }
+
+  // Wrapper to handle incoming messages and delegate to onmessage if available
+  private handleMessage(message: any) {
+    if (this._onmessage) {
+      this._onmessage(message);
+    }
+  }
+
+  // Getter and setter for onmessage to manage adding/removing listeners
+  get onmessage(): (message: any) => void {
+    return this._onmessage;
+  }
+
+  set onmessage(listener: (message: any) => void) {
+    this._onmessage = listener;
+  }
+
+  // Wrap port.postMessage to maintain 'this' context
+  postMessage = (message: any): void => {
+    this.port.postMessage(message);
+  };
+}
+
+/**
+ * A client of Engine that exposes the same interface
+ */
+export class ServiceWorkerEngine extends WebWorkerEngine {
+  port: chrome.runtime.Port;
+
+  constructor() {
+    let port = chrome.runtime.connect({ name: "web_llm_service_worker" });
+    let chatWorker = new PortAdapter(port);
+    super(chatWorker);
+    this.port = port;
+  }
+
+  keepAlive() {
+    this.port.postMessage({ type: "keepAlive" });
+  }
+
+  /**
+   * Initialize the chat with a model.
+   *
+   * @param modelId model_id of the model to load.
+   * @param chatOpts Extra options to overide chat behavior.
+   * @param appConfig Override the app config in this load.
+   * @returns A promise when reload finishes.
+   * @note The difference between init and reload is that init
+   * should be called only once when the engine is created, while reload
+   * can be called multiple times to switch between models.
+   */
+  async init(
+    modelId: string,
+    chatOpts?: ChatOptions,
+    appConfig?: AppConfig
+  ): Promise<void> {
+    const msg: WorkerMessage = {
+      kind: "init",
+      uuid: crypto.randomUUID(),
+      content: {
+        modelId: modelId,
+        chatOpts: chatOpts,
+        appConfig: appConfig,
+      },
+    };
+    await this.getPromise<null>(msg);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,11 @@ export interface EngineInterface {
   setInitProgressCallback: (initProgressCallback: InitProgressCallback) => void;
 
   /**
+   * @returns The current initialization progress callback function.
+   */
+  getInitProgressCallback: () => InitProgressCallback | undefined;
+
+  /**
    * Reload the chat with a new model.
    *
    * @param modelId model_id of the model to load.

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -14,83 +14,20 @@ import {
   ChatCompletionChunk,
 } from "./openai_api_protocols/index";
 import * as API from "./openai_api_protocols/apis";
+import {
+  WorkerMessage,
+  MessageContent,
+  ReloadParams,
+  GenerateParams,
+  ForwardTokensAndSampleParams,
+  ChatCompletionNonStreamingParams,
+  ChatCompletionStreamInitParams,
+  ResetChatParams,
+  GenerateProgressCallbackParams,
+} from "./message";
 
-/**
- * Message kind used by worker
- */
-type RequestKind = (
-  "return" | "throw" |
-  "reload" | "generate" | "runtimeStatsText" |
-  "interruptGenerate" | "unload" | "resetChat" |
-  "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
-  "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" | "getMessage" |
-  "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest"
-);
-
-interface ReloadParams {
-  modelId: string;
-  chatOpts?: ChatOptions;
-  appConfig?: AppConfig
-}
-
-interface GenerateParams {
-  input: string | ChatCompletionRequestNonStreaming,
-  streamInterval?: number;
-  genConfig?: GenerationConfig;
-}
-
-interface ResetChatParams {
-  keepStats: boolean;
-}
-
-interface GenerateProgressCallbackParams {
-  step: number,
-  currentMessage: string;
-}
-
-interface ForwardTokensAndSampleParams {
-  inputIds: Array<number>;
-  isPrefill: boolean;
-}
-
-interface ChatCompletionNonStreamingParams {
-  request: ChatCompletionRequestNonStreaming;
-}
-
-interface ChatCompletionStreamInitParams {
-  request: ChatCompletionRequestStreaming;
-}
-
-export interface CustomRequestParams {
-  requestName: string;
-  requestMessage: string;
-}
-
-type MessageContent =
-  GenerateProgressCallbackParams |
-  ReloadParams |
-  GenerateParams |
-  ResetChatParams |
-  ForwardTokensAndSampleParams |
-  ChatCompletionNonStreamingParams |
-  ChatCompletionStreamInitParams |
-  CustomRequestParams |
-  InitProgressReport |
-  string |
-  null |
-  number |
-  ChatCompletion |
-  ChatCompletionChunk |
-  void;
-
-/**
- * The message used in exchange between worker
- * and the main thread.
- */
-export interface WorkerMessage {
-  kind: RequestKind,
-  uuid: string,
-  content: MessageContent;
+export interface PostMessageHandler {
+  postMessage: (message: any) => void;
 }
 
 /**
@@ -107,17 +44,34 @@ export interface WorkerMessage {
 export class EngineWorkerHandler {
   protected engine: EngineInterface;
   protected chatCompletionAsyncChunkGenerator?: AsyncGenerator<ChatCompletionChunk, void, void>;
+  protected postMessageHandler: PostMessageHandler;
 
-  constructor(engine: EngineInterface) {
+  /**
+   * @param engine A concrete implementation of EngineInterface
+   * @param postMessageHandler Optionally, a handler to communicate with the content script. 
+   *   This is only needed in ServiceWorker. In web worker, we can use `postMessage` from
+   *   DOM API directly.
+   */
+  constructor(engine: EngineInterface, postMessageHandler?: PostMessageHandler) {
     this.engine = engine;
+    // Use the DOM API postMessage by default
+    if (postMessageHandler === undefined) {
+      this.postMessageHandler = {postMessage: postMessage};
+    } else {
+      this.postMessageHandler = postMessageHandler;
+    }
     this.engine.setInitProgressCallback((report: InitProgressReport) => {
       const msg: WorkerMessage = {
         kind: "initProgressCallback",
         uuid: "",
         content: report
       };
-      postMessage(msg);
+      this.postMessageHandler.postMessage(msg);
     });
+  }
+
+  setPostMessageHandler(postMessageHandler: PostMessageHandler) {
+    this.postMessageHandler = postMessageHandler;
   }
 
   async handleTask<T extends MessageContent>(uuid: string, task: () => Promise<T>) {
@@ -128,7 +82,7 @@ export class EngineWorkerHandler {
         uuid: uuid,
         content: res
       };
-      postMessage(msg);
+      this.postMessageHandler.postMessage(msg);
     } catch (err) {
       const errStr = (err as object).toString();
       const msg: WorkerMessage = {
@@ -136,12 +90,17 @@ export class EngineWorkerHandler {
         uuid: uuid,
         content: errStr
       };
-      postMessage(msg);
+      this.postMessageHandler.postMessage(msg);
     }
   }
 
-  onmessage(event: MessageEvent) {
-    const msg = event.data as WorkerMessage;
+  onmessage(event: any) {
+    let msg: WorkerMessage;
+    if (event instanceof MessageEvent) {
+      msg = event.data as WorkerMessage;
+    } else {
+      msg = event as WorkerMessage;
+    }
     switch (msg.kind) {
       case "reload": {
         this.handleTask(msg.uuid, async () => {
@@ -163,7 +122,7 @@ export class EngineWorkerHandler {
                 currentMessage: currentMessage
               }
             };
-            postMessage(cbMessage);
+            this.postMessageHandler.postMessage(cbMessage);
           };
           return await this.engine.generate(
             params.input,
@@ -267,7 +226,7 @@ export class EngineWorkerHandler {
   }
 }
 
-interface ChatWorker {
+export interface ChatWorker {
   onmessage: any,
   postMessage: (message: any) => void;
 }
@@ -301,7 +260,7 @@ export async function CreateWebWorkerEngine(
  *
  * @example
  *
- * const chat = new webllm.ChatWorkerClient(new Worker(
+ * const chat = new webllm.WebWorkerEngine(new Worker(
  *   new URL('./worker.ts', import.meta.url),
  *   {type: 'module'}
  * ));
@@ -324,6 +283,10 @@ export class WebWorkerEngine implements EngineInterface {
 
   setInitProgressCallback(initProgressCallback?: InitProgressCallback) {
     this.initProgressCallback = initProgressCallback;
+  }
+
+  getInitProgressCallback(): InitProgressCallback | undefined {
+    return this.initProgressCallback;
   }
 
   protected getPromise<T extends MessageContent>(msg: WorkerMessage): Promise<T> {
@@ -523,7 +486,12 @@ export class WebWorkerEngine implements EngineInterface {
   }
 
   onmessage(event: any) {
-    const msg = event.data as WorkerMessage;
+    let msg: WorkerMessage;
+    if (event instanceof MessageEvent) {
+      msg = event.data as WorkerMessage;
+    } else {
+      msg = event as WorkerMessage;
+    }
     switch (msg.kind) {
       case "initProgressCallback": {
         if (this.initProgressCallback !== undefined) {


### PR DESCRIPTION
This PR adds ServiceWorkerEngine support. It wraps the `EngineInterface` and `EngineWorkerHandler` to use with Chrome's Service Worker, which comes in handy when building Chrome extensions.

Also update the chrome extension example to use the new ServiceWorkerEngine.