### PR TITLE
[Refactor] Rename Engine to MLCEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ async function main() {
     label.innerText = report.text;
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     /*engineConfig=*/{ initProgressCallback: initProgressCallback }
   );
@@ -53,10 +53,10 @@ async function main() {
 main();
 ```
 
-Note that if you need to separate the instantiation of `webllm.Engine` from loading a model, you could substitute
+Note that if you need to separate the instantiation of `webllm.MLCEngine` from loading a model, you could substitute
 
 ```typescript
-const engine: webllm.EngineInterface = await webllm.CreateEngine(
+const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
   selectedModel,
   /*engineConfig=*/{ initProgressCallback: initProgressCallback }
 );
@@ -65,7 +65,7 @@ const engine: webllm.EngineInterface = await webllm.CreateEngine(
 with the equivalent
 
 ```typescript
-const engine: webllm.EngineInterface = new webllm.Engine();
+const engine: webllm.MLCEngineInterface = new webllm.MLCEngine();
 engine.setInitProgressCallback(initProgressCallback);
 await engine.reload(selectedModel, chatConfig, appConfig);
 ```
@@ -81,7 +81,7 @@ async function main() {
     console.log(report.text);
   };
   const selectedModel = "TinyLlama-1.1B-Chat-v0.4-q4f16_1-1k";
-  const engine = await webllm.CreateEngine(
+  const engine = await webllm.CreateMLCEngine(
     selectedModel,
     {initProgressCallback: initProgressCallback}
   );
@@ -105,31 +105,31 @@ WebLLM comes with API support for WebWorker so you can hook
 the generation process into a separate worker thread so that
 the compute in the webworker won't disrupt the UI.
 
-We first create a worker script that created a Engine and
+We first create a worker script that created a MLCEngine and
 hook it up to a handler that handles requests.
 
 ```typescript
 // worker.ts
-import { EngineWorkerHandler, Engine } from "@mlc-ai/web-llm";
+import { MLCEngineWorkerHandler, MLCEngine } from "@mlc-ai/web-llm";
 
-// Hookup an Engine to a worker handler
-const engine = new Engine();
-const handler = new EngineWorkerHandler(engine);
+// Hookup an MLCEngine to a worker handler
+const engine = new MLCEngine();
+const handler = new MLCEngineWorkerHandler(engine);
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };
 ```
 
-Then in the main logic, we create a `WebWorkerEngine` that
-implements the same `EngineInterface`. The rest of the logic remains the same.
+Then in the main logic, we create a `WebWorkerMLCEngine` that
+implements the same `MLCEngineInterface`. The rest of the logic remains the same.
 
 ```typescript
 // main.ts
 import * as webllm from "@mlc-ai/web-llm";
 
 async function main() {
-  // Use a WebWorkerEngine instead of Engine here
-  const engine: webllm.EngineInterface = await webllm.CreateWebWorkerEngine(
+  // Use a WebWorkerMLCEngine instead of MLCEngine here
+  const engine: webllm.MLCEngineInterface = await webllm.CreateWebWorkerMLCEngine(
     /*worker=*/new Worker(
       new URL('./worker.ts', import.meta.url),
       { type: 'module' }
@@ -147,29 +147,29 @@ WebLLM comes with API support for ServiceWorker so you can hook the generation p
 into a service worker to avoid reloading the model in every page visit and optimize 
 your application's offline experience.
 
-We first create a service worker script that created a Engine and hook it up to a handler
+We first create a service worker script that created a MLCEngine and hook it up to a handler
 that handles requests when the service worker is ready.
 
 ```typescript
 // sw.ts
 import {
-  ServiceWorkerEngineHandler,
-  EngineInterface,
-  Engine,
+  ServiceWorkerMLCEngineHandler,
+  MLCEngineInterface,
+  MLCEngine,
 } from "@mlc-ai/web-llm";
 
-const engine: EngineInterface = new Engine();
-let handler: ServiceWorkerEngineHandler;
+const engine: MLCEngineInterface = new MLCEngine();
+let handler: ServiceWorkerMLCEngineHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new ServiceWorkerEngineHandler(engine);
+  handler = new ServiceWorkerMLCEngineHandler(engine);
   console.log("Service Worker is ready")
 });
 
 ```
 
 Then in the main logic, we register the service worker and then create the engine using
-`CreateServiceWorkerEngine` function. The rest of the logic remains the same.
+`CreateServiceWorkerMLCEngine` function. The rest of the logic remains the same.
 
 ```typescript
 // main.ts
@@ -180,8 +180,8 @@ if ("serviceWorker" in navigator) {
   );
 }
 
