### PR TITLE
[ServiceWorker] Add verbose mode for debugging

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "all"
+}


### PR DESCRIPTION
Using service worker sometimes is tricky, especially when you are trying to debug an issue. This PR adds additional `debug` level logs for printing the entire event trace for easier debugging.

Broswer console in default logging level:
<img width="876" alt="Screenshot 2024-05-22 at 7 51 22 PM" src="https://github.com/mlc-ai/web-llm/assets/23090573/dfc4b477-0e5e-4bb7-abd7-773b045043f4">

Broswer console in verbose logging level:
<img width="878" alt="Screenshot 2024-05-22 at 7 51 48 PM" src="https://github.com/mlc-ai/web-llm/assets/23090573/47d085ad-a584-4ffa-890d-07ab892f1e67">
