### PR TITLE
[Rename] Rename service worker export classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,23 +124,23 @@ that handles requests when the service worker is ready.
 ```typescript
 // sw.ts
 import {
-  WebServiceWorkerEngineHandler,
+  ServiceWorkerEngineHandler,
   EngineInterface,
   Engine,
 } from "@mlc-ai/web-llm";
 
 const engine: EngineInterface = new Engine();
-let handler: WebServiceWorkerEngineHandler;
+let handler: ServiceWorkerEngineHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new WebServiceWorkerEngineHandler(engine);
+  handler = new ServiceWorkerEngineHandler(engine);
   console.log("Service Worker is ready")
 });
 
 ```
 
 Then in the main logic, we register the service worker and then create the engine using
-`CreateWebServiceWorkerEngine` function. The rest of the logic remains the same.
+`CreateServiceWorkerEngine` function. The rest of the logic remains the same.
 
 ```typescript
 // main.ts
@@ -152,7 +152,7 @@ if ("serviceWorker" in navigator) {
 }
 
 const engine: webllm.EngineInterface =
-  await webllm.CreateWebServiceWorkerEngine(
+  await webllm.CreateServiceWorkerEngine(
     /*modelId=*/selectedModel,
     /*engineConfig=*/{ initProgressCallback: initProgressCallback }
   );

--- a/examples/chrome-extension-webgpu-service-worker/src/background.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/background.ts
@@ -1,4 +1,4 @@
-import { ServiceWorkerEngineHandler, Engine } from "@mlc-ai/web-llm";
+import { ExtensionServiceWorkerEngineHandler, Engine } from "@mlc-ai/web-llm";
 
 // Hookup an engine to a service worker handler
 const engine = new Engine();
@@ -7,7 +7,7 @@ let handler;
 chrome.runtime.onConnect.addListener(function (port) {
   console.assert(port.name === "web_llm_service_worker");
   if (handler === undefined) {
-    handler = new ServiceWorkerEngineHandler(engine, port);
+    handler = new ExtensionServiceWorkerEngineHandler(engine, port);
   } else {
     handler.setPort(port);
   }

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -7,7 +7,7 @@ import "./popup.css";
 
 import {
   ChatCompletionMessageParam,
-  CreateServiceWorkerEngine,
+  CreateExtensionServiceWorkerEngine,
   EngineInterface,
   InitProgressReport,
 } from "@mlc-ai/web-llm";
@@ -46,7 +46,7 @@ const initProgressCallback = (report: InitProgressReport) => {
   }
 };
 
-const engine: EngineInterface = await CreateServiceWorkerEngine(
+const engine: EngineInterface = await CreateExtensionServiceWorkerEngine(
   "Mistral-7B-Instruct-v0.2-q4f16_1",
   { initProgressCallback: initProgressCallback }
 );

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -40,7 +40,7 @@ async function mainNonStreaming() {
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
   const engine: webllm.EngineInterface =
-    await webllm.CreateWebServiceWorkerEngine(selectedModel, {
+    await webllm.CreateServiceWorkerEngine(selectedModel, {
       initProgressCallback: initProgressCallback,
     });
 
@@ -77,8 +77,8 @@ async function mainStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.WebServiceWorkerEngine =
-    await webllm.CreateWebServiceWorkerEngine(selectedModel, {
+  const engine: webllm.ServiceWorkerEngine =
+    await webllm.CreateServiceWorkerEngine(selectedModel, {
       initProgressCallback: initProgressCallback,
     });
 

--- a/examples/service-worker/src/sw.ts
+++ b/examples/service-worker/src/sw.ts
@@ -1,13 +1,13 @@
 import {
-  WebServiceWorkerEngineHandler,
+  ServiceWorkerEngineHandler,
   EngineInterface,
   Engine,
 } from "@mlc-ai/web-llm";
 
 const engine: EngineInterface = new Engine();
-let handler: WebServiceWorkerEngineHandler;
+let handler: ServiceWorkerEngineHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new WebServiceWorkerEngineHandler(engine);
+  handler = new ServiceWorkerEngineHandler(engine);
   console.log("Web-LLM Service Worker Activated")
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,16 +40,16 @@ export {
 
 // TODO: Rename classes to ServiceWorker 
 export {
-  ServiceWorkerEngineHandler as WebServiceWorkerEngineHandler,
-  ServiceWorkerEngine as WebServiceWorkerEngine,
-  CreateServiceWorkerEngine as CreateWebServiceWorkerEngine,
+  ServiceWorkerEngineHandler,
+  ServiceWorkerEngine,
+  CreateServiceWorkerEngine,
 } from "./service_worker";
 
 // TODO: Rename classes to ExtensionServiceWorker 
 export {
-  ServiceWorkerEngineHandler,
-  ServiceWorkerEngine,
-  CreateServiceWorkerEngine,
+  ServiceWorkerEngineHandler as ExtensionServiceWorkerEngineHandler,
+  ServiceWorkerEngine as ExtensionServiceWorkerEngine,
+  CreateServiceWorkerEngine as CreateExtensionServiceWorkerEngine,
 } from './extension_service_worker'
 
 export * from './openai_api_protocols/index';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,14 +38,12 @@ export {
   CustomRequestParams
 } from "./message"
 
-// TODO: Rename classes to ServiceWorker 
 export {
   ServiceWorkerEngineHandler,
   ServiceWorkerEngine,
   CreateServiceWorkerEngine,
 } from "./service_worker";
 
-// TODO: Rename classes to ExtensionServiceWorker 
 export {
   ServiceWorkerEngineHandler as ExtensionServiceWorkerEngineHandler,
   ServiceWorkerEngine as ExtensionServiceWorkerEngine,


### PR DESCRIPTION
This PR renames the following classes in export to better align with their well-known names.

- WebServiceWorker -> ServiceWorker
  https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API
- ServiceWorker -> ExtensionServiceWorker
  https://developer.chrome.com/docs/extensions/develop/concepts/service-workers

Note, this is a **breaking** change for existing extension service worker engine users. Therefore, please merge with caution.