### PR TITLE
[Log] Set log level using 'loglevel' package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@mlc-ai/web-llm",
       "version": "0.2.38",
       "license": "Apache-2.0",
+      "dependencies": {
+        "loglevel": "^1.9.1"
+      },
       "devDependencies": {
         "@mlc-ai/web-tokenizers": "^0.1.3",
         "@rollup/plugin-commonjs": "^20.0.0",
@@ -6115,6 +6118,18 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "tslib": "^2.3.1",
     "tvmjs": "file:./tvm_home/web",
     "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "loglevel": "^1.9.1"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-
+import log from "loglevel";
 import { ResponseFormat } from "./openai_api_protocols";
-import { LogitProcessor, InitProgressCallback } from "./types";
+import { LogitProcessor, InitProgressCallback, LogLevel } from "./types";
 
 /**
  * Conversation template config
@@ -25,6 +25,8 @@ export enum Role {
   user = "user",
   assistant = "assistant",
 }
+
+export const DefaultLogLevel: LogLevel = "WARN";
 
 /**
  * Place holders that can be used in role templates.
@@ -91,6 +93,7 @@ export interface MLCEngineConfig {
   appConfig?: AppConfig;
   initProgressCallback?: InitProgressCallback;
   logitProcessorRegistry?: Map<string, LogitProcessor>;
+  logLevel: LogLevel;
 }
 
 /**
@@ -167,16 +170,14 @@ export function postInitAndCheckGenerationConfigValues(
     !_hasValue(config.presence_penalty)
   ) {
     config.presence_penalty = 0.0;
-    console.log(
-      "Only frequency_penalty is set; we default presence_penaty to 0.",
-    );
+    log.warn("Only frequency_penalty is set; we default presence_penaty to 0.");
   }
   if (
     _hasValue(config.presence_penalty) &&
     !_hasValue(config.frequency_penalty)
   ) {
     config.frequency_penalty = 0.0;
-    console.log(
+    log.warn(
       "Only presence_penalty is set; we default frequency_penalty to 0.",
     );
   }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,4 +1,5 @@
 import * as tvmjs from "tvmjs";
+import log from "loglevel";
 import { Tokenizer } from "@mlc-ai/web-tokenizers";
 import * as API from "./openai_api_protocols/apis";
 import {
@@ -10,6 +11,7 @@ import {
   postInitAndCheckGenerationConfigValues,
   Role,
   MLCEngineConfig,
+  DefaultLogLevel,
 } from "./config";
 import { LLMChatPipeline } from "./llm_chat";
 import {
@@ -30,6 +32,7 @@ import {
   MLCEngineInterface,
   GenerateProgressCallback,
   LogitProcessor,
+  LogLevel,
 } from "./types";
 import {
   Conversation,
@@ -60,6 +63,7 @@ export async function CreateMLCEngine(
   modelId: string,
   engineConfig?: MLCEngineConfig,
 ): Promise<MLCEngine> {
+  log.setLevel(engineConfig?.logLevel || DefaultLogLevel);
   const engine = new MLCEngine();
   engine.setInitProgressCallback(engineConfig?.initProgressCallback);
   engine.setLogitProcessorRegistry(engineConfig?.logitProcessorRegistry);
@@ -76,7 +80,7 @@ export class MLCEngine implements MLCEngineInterface {
   public chat: API.Chat;
 
   private currentModelId?: string = undefined; // Model current loaded, undefined if nothing is loaded
-  private logger: (msg: string) => void = console.log;
+  private logger: (msg: string) => void = log.info;
   private logitProcessorRegistry?: Map<string, LogitProcessor>;
   private logitProcessor?: LogitProcessor;
   private pipeline?: LLMChatPipeline;
@@ -238,7 +242,7 @@ export class MLCEngine implements MLCEngineInterface {
     let deviceLostInReload = false;
     gpuDetectOutput.device.lost.then((info: any) => {
       if (this.deviceLostIsError) {
-        console.error(
+        log.error(
           `Device was lost during reload. This can happen due to insufficient memory or other GPU constraints. Detailed error: ${info}. Please try to reload WebLLM with a less resource-intensive model.`,
         );
         this.unload();
@@ -291,7 +295,7 @@ export class MLCEngine implements MLCEngineInterface {
     streamInterval = 1,
     genConfig?: GenerationConfig,
   ): Promise<string> {
-    console.log(
+    log.warn(
       "WARNING: `generate()` will soon be deprecated. " +
         "Please use `engine.chat.completions.create()` instead. " +
         "For multi-round chatting, see `examples/multi-round-chat` on how to use " +
@@ -579,7 +583,7 @@ export class MLCEngine implements MLCEngineInterface {
       gpuDetectOutput.device.limits.maxStorageBufferBindingSize;
     const defaultMaxStorageBufferBindingSize = 1 << 30; // 1GB
     if (maxStorageBufferBindingSize < defaultMaxStorageBufferBindingSize) {
-      console.log(
+      log.warn(
         `WARNING: the current maxStorageBufferBindingSize ` +
           `(${computeMB(maxStorageBufferBindingSize)}) ` +
           `may only work for a limited number of models, e.g.: \n` +
@@ -792,7 +796,7 @@ export class MLCEngine implements MLCEngineInterface {
         this.resetChat();
         this.getPipeline().setConversation(newConv);
       } else {
-        console.log("Multiround chatting, reuse KVCache.");
+        log.info("Multiround chatting, reuse KVCache.");
       }
 
       // 2. Treat the last message as the usual input

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -63,8 +63,8 @@ export async function CreateMLCEngine(
   modelId: string,
   engineConfig?: MLCEngineConfig,
 ): Promise<MLCEngine> {
-  log.setLevel(engineConfig?.logLevel || DefaultLogLevel);
   const engine = new MLCEngine();
+  engine.setLogLevel(engineConfig?.logLevel || DefaultLogLevel);
   engine.setInitProgressCallback(engineConfig?.initProgressCallback);
   engine.setLogitProcessorRegistry(engineConfig?.logitProcessorRegistry);
   await engine.reload(modelId, engineConfig?.chatOpts, engineConfig?.appConfig);
@@ -638,6 +638,15 @@ export class MLCEngine implements MLCEngineInterface {
    */
   async getMessage(): Promise<string> {
     return this.getPipeline().getMessage();
+  }
+
+  /**
+   * Set MLCEngine logging output level
+   *
+   * @param logLevel The new log level
+   */
+  setLogLevel(logLevel: LogLevel) {
+    log.setLevel(logLevel);
   }
 
   /**

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -140,10 +140,10 @@ export async function CreateServiceWorkerMLCEngine(
   engineConfig?: MLCEngineConfig,
   keepAliveMs = 10000,
 ): Promise<ServiceWorkerMLCEngine> {
-  const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(
-    keepAliveMs,
-    engineConfig?.logLevel,
-  );
+  const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(keepAliveMs);
+  if (engineConfig?.logLevel) {
+    serviceWorkerMLCEngine.setLogLevel(engineConfig.logLevel);
+  }
   serviceWorkerMLCEngine.setInitProgressCallback(
     engineConfig?.initProgressCallback,
   );
@@ -192,10 +192,10 @@ class PortAdapter implements ChatWorker {
 export class ServiceWorkerMLCEngine extends WebWorkerMLCEngine {
   port: chrome.runtime.Port;
 
-  constructor(keepAliveMs = 10000, logLevel: LogLevel = "WARN") {
+  constructor(keepAliveMs = 10000) {
     const port = chrome.runtime.connect({ name: "web_llm_service_worker" });
     const chatWorker = new PortAdapter(port);
-    super(chatWorker, logLevel);
+    super(chatWorker);
     this.port = port;
     setInterval(() => {
       this.keepAlive();

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   InitProgressReport,
   MLCEngineInterface,
   LogitProcessor,
+  LogLevel,
 } from "./types";
 
 export { MLCEngine, CreateMLCEngine } from "./engine";

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-prototype-builtins */
 import * as tvmjs from "tvmjs";
+import log from "loglevel";
 import { Tokenizer } from "@mlc-ai/web-tokenizers";
 import { ChatConfig, GenerationConfig, Role } from "./config";
 import { getConversation, Conversation } from "./conversation";
@@ -71,9 +72,6 @@ export class LLMChatPipeline {
   // same as `prefillTotalTokens` and `decodingTotalTokens`, but reset at every `prefillStep()`
   private curRoundDecodingTotalTokens = 0;
   private curRoundPrefillTotalTokens = 0;
-
-  // logger
-  private logger = console.log;
 
   // LogitProcessor
   private logitProcessor?: LogitProcessor = undefined;
@@ -154,7 +152,7 @@ export class LLMChatPipeline {
 
     // 4. Read in compilation configurations from metadata
     this.prefillChunkSize = metadata.prefill_chunk_size;
-    this.logger("Using prefillChunkSize: ", this.prefillChunkSize);
+    log.info("Using prefillChunkSize: ", this.prefillChunkSize);
     if (this.prefillChunkSize <= 0) {
       throw Error("Prefill chunk size needs to be positive.");
     }
@@ -164,14 +162,14 @@ export class LLMChatPipeline {
       metadata.sliding_window_size != -1
     ) {
       this.slidingWindowSize = metadata.sliding_window_size;
-      this.logger("Using slidingWindowSize: ", this.slidingWindowSize);
+      log.info("Using slidingWindowSize: ", this.slidingWindowSize);
       // Parse attention sink size
       if (
         metadata.hasOwnProperty("attention_sink_size") &&
         metadata.attention_sink_size >= 0
       ) {
         this.attentionSinkSize = metadata.attention_sink_size;
-        this.logger("Using attentionSinkSize: ", this.attentionSinkSize);
+        log.info("Using attentionSinkSize: ", this.attentionSinkSize);
       } else {
         throw Error(
           "Need to specify non-negative attention_sink_size if using sliding window. " +
@@ -184,7 +182,7 @@ export class LLMChatPipeline {
       metadata.context_window_size != -1
     ) {
       this.maxWindowLength = metadata.context_window_size;
-      this.logger("Using maxWindowLength: ", this.maxWindowLength);
+      log.info("Using maxWindowLength: ", this.maxWindowLength);
     } else {
       throw Error(
         "Need to specify either sliding window size or max window size.",
@@ -905,7 +903,7 @@ export class LLMChatPipeline {
     }
 
     // need shift window and re-encode
-    this.logger("need shift window");
+    log.info("need shift window");
     this.filledKVCacheLength = 0;
     this.resetKVCache();
 
@@ -1056,8 +1054,8 @@ export class LLMChatPipeline {
       `decoding-time=${((decodingEnd - decodingStart) / 1000).toFixed(4)} sec`;
 
     // simply log tokens for eyeballing.
-    console.log("Logits:");
-    console.log(logitsOnCPU.toArray());
-    console.log(msg);
+    log.info("Logits:");
+    log.info(logitsOnCPU.toArray());
+    log.info(msg);
   }
 }

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -206,11 +206,10 @@ export async function CreateServiceWorkerMLCEngine(
         "Please refresh the page to retry initializing the service worker.",
     );
   }
-  const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(
-    serviceWorker,
-    undefined,
-    engineConfig?.logLevel,
-  );
+  const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(serviceWorker);
+  if (engineConfig?.logLevel) {
+    serviceWorkerMLCEngine.setLogLevel(engineConfig.logLevel);
+  }
   serviceWorkerMLCEngine.setInitProgressCallback(
     engineConfig?.initProgressCallback,
   );
@@ -228,15 +227,11 @@ export async function CreateServiceWorkerMLCEngine(
 export class ServiceWorkerMLCEngine extends WebWorkerMLCEngine {
   missedHeatbeat = 0;
 
-  constructor(
-    worker: IServiceWorker,
-    keepAliveMs = 10000,
-    logLevel: LogLevel = "WARN",
-  ) {
+  constructor(worker: IServiceWorker, keepAliveMs = 10000) {
     if (!("serviceWorker" in navigator)) {
       throw new Error("Service worker API is not available");
     }
-    super(new ServiceWorker(worker), logLevel);
+    super(new ServiceWorker(worker));
     const onmessage = this.onmessage.bind(this);
 
     (navigator.serviceWorker as ServiceWorkerContainer).addEventListener(

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,21 @@ export interface MLCEngineInterface {
     inputIds: Array<number>,
     isPrefill: boolean,
   ): Promise<number>;
+
+  /**
+   * Set MLCEngine logging output level
+   *
+   * @param logLevel The new log level
+   */
+  setLogLevel(logLevel: LogLevel): void;
 }
 
-export type LogLevel = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "SILENT";
+export const LOG_LEVELS = {
+  TRACE: 0,
+  DEBUG: 1,
+  INFO: 2,
+  WARN: 3,
+  ERROR: 4,
+  SILENT: 5,
+};
+export type LogLevel = keyof typeof LOG_LEVELS;

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,3 +195,5 @@ export interface MLCEngineInterface {
     isPrefill: boolean,
   ): Promise<number>;
 }
+
+export type LogLevel = "TRACE" | "DEBUG" | "INFO" | "WARN" | "ERROR" | "SILENT";

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -9,6 +9,7 @@ import {
   GenerateProgressCallback,
   InitProgressCallback,
   InitProgressReport,
+  LogLevel,
 } from "./types";
 import {
   ChatCompletionRequest,
@@ -31,6 +32,7 @@ import {
   WorkerResponse,
   WorkerRequest,
 } from "./message";
+import log from "loglevel";
 
 export interface PostMessageHandler {
   postMessage: (message: any) => void;
@@ -348,7 +350,8 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
   >();
   private pendingPromise = new Map<string, (msg: WorkerResponse) => void>();
 
-  constructor(worker: ChatWorker) {
+  constructor(worker: ChatWorker, logLevel: LogLevel = "WARN") {
+    log.setLevel(logLevel);
     this.worker = worker;
     worker.onmessage = (event: any) => {
       this.onmessage.bind(this)(event);

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -350,8 +350,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
   >();
   private pendingPromise = new Map<string, (msg: WorkerResponse) => void>();
 
-  constructor(worker: ChatWorker, logLevel: LogLevel = "WARN") {
-    log.setLevel(logLevel);
+  constructor(worker: ChatWorker) {
     this.worker = worker;
     worker.onmessage = (event: any) => {
       this.onmessage.bind(this)(event);
@@ -626,5 +625,9 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
         );
       }
     }
+  }
+
+  setLogLevel(logLevel: LogLevel) {
+    log.setLevel(logLevel);
   }
 }


### PR DESCRIPTION
This PR introduces a new package, `logLevel`, which is a lightweight logging javascript library for managing logging levels and filtering debug logs in production.

https://github.com/pimterry/loglevel

We exposed `logLevel` as part of the engine config to allow users to modify it. The default log level is `WARN`.

In `TRACE` level:
<img width="766" alt="Screenshot 2024-05-26 at 6 45 43 PM" src="https://github.com/mlc-ai/web-llm/assets/23090573/1245d868-4848-4310-a4ed-b3097b0972cd">

In `WARN` level:
<img width="779" alt="Screenshot 2024-05-26 at 6 53 27 PM" src="https://github.com/mlc-ai/web-llm/assets/23090573/0a391d55-5d40-4199-bb2b-7c02600b2460">

