### PR TITLE
[Fix] Remove perf hooks import from index.js

### DIFF
--- a/cleanup-index-js.sh
+++ b/cleanup-index-js.sh
@@ -10,6 +10,13 @@ sed -e s/"const{createRequire:createRequire}=await import('module');"//g -i .bac
 sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\"MLC_DUMMY_PATH\""/g -i .backup lib/index.js
 sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\"MLC_DUMMY_PATH\""/g -i .backup lib/index.js.map
 
+# Replace "import require$$3 from 'perf_hooks';" with a string "const require$$3 = "MLC_DUMMY_REQUIRE_VAR""
+# This is to prevent `perf_hooks` not found error
+# For more see https://github.com/mlc-ai/web-llm/issues/258 and https://github.com/mlc-ai/web-llm/issues/127
+sed -e s/"import require\$\$3 from 'perf_hooks';"/"const require\$\$3 = \"MLC_DUMMY_REQUIRE_VAR\""/g -i .backup lib/index.js
+# Similarly replace `const performanceNode = require(\"perf_hooks\")` with `const performanceNode = "MLC_DUMMY_REQUIRE_VAR"`
+sed -e s/'require(\\\"perf_hooks\\\")'/'\"MLC_DUMMY_REQUIRE_VAR\"'/g -i .backup lib/index.js.map
+
 # Cleanup backup files
 rm lib/index.js.backup
 rm lib/index.js.map.backup


### PR DESCRIPTION
Replace `import require$$3 from 'perf_hooks';` with `const require$$3 = "MLC_DUMMY_REQUIRE_VAR"` in `index.js`.

We use a dummy string because we should not reach to [this branch in tvmjs](https://github.com/apache/tvm/blob/a5862a5c696a3237f644f31bc312aae303213f3f/web/src/compact.ts#L29) which is for nodejs.

This should address https://github.com/mlc-ai/web-llm/issues/258 and https://github.com/mlc-ai/web-llm/issues/127