### PR TITLE
Add Service Worker support and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,53 @@ async function main() {
 }
 ```
 
+### Use Service Worker
+
+WebLLM comes with API support for ServiceWorker so you can hook the generation process 
+into a service worker to avoid reloading the model in every page visit and optimize 
+your application's offline experience.
+
+We first create a service worker script that created a Engine and hook it up to a handler
+that handles requests when the service worker is ready.
+
+```typescript
+// sw.ts
+import {
+  WebServiceWorkerEngineHandler,
+  EngineInterface,
+  Engine,
+} from "@mlc-ai/web-llm";
+
+const engine: EngineInterface = new Engine();
+let handler: WebServiceWorkerEngineHandler;
+
+self.addEventListener("activate", function (event) {
+  handler = new WebServiceWorkerEngineHandler(engine);
+  console.log("Service Worker is ready")
+});
+
+```
+
+Then in the main logic, we register the service worker and then create the engine using
+`CreateWebServiceWorkerEngine` function. The rest of the logic remains the same.
+
+```typescript
+// main.ts
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register(
+    /*workerScriptURL=*/new URL("sw.ts", import.meta.url),
+    { type: "module" }
+  );
+}
+
+const engine: webllm.EngineInterface =
+  await webllm.CreateWebServiceWorkerEngine(
+    /*modelId=*/selectedModel,
+    /*engineConfig=*/{ initProgressCallback: initProgressCallback }
+  );
+```
+
+You can find a complete example on how to run WebLLM in service worker in [examples/service-worker](examples/service-worker/).
 
 ### Build a ChatApp
 

--- a/examples/service-worker/README.md
+++ b/examples/service-worker/README.md
@@ -1,0 +1,8 @@
+# WebLLM Service Worker Example
+
+This example shows how we can create a page with Web-LLM running in service worker.
+
+```bash
+npm install
+npm run build
+```

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "web-llm-service-worker",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "start": "parcel src/index.html  --port 3000",
+        "build": "parcel build src/index.html --dist-dir lib"
+    },
+    "devDependencies": {
+        "buffer": "^6.0.3",
+        "parcel": "^2.8.3",
+        "process": "^0.11.10",
+        "tslib": "^2.3.1",
+        "typescript": "^4.9.5",
+        "url": "^0.11.3"
+    },
+    "dependencies": {
+        "@mlc-ai/web-llm": "file:../../lib"
+    }
+}

--- a/examples/service-worker/src/index.html
+++ b/examples/service-worker/src/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <script>
+    webLLMGlobal = {}
+  </script>
+  <body>
+    <h2>WebLLM Test Page</h2>
+    Open console to see output
+   </br>
+   </br>
+    <label id="init-label"> </label>
+
+    <h3>Prompt</h3>
+    <label id="prompt-label"> </label>
+
+    <h3>Response</h3>
+    <label id="generate-label"> </label>
+  </br>
+    <label id="stats-label"> </label>
+
+    <script type="module" src="./main.ts"></script>
+</html>

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -1,0 +1,120 @@
+import * as webllm from "@mlc-ai/web-llm";
+
+const registerServiceWorker = async () => {
+  if ("serviceWorker" in navigator) {
+    try {
+      const registration = await navigator.serviceWorker.register(
+        new URL("sw.ts", import.meta.url),
+        { type: "module" }
+      );
+      if (registration.installing) {
+        console.log("Service worker installing");
+      } else if (registration.waiting) {
+        console.log("Service worker installed");
+      } else if (registration.active) {
+        console.log("Service worker active");
+      }
+    } catch (error) {
+      console.error(`Registration failed with ${error}`);
+    }
+  }
+};
+
+function setLabel(id: string, text: string) {
+  const label = document.getElementById(id);
+  if (label == null) {
+    throw Error("Cannot find label " + id);
+  }
+  label.innerText = text;
+}
+
+// There are two demonstrations, pick one to run
+
+/**
+ * Chat completion (OpenAI style) without streaming, where we get the entire response at once.
+ */
+async function mainNonStreaming() {
+  const initProgressCallback = (report: webllm.InitProgressReport) => {
+    setLabel("init-label", report.text);
+  };
+  const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
+
+  const engine: webllm.EngineInterface =
+    await webllm.CreateWebServiceWorkerEngine(selectedModel, {
+      initProgressCallback: initProgressCallback,
+    });
+
+  const request: webllm.ChatCompletionRequest = {
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a helpful, respectful and honest assistant. " +
+          "Be as happy as you can when speaking please. ",
+      },
+      { role: "user", content: "Provide me three US states." },
+      { role: "assistant", content: "California, New York, Pennsylvania." },
+      { role: "user", content: "Two more please!" },
+    ],
+    n: 3,
+    temperature: 1.5,
+    max_gen_len: 256,
+  };
+
+  const reply0 = await engine.chat.completions.create(request);
+  console.log(reply0);
+  setLabel("generate-label", reply0.choices[0].message.content || "");
+
+  console.log(await engine.runtimeStatsText());
+}
+
+/**
+ * Chat completion (OpenAI style) with streaming, where delta is sent while generating response.
+ */
+async function mainStreaming() {
+  const initProgressCallback = (report: webllm.InitProgressReport) => {
+    setLabel("init-label", report.text);
+  };
+  const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
+
+  const engine: webllm.EngineInterface =
+    await webllm.CreateWebServiceWorkerEngine(selectedModel, {
+      initProgressCallback: initProgressCallback,
+    });
+
+  const request: webllm.ChatCompletionRequest = {
+    stream: true,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You are a helpful, respectful and honest assistant. " +
+          "Be as happy as you can when speaking please. ",
+      },
+      { role: "user", content: "Provide me three US states." },
+      { role: "assistant", content: "California, New York, Pennsylvania." },
+      { role: "user", content: "Two more please!" },
+    ],
+    temperature: 1.5,
+    max_gen_len: 256,
+  };
+
+  const asyncChunkGenerator = await engine.chat.completions.create(request);
+  let message = "";
+  for await (const chunk of asyncChunkGenerator) {
+    console.log(chunk);
+    if (chunk.choices[0].delta.content) {
+      // Last chunk has undefined content
+      message += chunk.choices[0].delta.content;
+    }
+    setLabel("generate-label", message);
+    // engine.interruptGenerate();  // works with interrupt as well
+  }
+  console.log("Final message:\n", await engine.getMessage()); // the concatenated message
+  console.log(await engine.runtimeStatsText());
+}
+
+registerServiceWorker();
+// Run one of the function below
+// mainNonStreaming();
+mainStreaming();

--- a/examples/service-worker/src/sw.ts
+++ b/examples/service-worker/src/sw.ts
@@ -1,0 +1,13 @@
+import {
+  WebServiceWorkerEngineHandler,
+  EngineInterface,
+  Engine,
+} from "@mlc-ai/web-llm";
+
+const engine: EngineInterface = new Engine();
+let handler: WebServiceWorkerEngineHandler;
+
+self.addEventListener("activate", function (event) {
+  handler = new WebServiceWorkerEngineHandler(engine);
+  console.log("Web-LLM Service Worker Activated")
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,10 +37,20 @@ export {
   CustomRequestParams
 } from "./message"
 
+// TODO: Rename to ExtensionServiceWorker 
 export {
   ServiceWorkerEngineHandler,
   ServiceWorkerEngine,
   CreateServiceWorkerEngine,
-} from "./service_worker";
+} from './service_worker'
+
+// TODO: Rename to ServiceWorker 
+export {
+  ServiceWorkerEngineHandler as WebServiceWorkerEngineHandler,
+  ServiceWorkerEngine as WebServiceWorkerEngine,
+  CreateServiceWorkerEngine as CreateWebServiceWorkerEngine,
+  serviceWorkerBroadcastChannel,
+  clientBroadcastChannel,
+} from "./web_service_worker";
 
 export * from './openai_api_protocols/index';

--- a/src/web_service_worker.ts
+++ b/src/web_service_worker.ts
@@ -1,0 +1,185 @@
+import * as tvmjs from "tvmjs";
+import { AppConfig, ChatOptions, EngineConfig } from "./config";
+import { ReloadParams, WorkerMessage } from "./message";
+import { EngineInterface } from "./types";
+import {
+  EngineWorkerHandler,
+  WebWorkerEngine,
+  PostMessageHandler,
+  ChatWorker,
+} from "./web_worker";
+
+const BROADCAST_CHANNEL_SERVICE_WORKER_ID = "@mlc-ai/web-llm-sw";
+const BROADCAST_CHANNEL_CLIENT_ID = "@mlc-ai/web-llm-client";
+export const serviceWorkerBroadcastChannel = new BroadcastChannel(
+  BROADCAST_CHANNEL_SERVICE_WORKER_ID
+);
+export const clientBroadcastChannel = new BroadcastChannel(
+  BROADCAST_CHANNEL_CLIENT_ID
+);
+
+/**
+ * PostMessageHandler wrapper for sending message from service worker back to client
+ */
+class ClientPostMessageHandler implements PostMessageHandler {
+  postMessage(message: any) {
+    clientBroadcastChannel.postMessage(message);
+  }
+}
+
+/**
+ * PostMessageHandler wrapper for sending message from client to service worker
+ */
+class ServiceWorker implements ChatWorker {
+  constructor() {
+    serviceWorkerBroadcastChannel.onmessage = this.onmessage;
+  }
+
+  // ServiceWorkerEngine will later overwrite this
+  onmessage() {}
+
+  postMessage(message: any) {
+    serviceWorkerBroadcastChannel.postMessage(message);
+  }
+}
+
+/**
+ * Worker handler that can be used in a ServiceWorker.
+ *
+ * @example
+ *
+ * const engine = new Engine();
+ * let handler;
+ * chrome.runtime.onConnect.addListener(function (port) {
+ *   if (handler === undefined) {
+ *     handler = new ServiceWorkerEngineHandler(engine, port);
+ *   } else {
+ *     handler.setPort(port);
+ *   }
+ *   port.onMessage.addListener(handler.onmessage.bind(handler));
+ * });
+ */
+export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
+  modelId?: string;
+  chatOpts?: ChatOptions;
+  appConfig?: AppConfig;
+
+  constructor(engine: EngineInterface) {
+    super(engine, new ClientPostMessageHandler());
+    serviceWorkerBroadcastChannel.onmessage = this.onmessage.bind(this);
+  }
+
+  onmessage(event: any): void {
+    const msgEvent = event as MessageEvent;
+    const msg = msgEvent.data as WorkerMessage;
+
+    if (msg.kind === "init") {
+      this.handleTask(msg.uuid, async () => {
+        const params = msg.content as ReloadParams;
+        // If the modelId, chatOpts, and appConfig are the same, immediately return
+        if (
+          this.modelId === params.modelId &&
+          this.chatOpts === params.chatOpts &&
+          this.appConfig === params.appConfig
+        ) {
+          console.log("Already loaded the model. Skip loading");
+          const gpuDetectOutput = await tvmjs.detectGPUDevice();
+          if (gpuDetectOutput == undefined) {
+            throw Error("Cannot find WebGPU in the environment");
+          }
+          let gpuLabel = "WebGPU";
+          if (gpuDetectOutput.adapterInfo.description.length != 0) {
+            gpuLabel += " - " + gpuDetectOutput.adapterInfo.description;
+          } else {
+            gpuLabel += " - " + gpuDetectOutput.adapterInfo.vendor;
+          }
+          this.engine.getInitProgressCallback()?.({
+            progress: 1,
+            timeElapsed: 0,
+            text: "Finish loading on " + gpuLabel,
+          });
+          return null;
+        }
+
+        await this.engine.reload(
+          params.modelId,
+          params.chatOpts,
+          params.appConfig
+        );
+        this.modelId = params.modelId;
+        this.chatOpts = params.chatOpts;
+        this.appConfig = params.appConfig;
+        return null;
+      });
+      return;
+    }
+    super.onmessage(event);
+  }
+}
+
+/**
+ * Create a ServiceWorkerEngine.
+ *
+ * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
+ * `engineConfig.appConfig`.
+ * @param engineConfig Optionally configures the engine, see `webllm.EngineConfig` for more.
+ * @returns An initialized `WebLLM.ServiceWorkerEngine` with `modelId` loaded.
+ */
+export async function CreateServiceWorkerEngine(
+  modelId: string,
+  engineConfig?: EngineConfig
+): Promise<ServiceWorkerEngine> {
+  await navigator.serviceWorker.ready;
+  const serviceWorkerEngine = new ServiceWorkerEngine(new ServiceWorker());
+  serviceWorkerEngine.setInitProgressCallback(
+    engineConfig?.initProgressCallback
+  );
+  await serviceWorkerEngine.init(
+    modelId,
+    engineConfig?.chatOpts,
+    engineConfig?.appConfig
+  );
+  return serviceWorkerEngine;
+}
+
+/**
+ * A client of Engine that exposes the same interface
+ */
+export class ServiceWorkerEngine extends WebWorkerEngine {
+  constructor(worker: ChatWorker) {
+    super(worker)
+    clientBroadcastChannel.onmessage = this.onmessage.bind(this)
+  }
+
+  keepAlive() {
+    this.worker.postMessage({ type: "keepAlive" });
+  }
+
+  /**
+   * Initialize the chat with a model.
+   *
+   * @param modelId model_id of the model to load.
+   * @param chatOpts Extra options to overide chat behavior.
+   * @param appConfig Override the app config in this load.
+   * @returns A promise when reload finishes.
+   * @note The difference between init and reload is that init
+   * should be called only once when the engine is created, while reload
+   * can be called multiple times to switch between models.
+   */
+  async init(
+    modelId: string,
+    chatOpts?: ChatOptions,
+    appConfig?: AppConfig
+  ): Promise<void> {
+    const msg: WorkerMessage = {
+      kind: "init",
+      uuid: crypto.randomUUID(),
+      content: {
+        modelId: modelId,
+        chatOpts: chatOpts,
+        appConfig: appConfig,
+      },
+    };
+    await this.getPromise<null>(msg);
+  }
+}

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -219,8 +219,11 @@ export class EngineWorkerHandler {
       case "customRequest": {
         return;
       }
+      case "throw": {
+        throw Error("Error thrown in worker: " + msg.content as string);
+      }
       default: {
-        throw Error("Invalid kind, msg=" + msg);
+        throw Error("Unknown message kind, msg: [" + msg.kind + "] " + msg.content);
       }
     }
   }
@@ -273,7 +276,7 @@ export class WebWorkerEngine implements EngineInterface {
   private generateCallbackRegistry = new Map<string, GenerateProgressCallback>();
   private pendingPromise = new Map<string, (msg: WorkerMessage) => void>();
 
-  constructor(worker: any) {
+  constructor(worker: ChatWorker) {
     this.worker = worker;
     worker.onmessage = (event: any) => {
       this.onmessage(event);
@@ -526,7 +529,7 @@ export class WebWorkerEngine implements EngineInterface {
         return;
       }
       default: {
-        throw Error("Unknown msg kind, msg=" + msg);
+        throw Error("Unknown message kind, msg=[" + msg.kind + "] " + msg.content);
       }
     }
   }


### PR DESCRIPTION
This PR adds support for [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API). Unless the extension service worker currently in the repo that is used for Chrome extensions only, this is the generic service worker API that can be used for any web application.

To avoid change names of existing classes, I keep the original service worker file the same and named the new ones `WebServiceWorkerXXX`.

This PR also includes an example for running Web-LLM engine using Service Worker API and updates the README as well.

<img width="432" alt="Screenshot 2024-05-14 at 12 38 30 AM" src="https://github.com/mlc-ai/web-llm/assets/23090573/90daac00-c05d-4abf-92a3-5d6a60691dd6">
