### PR TITLE
[Version] Bump version to 0.2.34, update prebuilt WASM models

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.33",
+    "@mlc-ai/web-llm": "^0.2.34",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.33",
+    "@mlc-ai/web-llm": "^0.2.34",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "../.."
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.33",
+    "@mlc-ai/web-llm": "^0.2.34",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33"
+        "@mlc-ai/web-llm": "^0.2.34"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.33",
+      "version": "0.2.34",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -238,7 +238,7 @@ export interface AppConfig {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_30";
+export const modelVersion = "v0_2_34";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 
@@ -316,14 +316,6 @@ export const prebuiltAppConfig: AppConfig = {
       "model_id": "Llama-2-13b-chat-hf-q4f16_1",
       "model_lib_url": modelLibURLPrefix + modelVersion + "/Llama-2-13b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       "vram_required_MB": 11814.09,
-      "low_resource_required": false,
-      "required_features": ["shader-f16"],
-    },
-    {
-      "model_url": "https://huggingface.co/mlc-ai/Llama-2-70b-chat-hf-q4f16_1-MLC/resolve/main/",
-      "model_id": "Llama-2-70b-chat-hf-q4f16_1",
-      "model_lib_url": modelLibURLPrefix + modelVersion + "/Llama-2-70b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
-      "vram_required_MB": 43729.05,
       "low_resource_required": false,
       "required_features": ["shader-f16"],
     },

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.33",
+        "@mlc-ai/web-llm": "^0.2.34",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
### Changes
Main changes include:
- Support for JSON schema via https://github.com/mlc-ai/web-llm/pull/371

### WASM Version
All WASMs are updated to `v0_2_34` reflect the change in MLC's runtime.

### TVMjs
TVMjs compiled at https://github.com/apache/tvm/commit/57316dae1497c36ed57732a7a610018a990f1927
- Main change: https://github.com/apache/tvm/pull/16910

### Note on wasm versioning
We updated all WASMs, as reflected by `modelVersion` in `src/config.ts` (reflected by the new folder `v0_2_34` in [binary-mlc-llm-libs](https://github.com/mlc-ai/binary-mlc-llm-libs/tree/main/web-llm-models)) and hence the implicitly updated `webllm.prebuiltAppConfig`. See https://github.com/mlc-ai/binary-mlc-llm-libs/pull/118 on the commits of MLC and TVM when compiling these models.

<0.2.34 users can still use WebLLM without breaking as we keep v0_2_30 models, and the links bind to the npm. Users also do not need to clear cache since `0.2.34` models have a different 