### PR TITLE
[Fix] Avoid unnecessary engine reload by correctly comparing ChatOption and AppConfig objects

### DIFF
--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -8,6 +8,7 @@ import {
   WebWorkerEngine,
   PostMessageHandler,
 } from "./web_worker";
+import { areAppConfigsEqual, areChatOptionsEqual } from "./utils";
 
 /**
  * A post message handler that sends messages to a chrome.runtime.Port.
@@ -84,8 +85,8 @@ export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
         // If the modelId, chatOpts, and appConfig are the same, immediately return
         if (
           this.modelId === params.modelId &&
-          this.chatOpts === params.chatOpts &&
-          this.appConfig === params.appConfig
+          areChatOptionsEqual(this.chatOpts, params.chatOpts) &&
+          areAppConfigsEqual(this.appConfig, params.appConfig)
         ) {
           console.log("Already loaded the model. Skip loading");
           const gpuDetectOutput = await tvmjs.detectGPUDevice();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,125 @@
+import { AppConfig, ChatOptions, ModelRecord } from "./config";
+
+// Helper function to compare two arrays
+function areArraysEqual(arr1?: Array<any>, arr2?: Array<any>): boolean {
+  if (!arr1 && !arr2) return true;
+  if (!arr1 || !arr2) return false;
+  if (arr1.length !== arr2.length) return false;
+  for (let i = 0; i < arr1.length; i++) {
+    if (arr1[i] !== arr2[i]) return false;
+  }
+  return true;
+}
+
+// Helper function to compare two objects deeply
+function areObjectsEqual(obj1: any, obj2: any): boolean {
+  if (obj1 === obj2) return true;
+  if (typeof obj1 !== typeof obj2) return false;
+  if (typeof obj1 !== "object" || obj1 === null || obj2 === null) return false;
+
+  const keys1 = Object.keys(obj1);
+  const keys2 = Object.keys(obj2);
+  if (keys1.length !== keys2.length) return false;
+
+  for (const key of keys1) {
+    if (!keys2.includes(key) || !areObjectsEqual(obj1[key], obj2[key]))
+      return false;
+  }
+  return true;
+}
+
+// Function to compare two ModelRecord instances
+export function areModelRecordsEqual(
+  record1: ModelRecord,
+  record2: ModelRecord
+): boolean {
+  // Compare primitive fields
+  if (
+    record1.model_url !== record2.model_url ||
+    record1.model_id !== record2.model_id ||
+    record1.model_lib_url !== record2.model_lib_url ||
+    record1.vram_required_MB !== record2.vram_required_MB ||
+    record1.low_resource_required !== record2.low_resource_required ||
+    record1.buffer_size_required_bytes !== record2.buffer_size_required_bytes
+  ) {
+    return false;
+  }
+
+  // Compare required_features arrays
+  if (
+    (record1.required_features && !record2.required_features) ||
+    (!record1.required_features && record2.required_features)
+  ) {
+    return false;
+  }
+
+  if (record1.required_features && record2.required_features) {
+    if (record1.required_features.length !== record2.required_features.length) {
+      return false;
+    }
+
+    for (let i = 0; i < record1.required_features.length; i++) {
+      if (record1.required_features[i] !== record2.required_features[i]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+export function areAppConfigsEqual(
+  config1?: AppConfig,
+  config2?: AppConfig
+): boolean {
+  if (config1 === undefined || config2 === undefined) {
+    return config1 === config2;
+  }
+
+  // Check if both configurations have the same IndexedDB cache usage
+  if (config1.useIndexedDBCache !== config2.useIndexedDBCache) {
+    return false;
+  }
+
+  // Check if both configurations have the same number of model records
+  if (config1.model_list.length !== config2.model_list.length) {
+    return false;
+  }
+
+  // Compare each ModelRecord in the model_list
+  for (let i = 0; i < config1.model_list.length; i++) {
+    if (!areModelRecordsEqual(config1.model_list[i], config2.model_list[i])) {
+      return false;
+    }
+  }
+
+  // If all checks passed, the configurations are equal
+  return true;
+}
+
+export function areChatOptionsEqual(
+  options1?: ChatOptions,
+  options2?: ChatOptions
+): boolean {
+  if (options1 === undefined || options2 === undefined) {
+    return options1 === options2;
+  }
+  // Compare each property of ChatOptions (which are Partial<ChatConfig>)
+  if (!areArraysEqual(options1.tokenizer_files, options2.tokenizer_files))
+    return false;
+  if (!areObjectsEqual(options1.conv_config, options2.conv_config))
+    return false;
+  if (options1.conv_template !== options2.conv_template) return false;
+  if (options1.mean_gen_len !== options2.mean_gen_len) return false;
+  if (options1.max_gen_len !== options2.max_gen_len) return false;
+  if (options1.shift_fill_factor !== options2.shift_fill_factor) return false;
+  if (options1.repetition_penalty !== options2.repetition_penalty) return false;
+  if (options1.frequency_penalty !== options2.frequency_penalty) return false;
+  if (options1.presence_penalty !== options2.presence_penalty) return false;
+  if (options1.top_p !== options2.top_p) return false;
+  if (options1.temperature !== options2.temperature) return false;
+  if (options1.bos_token_id !== options2.bos_token_id) return false;
+
+  // If all checks passed, the options are equal
+  return true;
+}

--- a/src/web_service_worker.ts
+++ b/src/web_service_worker.ts
@@ -8,6 +8,7 @@ import {
   PostMessageHandler,
   ChatWorker,
 } from "./web_worker";
+import { areAppConfigsEqual, areChatOptionsEqual } from "./utils";
 
 const BROADCAST_CHANNEL_SERVICE_WORKER_ID = "@mlc-ai/web-llm-sw";
 const BROADCAST_CHANNEL_CLIENT_ID = "@mlc-ai/web-llm-client";
@@ -79,8 +80,8 @@ export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
         // If the modelId, chatOpts, and appConfig are the same, immediately return
         if (
           this.modelId === params.modelId &&
-          this.chatOpts === params.chatOpts &&
-          this.appConfig === params.appConfig
+          areChatOptionsEqual(this.chatOpts, params.chatOpts) &&
+          areAppConfigsEqual(this.appConfig, params.appConfig)
         ) {
           console.log("Already loaded the model. Skip loading");
           const gpuDetectOutput = await tvmjs.detectGPUDevice();
@@ -147,8 +148,8 @@ export async function CreateServiceWorkerEngine(
  */
 export class ServiceWorkerEngine extends WebWorkerEngine {
   constructor(worker: ChatWorker) {
-    super(worker)
-    clientBroadcastChannel.onmessage = this.onmessage.bind(this)
+    super(worker);
+    clientBroadcastChannel.onmessage = this.onmessage.bind(this);
   }
 
   keepAlive() {


### PR DESCRIPTION
## Overview
Currently, even the client is initializing the worker engine with the exact same configurations, the worker will not correctly recognize this but instead it will unnecessarily re-initialize itself. The root cause is due to the use of `===` to compare object equity which is actually comparing object reference equity instead of value equity.

This PR fixed it by create utility functions for deep comparing the **VALUE** of these config objects. The code is tedious and thus I generated using AI models.

## Test
Tested on https://chat.neet.coffee with the following code added to `web_service_worker.ts`.

```typescript
        console.log("modelId same? " + this.modelId === params.modelId);
        console.log("chatOpts same? " + areChatOptionsEqual(this.chatOpts, params.chatOpts));
        console.log("appConfig same? " + areAppConfigsEqual(this.appConfig, params.appConfig));
```

Before the fix:
```
modelId same? true
chatOpts same? false
appConfig same? false
```

After:
```
modelId same? true
chatOpts same? true
appConfig same? true
Already loaded the model. Skip loading
```

