### PR TITLE
[Function] Add heartbeat to service worker

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -16,7 +16,8 @@ type RequestKind = (
   "interruptGenerate" | "unload" | "resetChat" | "init" |
   "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
   "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" | "getMessage" |
-  "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest");
+  "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest" | 'keepAlive' | 'heartbeat');
+
 export interface ReloadParams {
   modelId: string;
   chatOpts?: ChatOptions;


### PR DESCRIPTION
## Overview
This PR adds heartbeat event in web service worker so that the client can monitor its status and respond correspondingly.

## Primary Changes
- Update `{ type: "keepAlive" }` event to `{ kind: "keepAlive" }` to keep all event format consistent
- Add heartbeat event in web service worker handler to report back its status

## Testing
<img width="616" alt="Screenshot 2024-05-15 at 2 01 51 AM" src="https://github.com/mlc-ai/web-llm/assets/23090573/42fcd7b0-f8f2-4b23-80c3-664426853161">
