### PR TITLE
[Version] Bump version to 0.2.35

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.34",
+    "@mlc-ai/web-llm": "^0.2.35",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.34",
+    "@mlc-ai/web-llm": "^0.2.35",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.34",
+    "@mlc-ai/web-llm": "^0.2.35",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/simple-chat/package.json
+++ b/examples/simple-chat/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34"
+        "@mlc-ai/web-llm": "^0.2.35"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.34",
+      "version": "0.2.35",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "^0.2.34",
+        "@mlc-ai/web-llm": "^0.2.35",
         "tvmjs": "file:./../../tvm_home/web"
     }
 }


### PR DESCRIPTION
### Changes
Very minor change from 0.2.34, only slightly updated prebuilt config
- https://github.com/mlc-ai/web-llm/pull/377

### WASM Version
`v0_2_34` as no change is required.

### TVMjs
TVMjs compiled at https://github.com/apache/tvm/commit/57316dae1497c36ed57732a7a610018a990f1927
