### PR TITLE
[Feature] Replace BroadcastChannel API with Client API in Service Worker

### DIFF
--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "start": "parcel src/index.html  --port 3000",
+        "start": "parcel src/index.html --port 3000",
         "build": "parcel build src/index.html --dist-dir lib"
     },
     "devDependencies": {
@@ -15,6 +15,6 @@
         "url": "^0.11.3"
     },
     "dependencies": {
-        "@mlc-ai/web-llm": "file:../../lib"
+        "@mlc-ai/web-llm": "file:../../lib/"
     }
 }

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -77,7 +77,7 @@ async function mainStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.EngineInterface =
+  const engine: webllm.WebServiceWorkerEngine =
     await webllm.CreateWebServiceWorkerEngine(selectedModel, {
       initProgressCallback: initProgressCallback,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@mlc-ai/web-llm",
-  "version": "0.2.35",
+  "name": "@neet-nestor/web-llm",
+  "version": "0.2.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@mlc-ai/web-llm",
-      "version": "0.2.35",
+      "name": "@neet-nestor/web-llm",
+      "version": "0.2.39",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",
@@ -14,6 +14,7 @@
         "@rollup/plugin-node-resolve": "^13.0.4",
         "@types/chrome": "^0.0.266",
         "@types/jest": "^29.5.11",
+        "@types/serviceworker": "^0.0.86",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
         "@webgpu/types": "^0.1.24",
@@ -1542,6 +1543,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/@types/serviceworker": {
+      "version": "0.0.86",
+      "resolved": "https://registry.npmjs.org/@types/serviceworker/-/serviceworker-0.0.86.tgz",
+      "integrity": "sha512-RAi6tWm5hfipcDKX3l2GNhGseUim97RkJCnhUseNaDMfWtxcgolrHEBR5b5tYL9aT8TIhxcrqQVfF6DlnZsCPg==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@rollup/plugin-node-resolve": "^13.0.4",
     "@types/chrome": "^0.0.266",
     "@types/jest": "^29.5.11",
+    "@types/serviceworker": "^0.0.86",
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
     "@webgpu/types": "^0.1.24",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,24 +33,23 @@ export {
 } from "./web_worker";
 
 export {
-  WorkerMessage,
+  WorkerRequest,
+  WorkerResponse,
   CustomRequestParams
 } from "./message"
 
-// TODO: Rename to ExtensionServiceWorker 
-export {
-  ServiceWorkerEngineHandler,
-  ServiceWorkerEngine,
-  CreateServiceWorkerEngine,
-} from './service_worker'
-
-// TODO: Rename to ServiceWorker 
+// TODO: Rename classes to ServiceWorker 
 export {
   ServiceWorkerEngineHandler as WebServiceWorkerEngineHandler,
   ServiceWorkerEngine as WebServiceWorkerEngine,
   CreateServiceWorkerEngine as CreateWebServiceWorkerEngine,
-  serviceWorkerBroadcastChannel,
-  clientBroadcastChannel,
-} from "./web_service_worker";
+} from "./service_worker";
+
+// TODO: Rename classes to ExtensionServiceWorker 
+export {
+  ServiceWorkerEngineHandler,
+  ServiceWorkerEngine,
+  CreateServiceWorkerEngine,
+} from './extension_service_worker'
 
 export * from './openai_api_protocols/index';

--- a/src/message.ts
+++ b/src/message.ts
@@ -4,19 +4,36 @@ import {
   ChatCompletionRequestStreaming,
   ChatCompletionRequestNonStreaming,
   ChatCompletion,
-  ChatCompletionChunk
+  ChatCompletionChunk,
 } from "./openai_api_protocols/index";
 
 /**
  * Message kind used by worker
  */
-type RequestKind = (
-  "return" | "throw" |
-  "reload" | "generate" | "runtimeStatsText" |
-  "interruptGenerate" | "unload" | "resetChat" | "init" |
-  "initProgressCallback" | "generateProgressCallback" | "getMaxStorageBufferBindingSize" |
-  "getGPUVendor" | "forwardTokensAndSample" | "chatCompletionNonStreaming" | "getMessage" |
-  "chatCompletionStreamInit" | "chatCompletionStreamNextChunk" | "customRequest" | 'keepAlive' | 'heartbeat');
+type RequestKind =
+  | "reload"
+  | "generate"
+  | "runtimeStatsText"
+  | "interruptGenerate"
+  | "unload"
+  | "resetChat"
+  | "init"
+  | "getMaxStorageBufferBindingSize"
+  | "getGPUVendor"
+  | "forwardTokensAndSample"
+  | "chatCompletionNonStreaming"
+  | "getMessage"
+  | "chatCompletionStreamInit"
+  | "chatCompletionStreamNextChunk"
+  | "customRequest"
+  | "keepAlive"
+  | "heartbeat";
+
+type ResponseKind =
+  | "return"
+  | "throw"
+  | "initProgressCallback"
+  | "generateProgressCallback";
 
 export interface ReloadParams {
   modelId: string;
@@ -51,28 +68,54 @@ export interface CustomRequestParams {
   requestMessage: string;
 }
 export type MessageContent =
-  GenerateProgressCallbackParams |
-  ReloadParams |
-  GenerateParams |
-  ResetChatParams |
-  ForwardTokensAndSampleParams |
-  ChatCompletionNonStreamingParams |
-  ChatCompletionStreamInitParams |
-  CustomRequestParams |
-  InitProgressReport |
-  string |
-  null |
-  number |
-  ChatCompletion |
-  ChatCompletionChunk |
-  void;
+  | GenerateProgressCallbackParams
+  | ReloadParams
+  | GenerateParams
+  | ResetChatParams
+  | ForwardTokensAndSampleParams
+  | ChatCompletionNonStreamingParams
+  | ChatCompletionStreamInitParams
+  | CustomRequestParams
+  | InitProgressReport
+  | string
+  | null
+  | number
+  | ChatCompletion
+  | ChatCompletionChunk
+  | void;
 /**
  * The message used in exchange between worker
  * and the main thread.
  */
 
-export interface WorkerMessage {
+export type WorkerRequest = {
   kind: RequestKind;
   uuid: string;
   content: MessageContent;
-}
+};
+
+export type OneTimeWorkerResponse = {
+  kind: "return" | "throw";
+  uuid: string;
+  content: MessageContent;
+};
+
+export type InitProgressWorkerResponse = {
+  kind: "initProgressCallback";
+  uuid: string;
+  content: InitProgressReport;
+};
+
+export type GenerateProgressWorkerResponse = {
+  kind: "generateProgressCallback";
+  uuid: string;
+  content: {
+    step: number;
+    currentMessage: string;
+  };
+};
+
+export type WorkerResponse =
+  | OneTimeWorkerResponse
+  | InitProgressWorkerResponse
+  | GenerateProgressWorkerResponse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,10 @@
     "sourceMap": true,
     "strict": true,
     "moduleResolution": "Node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "lib": ["dom", "WebWorker"]
   },
-  "typeRoots": [ "./node_modules/@webgpu/types", "./node_modules/@types"],
+  "typeRoots": ["./node_modules/@webgpu/types", "./node_modules/@types"],
   "include": ["src"],
   "exclude": ["node_modules", "build", "dist", "rollup.config.cjs"]
 }


### PR DESCRIPTION
## Overview

There are many different APIs available for the two-way communication between service worker and web pages. According to the suggestion of web.dev, previously we used the simple BroadcastChannel API.
https://web.dev/articles/two-way-communication-guide

However, if the service worker has been killed by the browser, messages sent via the BroadcastChannel API cannot revive it. This causes unstable service worker life while users are using the webapp.

This PR replaces BroadcastChannel API with the more primitive Client API as we found that messages sent via Client API will revive a stopped service worker. This ensures the normal functioning of our keep-alive mechanism.

## Primary Change

- service_worker.ts:
  - Replace `BroadcastChannel` with Client API  (`navigator.serviceWorker.controller.postMessage()` and `client.postMessage()`)
  - Add `clientRegistry` to remember mapping between incoming messages and client ids
  - Add 
- Rename files (the export names are kept the same):
  - `web_service_worker.ts` -> `service_worker.ts`
  - `service_worker.ts` -> `extension_service_worker.ts`

## Testing

- https://chat.webllm.ai/
- `examples/service-worker`

The chat webapp is able to correctly keeping service worker alive after this change.