-const engine: webllm.EngineInterface =
-  await webllm.CreateServiceWorkerEngine(
+const engine: webllm.MLCEngineInterface =
+  await webllm.CreateServiceWorkerMLCEngine(
     /*modelId=*/selectedModel,
     /*engineConfig=*/{ initProgressCallback: initProgressCallback }
   );
@@ -208,7 +208,7 @@ WebLLM is designed to be fully compatible with [OpenAI API](https://platform.ope
 ## Model Support
 
 We export all supported models in `webllm.prebuiltAppConfig`, where you can see a list of models
-that you can simply call `const engine: webllm.EngineInterface = await webllm.CreateEngine(anyModel)` with.
+that you can simply call `const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(anyModel)` with.
 Prebuilt models include:
 - Llama-2
 - Llama-3
@@ -257,7 +257,7 @@ async main() {
   // and cache it in the browser cache
   // The chat will also load the model library from "/url/to/myllama3b.wasm",
   // assuming that it is compatible to the model in myLlamaUrl.
-  const engine = await webllm.CreateEngine(
+  const engine = await webllm.CreateMLCEngine(
     "MyLlama-3b-v1-q4f32_0", 
     /*engineConfig=*/{ chatOpts: chatOpts, appConfig: appConfig }
   );

--- a/examples/cache-usage/src/cache_usage.ts
+++ b/examples/cache-usage/src/cache_usage.ts
@@ -25,7 +25,7 @@ async function main() {
 
   // 1. This triggers downloading and caching the model with either Cache or IndexedDB Cache
   const selectedModel = "Phi2-q4f16_1"
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     "Phi2-q4f16_1",
     { initProgressCallback: initProgressCallback, appConfig: appConfig }
   );

--- a/examples/chrome-extension-webgpu-service-worker/src/background.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/background.ts
@@ -1,13 +1,13 @@
-import { ExtensionServiceWorkerEngineHandler, Engine } from "@mlc-ai/web-llm";
+import { ExtensionServiceWorkerMLCEngineHandler, MLCEngine } from "@mlc-ai/web-llm";
 
 // Hookup an engine to a service worker handler
-const engine = new Engine();
+const engine = new MLCEngine();
 let handler;
 
 chrome.runtime.onConnect.addListener(function (port) {
   console.assert(port.name === "web_llm_service_worker");
   if (handler === undefined) {
-    handler = new ExtensionServiceWorkerEngineHandler(engine, port);
+    handler = new ExtensionServiceWorkerMLCEngineHandler(engine, port);
   } else {
     handler.setPort(port);
   }

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -7,8 +7,8 @@ import "./popup.css";
 
 import {
   ChatCompletionMessageParam,
-  CreateExtensionServiceWorkerEngine,
-  EngineInterface,
+  CreateExtensionServiceWorkerMLCEngine,
+  MLCEngineInterface,
   InitProgressReport,
 } from "@mlc-ai/web-llm";
 import { prebuiltAppConfig } from "@mlc-ai/web-llm";
@@ -36,7 +36,7 @@ const progressBar: ProgressBar = new Line("#loadingContainer", {
   svgStyle: { width: "100%", height: "100%" },
 });
 
-/***************** Web-LLM Engine Configuration *****************/
+/***************** Web-LLM MLCEngine Configuration *****************/
 const initProgressCallback = (report: InitProgressReport) => {
   progressBar.animate(report.progress, {
     duration: 50,
@@ -46,7 +46,7 @@ const initProgressCallback = (report: InitProgressReport) => {
   }
 };
 
-const engine: EngineInterface = await CreateExtensionServiceWorkerEngine(
+const engine: MLCEngineInterface = await CreateExtensionServiceWorkerMLCEngine(
   "Mistral-7B-Instruct-v0.2-q4f16_1",
   { initProgressCallback: initProgressCallback }
 );

--- a/examples/chrome-extension/src/popup.ts
+++ b/examples/chrome-extension/src/popup.ts
@@ -6,7 +6,7 @@
 
 import './popup.css';
 
-import { EngineInterface, InitProgressReport, CreateEngine, ChatCompletionMessageParam } from "@mlc-ai/web-llm";
+import { MLCEngineInterface, InitProgressReport, CreateMLCEngine, ChatCompletionMessageParam } from "@mlc-ai/web-llm";
 import { ProgressBar, Line } from "progressbar.js";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -43,7 +43,7 @@ const initProgressCallback = (report: InitProgressReport) => {
 
 // const selectedModel = "TinyLlama-1.1B-Chat-v0.4-q4f16_1-1k";
 const selectedModel = "Mistral-7B-Instruct-v0.2-q4f16_1";
-const engine: EngineInterface = await CreateEngine(
+const engine: MLCEngineInterface = await CreateMLCEngine(
     selectedModel,
     { initProgressCallback: initProgressCallback }
 );

--- a/examples/function-calling/src/function_calling.ts
+++ b/examples/function-calling/src/function_calling.ts
@@ -24,7 +24,7 @@ async function main() {
     setLabel("init-label", report.text);
   };
   const selectedModel = "gorilla-openfunctions-v2-q4f16_1"
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     { appConfig: myAppConfig, initProgressCallback: initProgressCallback }
   );

--- a/examples/get-started-web-worker/src/main.ts
+++ b/examples/get-started-web-worker/src/main.ts
@@ -19,7 +19,7 @@ async function mainNonStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.EngineInterface = await webllm.CreateWebWorkerEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateWebWorkerMLCEngine(
     new Worker(
       new URL('./worker.ts', import.meta.url),
       { type: 'module' }
@@ -59,7 +59,7 @@ async function mainStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.EngineInterface = await webllm.CreateWebWorkerEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateWebWorkerMLCEngine(
     new Worker(
       new URL('./worker.ts', import.meta.url),
       { type: 'module' }

--- a/examples/get-started-web-worker/src/worker.ts
+++ b/examples/get-started-web-worker/src/worker.ts
@@ -1,8 +1,8 @@
-import { EngineWorkerHandler, Engine } from "@mlc-ai/web-llm";
+import { MLCEngineWorkerHandler, MLCEngine } from "@mlc-ai/web-llm";
 
 // Hookup an engine to a worker handler
-const engine = new Engine();
-const handler = new EngineWorkerHandler(engine);
+const engine = new MLCEngine();
+const handler = new MLCEngineWorkerHandler(engine);
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };

--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -14,7 +14,7 @@ async function main() {
   };
   // Option 1: If we do not specify appConfig, we use `prebuiltAppConfig` defined in `config.ts`
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     { initProgressCallback: initProgressCallback }
   );
@@ -29,7 +29,7 @@ async function main() {
   //     },
   //   ]
   // };
-  // const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  // const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
   //   selectedModel,
   //   { appConfig: appConfig, initProgressCallback: initProgressCallback }
   // );
@@ -56,7 +56,7 @@ async function main() {
   console.log(reply0);
   console.log(await engine.runtimeStatsText());
 
-  // To change model, either create a new engine via `CreateEngine()`, or call `engine.reload(modelId)`
+  // To change model, either create a new engine via `CreateMLCEngine()`, or call `engine.reload(modelId)`
 }
 
 main();

--- a/examples/json-mode/src/json_mode.ts
+++ b/examples/json-mode/src/json_mode.ts
@@ -13,7 +13,7 @@ async function main() {
         setLabel("init-label", report.text);
     };
     const selectedModel = "Llama-2-7b-chat-hf-q4f32_1";
-    const engine: webllm.EngineInterface = await webllm.CreateEngine(
+    const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
         selectedModel,
         { initProgressCallback: initProgressCallback }
     );

--- a/examples/json-schema/src/json_schema.ts
+++ b/examples/json-schema/src/json_schema.ts
@@ -37,7 +37,7 @@ async function simpleStructuredTextExample() {
   const initProgressCallback = (report: webllm.InitProgressReport) => {
     setLabel("init-label", report.text);
   };
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     "Llama-2-7b-chat-hf-q4f16_1",
     { initProgressCallback: initProgressCallback }
   );
@@ -104,7 +104,7 @@ async function harryPotterExample() {
     setLabel("init-label", report.text);
   };
 
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     "Llama-2-7b-chat-hf-q4f16_1",
     { initProgressCallback: initProgressCallback }
   );
@@ -171,7 +171,7 @@ async function functionCallingExample() {
   };
 
   const selectedModel = "Hermes-2-Pro-Mistral-7B-q4f16_1";
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     {
       initProgressCallback: initProgressCallback,

--- a/examples/logit-processor/src/logit_processor.ts
+++ b/examples/logit-processor/src/logit_processor.ts
@@ -21,12 +21,12 @@ async function main() {
   const logitProcessorRegistry = new Map<string, webllm.LogitProcessor>();
   logitProcessorRegistry.set("Phi2-q4f32_1", myLogitProcessor);
 
-  let engine: webllm.EngineInterface;
+  let engine: webllm.MLCEngineInterface;
 
   // Depending on whether we use a web worker, the code is slightly different
   if (USE_WEB_WORKER) {
     // see worker.ts on how LogitProcessor plays a role there
-    engine = await webllm.CreateWebWorkerEngine(
+    engine = await webllm.CreateWebWorkerMLCEngine(
       new Worker(
         new URL('./worker.ts', import.meta.url),
         { type: 'module' }
@@ -35,7 +35,7 @@ async function main() {
       { initProgressCallback: initProgressCallback }
     );
   } else {
-    engine = await webllm.CreateEngine(
+    engine = await webllm.CreateMLCEngine(
       "Phi2-q4f32_1",
       {
         initProgressCallback: initProgressCallback,

--- a/examples/logit-processor/src/worker.ts
+++ b/examples/logit-processor/src/worker.ts
@@ -8,9 +8,9 @@ const myLogitProcessor = new MyLogitProcessor();
 const logitProcessorRegistry = new Map<string, webllm.LogitProcessor>();
 logitProcessorRegistry.set("Phi2-q4f32_1", myLogitProcessor);
 
-const engine = new webllm.Engine();
+const engine = new webllm.MLCEngine();
 engine.setLogitProcessorRegistry(logitProcessorRegistry);
-const handler = new webllm.EngineWorkerHandler(engine);
+const handler = new webllm.MLCEngineWorkerHandler(engine);
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };

--- a/examples/multi-round-chat/src/multi_round_chat.ts
+++ b/examples/multi-round-chat/src/multi_round_chat.ts
@@ -18,7 +18,7 @@ async function main() {
     setLabel("init-label", report.text);
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     { initProgressCallback: initProgressCallback }
   );

--- a/examples/next-simple-chat/src/utils/chat_component.tsx
+++ b/examples/next-simple-chat/src/utils/chat_component.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Engine } from "@mlc-ai/web-llm";
+import { MLCEngine } from "@mlc-ai/web-llm";
 import ChatUI from "~/utils/chat_ui";
 
 const ChatComponent = () => {
@@ -8,7 +8,7 @@ const ChatComponent = () => {
   );
   const [prompt, setPrompt] = useState("");
   const [runtimeStats, setRuntimeStats] = useState("");
-  const [chat_ui] = useState(new ChatUI(new Engine()));
+  const [chat_ui] = useState(new ChatUI(new MLCEngine()));
   const updateMessage = (kind: string, text: string, append: boolean) => {
     if (kind == "init") {
       text = "[System Initalize] " + text;

--- a/examples/next-simple-chat/src/utils/chat_ui.ts
+++ b/examples/next-simple-chat/src/utils/chat_ui.ts
@@ -1,7 +1,7 @@
-import { EngineInterface, ChatCompletionMessageParam } from "@mlc-ai/web-llm";
+import { MLCEngineInterface, ChatCompletionMessageParam } from "@mlc-ai/web-llm";
 
 export default class ChatUI {
-    private engine: EngineInterface;
+    private engine: MLCEngineInterface;
     private chatLoaded = false;
     private requestInProgress = false;
     // We use a request chain to ensure that
@@ -9,7 +9,7 @@ export default class ChatUI {
     private chatRequestChain: Promise<void> = Promise.resolve();
     private chatHistory: ChatCompletionMessageParam[] = [];
 
-    constructor(engine: EngineInterface) {
+    constructor(engine: MLCEngineInterface) {
         this.engine = engine;
     }
     /**

--- a/examples/seed-to-reproduce/src/seed.ts
+++ b/examples/seed-to-reproduce/src/seed.ts
@@ -19,7 +19,7 @@ async function main() {
         setLabel("init-label", report.text);
     };
     const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
-    const engine: webllm.EngineInterface = await webllm.CreateEngine(
+    const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
         selectedModel,
         { initProgressCallback: initProgressCallback }
     );

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "start": "parcel src/index.html --port 3000",
-        "build": "parcel build src/index.html --dist-dir lib"
+        "start": "rm -rf .parcel-cache && parcel src/index.html --port 3000",
+        "build": "rm -rf .parcel-cache && parcel build src/index.html --dist-dir lib"
     },
     "devDependencies": {
         "buffer": "^6.0.3",

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -39,8 +39,8 @@ async function mainNonStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.EngineInterface =
-    await webllm.CreateServiceWorkerEngine(selectedModel, {
+  const engine: webllm.MLCEngineInterface =
+    await webllm.CreateServiceWorkerMLCEngine(selectedModel, {
       initProgressCallback: initProgressCallback,
     });
 
@@ -77,8 +77,8 @@ async function mainStreaming() {
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
 
-  const engine: webllm.ServiceWorkerEngine =
-    await webllm.CreateServiceWorkerEngine(selectedModel, {
+  const engine: webllm.ServiceWorkerMLCEngine =
+    await webllm.CreateServiceWorkerMLCEngine(selectedModel, {
       initProgressCallback: initProgressCallback,
     });
 

--- a/examples/service-worker/src/sw.ts
+++ b/examples/service-worker/src/sw.ts
@@ -1,13 +1,13 @@
 import {
-  ServiceWorkerEngineHandler,
-  EngineInterface,
-  Engine,
+  ServiceWorkerMLCEngineHandler,
+  MLCEngineInterface,
+  MLCEngine,
 } from "@mlc-ai/web-llm";
 
-const engine: EngineInterface = new Engine();
-let handler: ServiceWorkerEngineHandler;
+const engine: MLCEngineInterface = new MLCEngine();
+let handler: ServiceWorkerMLCEngineHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new ServiceWorkerEngineHandler(engine);
+  handler = new ServiceWorkerMLCEngineHandler(engine);
   console.log("Web-LLM Service Worker Activated")
 });

--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -13,7 +13,7 @@ class ChatUI {
   private uiChat: HTMLElement;
   private uiChatInput: HTMLInputElement;
   private uiChatInfoLabel: HTMLLabelElement;
-  private engine: webllm.EngineInterface | webllm.WebWorkerEngine;
+  private engine: webllm.MLCEngineInterface | webllm.WebWorkerMLCEngine;
   private config: webllm.AppConfig = appConfig;
   private selectedModel: string;
   private chatLoaded = false;
@@ -27,7 +27,7 @@ class ChatUI {
    * An asynchronous factory constructor since we need to await getMaxStorageBufferBindingSize();
    * this is not allowed in a constructor (which cannot be asynchronous).
    */
-  public static CreateAsync = async (engine: webllm.EngineInterface) => {
+  public static CreateAsync = async (engine: webllm.MLCEngineInterface) => {
     const chatUI = new ChatUI();
     chatUI.engine = engine;
     // get the elements
@@ -286,16 +286,16 @@ class ChatUI {
 }
 
 const useWebWorker = appConfig.use_web_worker;
-let engine: webllm.EngineInterface;
+let engine: webllm.MLCEngineInterface;
 
-// Here we do not use `CreateEngine()` but instantiate an engine that is not loaded with model
+// Here we do not use `CreateMLCEngine()` but instantiate an engine that is not loaded with model
 if (useWebWorker) {
-  engine = new webllm.WebWorkerEngine(new Worker(
+  engine = new webllm.WebWorkerMLCEngine(new Worker(
     new URL('./worker.ts', import.meta.url),
     { type: 'module' }
   ));
 } else {
-  engine = new webllm.Engine();
+  engine = new webllm.MLCEngine();
 }
 ChatUI.CreateAsync(engine);
 

--- a/examples/simple-chat-upload/src/worker.ts
+++ b/examples/simple-chat-upload/src/worker.ts
@@ -1,8 +1,8 @@
 // Serve the engine workload through web worker
-import { EngineWorkerHandler, Engine } from "@mlc-ai/web-llm";
+import { MLCEngineWorkerHandler, MLCEngine } from "@mlc-ai/web-llm";
 
-const engine = new Engine();
-const handler = new EngineWorkerHandler(engine);
+const engine = new MLCEngine();
+const handler = new MLCEngineWorkerHandler(engine);
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };

--- a/examples/simple-chat/src/simple_chat.ts
+++ b/examples/simple-chat/src/simple_chat.ts
@@ -13,7 +13,7 @@ class ChatUI {
   private uiChat: HTMLElement;
   private uiChatInput: HTMLInputElement;
   private uiChatInfoLabel: HTMLLabelElement;
-  private engine: webllm.EngineInterface | webllm.WebWorkerEngine;
+  private engine: webllm.MLCEngineInterface | webllm.WebWorkerMLCEngine;
   private config: webllm.AppConfig = appConfig;
   private selectedModel: string;
   private chatLoaded = false;
@@ -27,7 +27,7 @@ class ChatUI {
    * An asynchronous factory constructor since we need to await getMaxStorageBufferBindingSize();
    * this is not allowed in a constructor (which cannot be asynchronous).
    */
-  public static CreateAsync = async (engine: webllm.EngineInterface) => {
+  public static CreateAsync = async (engine: webllm.MLCEngineInterface) => {
     const chatUI = new ChatUI();
     chatUI.engine = engine;
     // get the elements
@@ -305,15 +305,15 @@ class ChatUI {
 }
 
 const useWebWorker = appConfig.use_web_worker;
-let engine: webllm.EngineInterface;
+let engine: webllm.MLCEngineInterface;
 
-// Here we do not use `CreateEngine()` but instantiate an engine that is not loaded with model
+// Here we do not use `CreateMLCEngine()` but instantiate an engine that is not loaded with model
 if (useWebWorker) {
-  engine = new webllm.WebWorkerEngine(new Worker(
+  engine = new webllm.WebWorkerMLCEngine(new Worker(
     new URL('./worker.ts', import.meta.url),
     { type: 'module' }
   ));
 } else {
-  engine = new webllm.Engine();
+  engine = new webllm.MLCEngine();
 }
 ChatUI.CreateAsync(engine);

--- a/examples/simple-chat/src/worker.ts
+++ b/examples/simple-chat/src/worker.ts
@@ -1,8 +1,8 @@
 // Serve the engine workload through web worker
-import { EngineWorkerHandler, Engine } from "@mlc-ai/web-llm";
+import { MLCEngineWorkerHandler, MLCEngine } from "@mlc-ai/web-llm";
 
-const engine = new Engine();
-const handler = new EngineWorkerHandler(engine);
+const engine = new MLCEngine();
+const handler = new MLCEngineWorkerHandler(engine);
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };

--- a/examples/streaming/src/streaming.ts
+++ b/examples/streaming/src/streaming.ts
@@ -16,7 +16,7 @@ async function main() {
     setLabel("init-label", report.text);
   };
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
-  const engine: webllm.EngineInterface = await webllm.CreateEngine(
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     { initProgressCallback: initProgressCallback }
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.35",
+      "version": "0.2.36",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,17 +76,17 @@ export interface ChatConfig {
 export interface ChatOptions extends Partial<ChatConfig> { }
 
 /**
- * Optional configurations for `CreateEngine()` and `CreateWebWorkerEngine()`.
+ * Optional configurations for `CreateMLCEngine()` and `CreateWebWorkerMLCEngine()`.
  * 
  * chatOpts: To optionally override the `mlc-chat-config.json` of `modelId`.
  * appConfig: Configure the app, including the list of models and whether to use IndexedDB cache.
  * initProgressCallback: A callback for showing the progress of loading the model.
  * logitProcessorRegistry: A register for stateful logit processors, see `webllm.LogitProcessor`.
  * 
- * @note All fields are optional, and `logitProcessorRegistry` is only used for `CreateEngine()`
- * not `CreateWebWorkerEngine()`.
+ * @note All fields are optional, and `logitProcessorRegistry` is only used for `CreateMLCEngine()`
+ * not `CreateWebWorkerMLCEngine()`.
  */
-export interface EngineConfig {
+export interface MLCEngineConfig {
   chatOpts?: ChatOptions,
   appConfig?: AppConfig,
   initProgressCallback?: InitProgressCallback,

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -1,11 +1,11 @@
 import * as tvmjs from "tvmjs";
-import { AppConfig, ChatOptions, EngineConfig } from "./config";
+import { AppConfig, ChatOptions, MLCEngineConfig } from "./config";
 import { ReloadParams, WorkerRequest } from "./message";
-import { EngineInterface } from "./types";
+import { MLCEngineInterface } from "./types";
 import {
   ChatWorker,
-  EngineWorkerHandler,
-  WebWorkerEngine,
+  MLCEngineWorkerHandler,
+  WebWorkerMLCEngine,
   PostMessageHandler,
 } from "./web_worker";
 import { areAppConfigsEqual, areChatOptionsEqual } from "./utils";
@@ -40,23 +40,23 @@ export class PortPostMessageHandler implements PostMessageHandler {
  *
  * @example
  *
- * const engine = new Engine();
+ * const engine = new MLCEngine();
  * let handler;
  * chrome.runtime.onConnect.addListener(function (port) {
  *   if (handler === undefined) {
- *     handler = new ServiceWorkerEngineHandler(engine, port);
+ *     handler = new ServiceWorkerMLCEngineHandler(engine, port);
  *   } else {
  *     handler.setPort(port);
  *   }
  *   port.onMessage.addListener(handler.onmessage.bind(handler));
  * });
  */
-export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
+export class ServiceWorkerMLCEngineHandler extends MLCEngineWorkerHandler {
   modelId?: string;
   chatOpts?: ChatOptions;
   appConfig?: AppConfig;
 
-  constructor(engine: EngineInterface, port: chrome.runtime.Port) {
+  constructor(engine: MLCEngineInterface, port: chrome.runtime.Port) {
     let portHandler = new PortPostMessageHandler(port);
     super(engine, portHandler);
 
@@ -124,31 +124,31 @@ export class ServiceWorkerEngineHandler extends EngineWorkerHandler {
 }
 
 /**
- * Create a ServiceWorkerEngine.
+ * Create a ServiceWorkerMLCEngine.
  *
  * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
  * `engineConfig.appConfig`.
- * @param engineConfig Optionally configures the engine, see `webllm.EngineConfig` for more.
+ * @param engineConfig Optionally configures the engine, see `webllm.MLCEngineConfig` for more.
  * @param keepAliveMs The interval to send keep alive messages to the service worker.
  * See [Service worker lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle#idle-shutdown)
  * The default is 10s.
- * @returns An initialized `WebLLM.ServiceWorkerEngine` with `modelId` loaded.
+ * @returns An initialized `WebLLM.ServiceWorkerMLCEngine` with `modelId` loaded.
  */
-export async function CreateServiceWorkerEngine(
+export async function CreateServiceWorkerMLCEngine(
   modelId: string,
-  engineConfig?: EngineConfig,
+  engineConfig?: MLCEngineConfig,
   keepAliveMs: number = 10000
-): Promise<ServiceWorkerEngine> {
-  const serviceWorkerEngine = new ServiceWorkerEngine(keepAliveMs);
-  serviceWorkerEngine.setInitProgressCallback(
+): Promise<ServiceWorkerMLCEngine> {
+  const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(keepAliveMs);
+  serviceWorkerMLCEngine.setInitProgressCallback(
     engineConfig?.initProgressCallback
   );
-  await serviceWorkerEngine.init(
+  await serviceWorkerMLCEngine.init(
     modelId,
     engineConfig?.chatOpts,
     engineConfig?.appConfig
   );
-  return serviceWorkerEngine;
+  return serviceWorkerMLCEngine;
 }
 
 class PortAdapter implements ChatWorker {
@@ -183,9 +183,9 @@ class PortAdapter implements ChatWorker {
 }
 
 /**
- * A client of Engine that exposes the same interface
+ * A client of MLCEngine that exposes the same interface
  */
-export class ServiceWorkerEngine extends WebWorkerEngine {
+export class ServiceWorkerMLCEngine extends WebWorkerMLCEngine {
   port: chrome.runtime.Port;
 
   constructor(keepAliveMs: number = 10000) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export {
   ModelRecord,
   AppConfig,
   ChatOptions,
-  EngineConfig,
+  MLCEngineConfig,
   GenerationConfig,
   prebuiltAppConfig,
   modelVersion,
@@ -13,13 +13,13 @@ export {
 export {
   InitProgressCallback,
   InitProgressReport,
-  EngineInterface,
+  MLCEngineInterface,
   LogitProcessor,
 } from "./types";
 
 export {
-  Engine,
-  CreateEngine,
+  MLCEngine,
+  CreateMLCEngine,
 } from "./engine";
 
 export {
@@ -27,9 +27,9 @@ export {
 } from "./cache_util";
 
 export {
-  EngineWorkerHandler,
-  WebWorkerEngine,
-  CreateWebWorkerEngine
+  MLCEngineWorkerHandler,
+  WebWorkerMLCEngine,
+  CreateWebWorkerMLCEngine
 } from "./web_worker";
 
 export {
@@ -39,15 +39,15 @@ export {
 } from "./message"
 
 export {
-  ServiceWorkerEngineHandler,
-  ServiceWorkerEngine,
-  CreateServiceWorkerEngine,
+  ServiceWorkerMLCEngineHandler,
+  ServiceWorkerMLCEngine,
+  CreateServiceWorkerMLCEngine,
 } from "./service_worker";
 
 export {
-  ServiceWorkerEngineHandler as ExtensionServiceWorkerEngineHandler,
-  ServiceWorkerEngine as ExtensionServiceWorkerEngine,
-  CreateServiceWorkerEngine as CreateExtensionServiceWorkerEngine,
+  ServiceWorkerMLCEngineHandler as ExtensionServiceWorkerMLCEngineHandler,
+  ServiceWorkerMLCEngine as ExtensionServiceWorkerMLCEngine,
+  CreateServiceWorkerMLCEngine as CreateExtensionServiceWorkerMLCEngine,
 } from './extension_service_worker'
 
 export * from './openai_api_protocols/index';

--- a/src/openai_api_protocols/apis.ts
+++ b/src/openai_api_protocols/apis.ts
@@ -1,11 +1,11 @@
-import { EngineInterface } from "../types";
+import { MLCEngineInterface } from "../types";
 import { Completions } from "./chat_completion";
 
 export class Chat {
-    private engine: EngineInterface;
+    private engine: MLCEngineInterface;
     completions: Completions;
 
-    constructor(engine: EngineInterface) {
+    constructor(engine: MLCEngineInterface) {
         this.engine = engine;
         this.completions = new Completions(this.engine);
     }

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -15,14 +15,14 @@
  * limitations under the License.
 */
 
-import { EngineInterface } from "../types";
+import { MLCEngineInterface } from "../types";
 
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export class Completions {
-    private engine: EngineInterface;
+    private engine: MLCEngineInterface;
 
-    constructor(engine: EngineInterface) {
+    constructor(engine: MLCEngineInterface) {
         this.engine = engine;
     }
 
@@ -200,7 +200,7 @@ export interface ChatCompletionRequestBase {
     /**
      * Model to carry out this API.
      * 
-     * @note Not supported. Instead call `CreateEngine(model)` or `engine.reload(model)` instead.
+     * @note Not supported. Instead call `CreateMLCEngine(model)` or `engine.reload(model)` instead.
      */
     model?: string | null;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,9 +56,9 @@ export interface LogitProcessor {
 
 
 /**
- * Common interface of Engine that UI can interact with
+ * Common interface of MLCEngine that UI can interact with
  */
-export interface EngineInterface {
+export interface MLCEngineInterface {
   /**
    * An object that exposes chat-related APIs.
    */

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -1,11 +1,11 @@
 import {
   AppConfig,
   ChatOptions,
-  EngineConfig,
+  MLCEngineConfig,
   GenerationConfig,
 } from "./config";
 import {
-  EngineInterface,
+  MLCEngineInterface,
   GenerateProgressCallback,
   InitProgressCallback,
   InitProgressReport,
@@ -43,12 +43,12 @@ export interface PostMessageHandler {
  *
  * // setup a chat worker handler that routes
  * // requests to the chat
- * const engine = new Engine();
- * cont handler = new EngineWorkerHandler(engine);
+ * const engine = new MLCEngine();
+ * cont handler = new MLCEngineWorkerHandler(engine);
  * onmessage = handler.onmessage;
  */
-export class EngineWorkerHandler {
-  protected engine: EngineInterface;
+export class MLCEngineWorkerHandler {
+  protected engine: MLCEngineInterface;
   protected chatCompletionAsyncChunkGenerator?: AsyncGenerator<
     ChatCompletionChunk,
     void,
@@ -57,13 +57,13 @@ export class EngineWorkerHandler {
   protected postMessageHandler?: PostMessageHandler;
 
   /**
-   * @param engine A concrete implementation of EngineInterface
+   * @param engine A concrete implementation of MLCEngineInterface
    * @param postMessageHandler Optionally, a handler to communicate with the content script.
    *   This is only needed in ServiceWorker. In web worker, we can use `postMessage` from
    *   DOM API directly.
    */
   constructor(
-    engine: EngineInterface,
+    engine: MLCEngineInterface,
     postMessageHandler?: PostMessageHandler,
     initProgressCallback?: (report: InitProgressReport) => void
   ) {
@@ -298,44 +298,44 @@ export interface ChatWorker {
 }
 
 /**
- * Creates `WebWorkerEngine`, a client that holds the same interface as `Engine`.
+ * Creates `WebWorkerMLCEngine`, a client that holds the same interface as `MLCEngine`.
  *
- * Equivalent to `new webllm.WebWorkerEngine(worker).reload(...)`.
+ * Equivalent to `new webllm.WebWorkerMLCEngine(worker).reload(...)`.
  *
- * @param worker The worker that holds the actual Engine, intialized with `new Worker()`.
+ * @param worker The worker that holds the actual MLCEngine, intialized with `new Worker()`.
  * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
  * `engineConfig.appConfig`.
- * @param engineConfig Optionally configures the engine, see `webllm.EngineConfig` for more.
- * @returns An initialized `WebLLM.WebWorkerEngine` with `modelId` loaded.
+ * @param engineConfig Optionally configures the engine, see `webllm.MLCEngineConfig` for more.
+ * @returns An initialized `WebLLM.WebWorkerMLCEngine` with `modelId` loaded.
  *
- * @note engineConfig.logitProcessorRegistry is ignored for `CreateWebWorkEngine()`.
+ * @note engineConfig.logitProcessorRegistry is ignored for `CreateWebWorkMLCEngine()`.
  */
-export async function CreateWebWorkerEngine(
+export async function CreateWebWorkerMLCEngine(
   worker: any,
   modelId: string,
-  engineConfig?: EngineConfig
-): Promise<WebWorkerEngine> {
-  const webWorkerEngine = new WebWorkerEngine(worker);
-  webWorkerEngine.setInitProgressCallback(engineConfig?.initProgressCallback);
-  await webWorkerEngine.reload(
+  engineConfig?: MLCEngineConfig
+): Promise<WebWorkerMLCEngine> {
+  const webWorkerMLCEngine = new WebWorkerMLCEngine(worker);
+  webWorkerMLCEngine.setInitProgressCallback(engineConfig?.initProgressCallback);
+  await webWorkerMLCEngine.reload(
     modelId,
     engineConfig?.chatOpts,
     engineConfig?.appConfig
   );
-  return webWorkerEngine;
+  return webWorkerMLCEngine;
 }
 
 /**
- * A client of Engine that exposes the same interface
+ * A client of MLCEngine that exposes the same interface
  *
  * @example
  *
- * const chat = new webllm.WebWorkerEngine(new Worker(
+ * const chat = new webllm.WebWorkerMLCEngine(new Worker(
  *   new URL('./worker.ts', import.meta.url),
  *   {type: 'module'}
  * ));
  */
-export class WebWorkerEngine implements EngineInterface {
+export class WebWorkerMLCEngine implements MLCEngineInterface {
   public worker: ChatWorker;
   public chat: API.Chat;
 

--- a/tests/conv_template.test.ts
+++ b/tests/conv_template.test.ts
@@ -1,6 +1,6 @@
 import { ChatConfig, ConvTemplateConfig, Role } from '../src/config'
 import { getConversation } from '../src/conversation'
-import { Engine } from '../src/engine'
+import { MLCEngine } from '../src/engine'
 import { ChatCompletionRequest } from "../src/openai_api_protocols/chat_completion"
 
 

--- a/tests/function_calling.test.ts
+++ b/tests/function_calling.test.ts
@@ -1,6 +1,6 @@
 import { Role } from '../src/config'
 import { getConversation } from '../src/conversation'
-import { Engine } from '../src/engine'
+import { MLCEngine } from '../src/engine'
 import { ChatCompletionRequest } from "../src/openai_api_protocols/chat_completion"
 
 
@@ -41,9 +41,9 @@ describe('Test conversation template', () => {
     })
 });
 
-describe('Test Engine', () => {
+describe('Test MLCEngine', () => {
     test('Test getFunctionCallUsage none', () => {
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         const request: ChatCompletionRequest = {
             model: "gorilla-openfunctions-v1-q4f16_1_MLC",
@@ -63,7 +63,7 @@ describe('Test Engine', () => {
     });
 
     test('Test getFunctionCallUsage auto', () => {
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         const request: ChatCompletionRequest = {
             model: "gorilla-openfunctions-v1-q4f16_1_MLC",
@@ -82,7 +82,7 @@ describe('Test Engine', () => {
     });
 
     test('Test getFunctionCallUsage function', () => {
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         const request: ChatCompletionRequest = {
             model: "gorilla-openfunctions-v1-q4f16_1_MLC",

--- a/tests/multi_round_chat.test.ts
+++ b/tests/multi_round_chat.test.ts
@@ -6,7 +6,7 @@ import {
     ChatCompletionRequest,
     ChatCompletionUserMessageParam,
 } from "../src/openai_api_protocols/chat_completion";
-import { Engine } from '../src/engine';
+import { MLCEngine } from '../src/engine';
 import { Conversation, compareConversationObject } from '../src/conversation';
 import { ChatConfig, Role } from '../src/config';
 
@@ -51,7 +51,7 @@ describe('Test multi-round chatting', () => {
         // Setups
         const config_json = JSON.parse(configStr);
         const chatConfig = { ...config_json } as ChatConfig;
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         // Simulate request0
         const messages: ChatCompletionMessageParam[] = [
@@ -91,7 +91,7 @@ describe('Test multi-round chatting', () => {
         // Setups
         const config_json = JSON.parse(configStr);
         const chatConfig = { ...config_json } as ChatConfig;
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         // Simulate request0
         const messages: ChatCompletionMessageParam[] = [
@@ -136,7 +136,7 @@ describe('Test multi-round chatting', () => {
         // Setups
         const config_json = JSON.parse(configStr);
         const chatConfig = { ...config_json } as ChatConfig;
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         // Simulate request0
         const messages: ChatCompletionMessageParam[] = [
@@ -180,7 +180,7 @@ describe('Test multi-round chatting', () => {
         // Setups
         const config_json = JSON.parse(configStr);
         const chatConfig = { ...config_json } as ChatConfig;
-        const engine = new Engine();
+        const engine = new MLCEngine();
 
         // Simulate request0
         const messages: ChatCompletionMessageParam[] = [


### PR DESCRIPTION
We rename all `Engine` to `MLCEngine` to:
1. Match naming scheme in https://github.com/mlc-ai/mlc-llm
2. Better demonstrate the semantics of an `Engine`, especially when users do wildcard importing

To accommodate this breaking change, control-F `Engine` (with same capitalization) and replace with `MLCEngine` should suffice 