### PR TITLE
[Models] Add Phi3-mini, StableLM 1.6B, Qwen 1.8B, update MLC runtime

### DIFF
--- a/examples/json-mode/src/json_mode.ts
+++ b/examples/json-mode/src/json_mode.ts
@@ -1,37 +1,40 @@
 import * as webllm from "@mlc-ai/web-llm";
 
 function setLabel(id: string, text: string) {
-    const label = document.getElementById(id);
-    if (label == null) {
-        throw Error("Cannot find label " + id);
-    }
-    label.innerText = text;
+  const label = document.getElementById(id);
+  if (label == null) {
+    throw Error("Cannot find label " + id);
+  }
+  label.innerText = text;
 }
 
 async function main() {
-    const initProgressCallback = (report: webllm.InitProgressReport) => {
-        setLabel("init-label", report.text);
-    };
-    const selectedModel = "Llama-2-7b-chat-hf-q4f32_1";
-    const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
-        selectedModel,
-        { initProgressCallback: initProgressCallback }
-    );
+  const initProgressCallback = (report: webllm.InitProgressReport) => {
+    setLabel("init-label", report.text);
+  };
+  const selectedModel = "Llama-3-8B-Instruct-q4f32_1";
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
+    selectedModel,
+    { initProgressCallback: initProgressCallback },
+  );
 
-    const request: webllm.ChatCompletionRequest = {
-        stream: false,  // works with streaming, logprobs, top_logprobs as well
-        messages: [
-            { "role": "user", "content": "Write a short JSON file introducing yourself." }
-        ],
-        n: 2,
-        max_gen_len: 128,
-        response_format: { type: "json_object" } as webllm.ResponseFormat
-    };
+  const request: webllm.ChatCompletionRequest = {
+    stream: false, // works with streaming, logprobs, top_logprobs as well
+    messages: [
+      {
+        role: "user",
+        content: "Write a short JSON file introducing yourself.",
+      },
+    ],
+    n: 2,
+    max_gen_len: 128,
+    response_format: { type: "json_object" } as webllm.ResponseFormat,
+  };
 
-    const reply0 = await engine.chatCompletion(request);
-    console.log(reply0);
-    console.log("First reply's last choice:\n" + await engine.getMessage());
-    console.log(await engine.runtimeStatsText());
+  const reply0 = await engine.chatCompletion(request);
+  console.log(reply0);
+  console.log("First reply's last choice:\n" + (await engine.getMessage()));
+  console.log(await engine.runtimeStatsText());
 }
 
 main();

--- a/examples/json-schema/src/json_schema.ts
+++ b/examples/json-schema/src/json_schema.ts
@@ -38,8 +38,8 @@ async function simpleStructuredTextExample() {
     setLabel("init-label", report.text);
   };
   const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
-    "Llama-2-7b-chat-hf-q4f16_1",
-    { initProgressCallback: initProgressCallback }
+    "Llama-3-8B-Instruct-q4f16_1",
+    { initProgressCallback: initProgressCallback },
   );
 
   const request: webllm.ChatCompletionRequest = {
@@ -105,8 +105,8 @@ async function harryPotterExample() {
   };
 
   const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
-    "Llama-2-7b-chat-hf-q4f16_1",
-    { initProgressCallback: initProgressCallback }
+    "Llama-3-8B-Instruct-q4f16_1",
+    { initProgressCallback: initProgressCallback },
   );
 
   const request: webllm.ChatCompletionRequest = {
@@ -138,7 +138,7 @@ async function functionCallingExample() {
       Type.Object({
         arguments: Type.Any(),
         name: Type.String(),
-      })
+      }),
     ),
   });
   type T = Static<typeof T>;
@@ -170,12 +170,12 @@ async function functionCallingExample() {
     setLabel("init-label", report.text);
   };
 
-  const selectedModel = "Hermes-2-Pro-Mistral-7B-q4f16_1";
+  const selectedModel = "Hermes-2-Pro-Llama-3-8B-q4f16_1";
   const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
     {
       initProgressCallback: initProgressCallback,
-    }
+    },
   );
 
   const request: webllm.ChatCompletionRequest = {
@@ -184,12 +184,12 @@ async function functionCallingExample() {
       {
         role: "system",
         content: `You are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools: <tools> ${JSON.stringify(
-          tools
+          tools,
         )} </tools>. Do not stop calling functions until the task has been accomplished or you've reached max iteration of 10.
       Calling multiple functions at once can overload the system and increase cost so call one function at a time please.
       If you plan to continue with analysis, always call another function.
       Return a valid json object (using double quotes) in the following schema: ${JSON.stringify(
-        schema
+        schema,
       )}.`,
       },
       {

--- a/src/config.ts
+++ b/src/config.ts
@@ -43,6 +43,16 @@ export enum MessagePlaceholders {
 }
 
 /**
+ * Information about the tokenizer. Currently, only `token_postproc_method` is used to
+ * post process the token table when using grammar.
+ */
+export interface TokenizerInfo {
+  token_postproc_method: string;
+  prepend_space_in_encode: boolean;
+  strip_space_in_decode: boolean;
+}
+
+/**
  * Config of one chat model, a data structure representing `mlc-chat-config.json`.
  * This only corresponds to the chat-related fields and `tokenizer_files` of `mlc-chat-config.json`.
  * Only these fields affect the conversation in runtime.
@@ -61,9 +71,11 @@ export interface ChatConfig {
   max_gen_len: number;
   shift_fill_factor: number;
   repetition_penalty: number;
+  tokenizer_info?: TokenizerInfo;
+  token_table_postproc_method?: string; // TODO: backward compatibility, remove soon
+  // Fields shared by MLC and OpenAI APIs
   frequency_penalty: number;
   presence_penalty: number;
-  // Fields shared by MLC and OpenAI APIs
   top_p: number;
   temperature: number;
   bos_token_id?: number;
@@ -265,7 +277,7 @@ export interface AppConfig {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_34";
+export const modelVersion = "v0_2_39";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 
@@ -334,6 +346,51 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 31153.13,
       low_resource_required: false,
     },
+    // Phi3-mini-instruct
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC/resolve/main/",
+      model_id: "Phi-3-mini-4k-instruct-q4f16_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 3672.07,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC/resolve/main/",
+      model_id: "Phi-3-mini-4k-instruct-q4f32_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 5483.12,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC/resolve/main/",
+      model_id: "Phi-3-mini-4k-instruct-q4f16_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 2520.07,
+      low_resource_required: true,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC/resolve/main/",
+      model_id: "Phi-3-mini-4k-instruct-q4f32_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 3179.12,
+      low_resource_required: true,
+    },
     // Llama-2
     {
       model_url:
@@ -342,7 +399,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f32_1-ctx1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f32_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 5284.01,
       low_resource_required: false,
     },
@@ -353,7 +410,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f16_1-ctx1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f16_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 4618.52,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -442,6 +499,29 @@ export const prebuiltAppConfig: AppConfig = {
       low_resource_required: false,
       required_features: ["shader-f16"],
     },
+    // Hermes-2 Pro
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Hermes-2-Pro-Llama-3-8B-q4f16_1-MLC/resolve/main/",
+      model_id: "Hermes-2-Pro-Llama-3-8B-q4f16_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4976.13,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Hermes-2-Pro-Llama-3-8B-q4f32_1-MLC/resolve/main/",
+      model_id: "Hermes-2-Pro-Llama-3-8B-q4f32_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 6051.27,
+      low_resource_required: false,
+    },
     {
       model_url:
         "https://huggingface.co/mlc-ai/Hermes-2-Pro-Mistral-7B-q4f16_1-MLC/resolve/main/",
@@ -449,7 +529,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/Hermes-2-Pro-Mistral-7B-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
       vram_required_MB: 4033.28,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -505,6 +585,96 @@ export const prebuiltAppConfig: AppConfig = {
       low_resource_required: true,
       buffer_size_required_bytes: 262144000,
     },
+    // Qwen-1.5-1.8B
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC/resolve/main/",
+      model_id: "Qwen1.5-1.8B-Chat-q4f16_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 2404.94,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC/resolve/main/",
+      model_id: "Qwen1.5-1.8B-Chat-q4f32_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 3313.63,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC/resolve/main/",
+      model_id: "Qwen1.5-1.8B-Chat-q4f16_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 1828.94,
+      low_resource_required: true,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC/resolve/main/",
+      model_id: "Qwen1.5-1.8B-Chat-q4f32_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 2161.63,
+      low_resource_required: true,
+    },
+    // StableLM-zephyr-1.6B
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f16_1-MLC/resolve/main/",
+      model_id: "stablelm-2-zephyr-1_6b-q4f16_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 2087.66,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f32_1-MLC/resolve/main/",
+      model_id: "stablelm-2-zephyr-1_6b-q4f32_1",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 2999.33,
+      low_resource_required: false,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f16_1-MLC/resolve/main/",
+      model_id: "stablelm-2-zephyr-1_6b-q4f16_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 1511.66,
+      low_resource_required: true,
+    },
+    {
+      model_url:
+        "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f32_1-MLC/resolve/main/",
+      model_id: "stablelm-2-zephyr-1_6b-q4f32_1-1k",
+      model_lib_url:
+        modelLibURLPrefix +
+        modelVersion +
+        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 1847.33,
+      low_resource_required: true,
+    },
     // RedPajama
     {
       model_url:
@@ -513,7 +683,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx2k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 2972.09,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -525,7 +695,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx2k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 3928.09,
       low_resource_required: false,
     },
@@ -536,7 +706,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 2041.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -548,34 +718,19 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 2558.09,
       low_resource_required: true,
     },
     // Phi-2
     {
-      model_url: "https://huggingface.co/mlc-ai/phi-2-q0f16-MLC/resolve/main/",
-      model_id: "Phi2-q0f16",
-      model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q0f16-ctx2k-webgpu.wasm",
-      vram_required_MB: 11079.47,
-      low_resource_required: false,
-      required_features: ["shader-f16"],
-    },
-    {
-      model_url: "https://huggingface.co/mlc-ai/phi-2-q0f32-MLC/resolve/main/",
-      model_id: "Phi2-q0f32",
-      model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q0f32-ctx2k-webgpu.wasm",
-      vram_required_MB: 12043.48,
-      low_resource_required: false,
-    },
-    {
       model_url:
         "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC/resolve/main/",
       model_id: "Phi2-q4f16_1",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q4f16_1-ctx2k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-2-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 3053.97,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -585,7 +740,9 @@ export const prebuiltAppConfig: AppConfig = {
         "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC/resolve/main/",
       model_id: "Phi2-q4f32_1",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q4f32_1-ctx2k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-2-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 4032.48,
       low_resource_required: false,
     },
@@ -594,7 +751,9 @@ export const prebuiltAppConfig: AppConfig = {
         "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC/resolve/main/",
       model_id: "Phi2-q4f16_1-1k",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q4f16_1-ctx1k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-2-q4f16_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 2131.97,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -604,36 +763,44 @@ export const prebuiltAppConfig: AppConfig = {
         "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC/resolve/main/",
       model_id: "Phi2-q4f32_1-1k",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-2-q4f32_1-ctx1k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-2-q4f32_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 2740.48,
       low_resource_required: true,
     },
     // Phi-1.5
     {
       model_url:
-        "https://huggingface.co/mlc-ai/phi-1_5-q0f16-MLC/resolve/main/",
-      model_id: "Phi1.5-q0f16",
+        "https://huggingface.co/mlc-ai/phi-1_5-q4f16_1-MLC/resolve/main/",
+      model_id: "Phi1.5-q4f16_1",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-1_5-q0f16-ctx2k-webgpu.wasm",
-      vram_required_MB: 5818.09,
-      low_resource_required: false,
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-1_5-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 1210.09,
+      low_resource_required: true,
       required_features: ["shader-f16"],
     },
     {
       model_url:
-        "https://huggingface.co/mlc-ai/phi-1_5-q0f32-MLC/resolve/main/",
-      model_id: "Phi1.5-q0f32",
+        "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC/resolve/main/",
+      model_id: "Phi1.5-q4f32_1",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-1_5-q0f32-ctx2k-webgpu.wasm",
-      vram_required_MB: 6514.09,
-      low_resource_required: false,
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-1_5-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 1682.09,
+      low_resource_required: true,
     },
     {
       model_url:
         "https://huggingface.co/mlc-ai/phi-1_5-q4f16_1-MLC/resolve/main/",
       model_id: "Phi1.5-q4f16_1-1k",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f16_1-ctx1k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-1_5-q4f16_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 1210.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -643,33 +810,35 @@ export const prebuiltAppConfig: AppConfig = {
         "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC/resolve/main/",
       model_id: "Phi1.5-q4f32_1-1k",
       model_lib_url:
-        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f32_1-ctx1k-webgpu.wasm",
+        modelLibURLPrefix +
+        modelVersion +
+        "/phi-1_5-q4f32_1-ctx1k_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
     },
     // TinyLlama
     {
       model_url:
-        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v0.4-q0f16-MLC/resolve/main/",
-      model_id: "TinyLlama-1.1B-Chat-v0.4-q0f16",
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC/resolve/main/",
+      model_id: "TinyLlama-1.1B-Chat-v0.4-q4f16_1",
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q0f16-ctx2k-webgpu.wasm",
-      vram_required_MB: 5063.52,
-      low_resource_required: false,
+        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 697.24,
+      low_resource_required: true,
       required_features: ["shader-f16"],
     },
     {
       model_url:
-        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v0.4-q0f32-MLC/resolve/main/",
-      model_id: "TinyLlama-1.1B-Chat-v0.4-q0f32",
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v0.4-q4f32_1-MLC/resolve/main/",
+      model_id: "TinyLlama-1.1B-Chat-v0.4-q4f32_1",
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q0f32-ctx2k-webgpu.wasm",
-      vram_required_MB: 5394.53,
-      low_resource_required: false,
+        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 839.98,
+      low_resource_required: true,
     },
     {
       model_url:
@@ -678,8 +847,8 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx1k-webgpu.wasm",
-      vram_required_MB: 899.11,
+        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 675.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
     },
@@ -690,8 +859,8 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib_url:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx1k-webgpu.wasm",
-      vram_required_MB: 992.11,
+        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 795.98,
       low_resource_required: true,
     },
   ],

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -107,14 +107,14 @@ export class GrammarFactory {
    * Creates a Grammar State Matcher from a specified BNFGrammar rule and a token table.
    *
    * @param grammar A BNFGrammar used to specify the rule for the state matcher.
-   * @param tokenTable A list of all tokens in the tokenizer in the order of their ids.
+   * @param tokenTable A list of all tokens in the tokenizer in the order of their ids, post processed.
    * @param maxRollbackSteps Max rollback steps to support. Currently not supported, has to be zero.
    * @returns A Grammar state matcher
    * @note Caller needs to handle disposal of returned object.
    */
   getGrammarStateMatcherFromTokenTable(
     grammar: BNFGrammar,
-    tokenTable: string[],
+    tokenTable: tvmjs.TVMObject,
     maxRollbackSteps = 0,
   ): GrammarStateMatcher {
     if (maxRollbackSteps !== 0) {

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -26,6 +26,7 @@ export class LLMChatPipeline {
   private decoding: tvmjs.PackedFunc;
   private embed: tvmjs.PackedFunc;
   private fapplyBitmask: tvmjs.PackedFunc;
+  private fpostProcessTokenTable: tvmjs.PackedFunc;
   // Functions related to PagedKVCache
   private fclearKVCaches: tvmjs.PackedFunc;
   private fKVCacheAddSequence: tvmjs.PackedFunc;
@@ -88,11 +89,13 @@ export class LLMChatPipeline {
   // using JSON mode. We use this field to determine whether we re-initiate a GrammarStateMatcher
   // or simply reset the state during each round (i.e. during prefillStep).
   private schema?: string = undefined;
-  // A string list of tokens ordered by their token id. Once initialized, will not be reinitialized
-  // since `this.tokenizer` does not change throughout the lifetime of LLMChatPipeline.
-  private tokenTable?: string[] = undefined;
+  // A string list of tokens ordered by their token id, post-processed. Once initialized, will not
+  // be reinitialized since `this.tokenizer` does not change throughout the lifetime of LLMChatPipeline.
+  private tokenTable?: tvmjs.TVMObject = undefined;
   private bitmaskSize: number;
   private vocabSize: number;
+  // Method to post process the token for grammar; either "byte_level" or default "byte_fallback".
+  private token_postproc_method: string;
 
   constructor(
     tvm: tvmjs.Instance,
@@ -118,6 +121,22 @@ export class LLMChatPipeline {
     if (config.bos_token_id !== undefined) {
       this.bosTokenId = config.bos_token_id;
     }
+    // Set token_post_proc_method, currently mlc-chat-config.json are unstable, hence various
+    // fallback mechanisms
+    if (config.tokenizer_info !== undefined) {
+      this.token_postproc_method = config.tokenizer_info.token_postproc_method;
+    } else if (config.token_table_postproc_method !== undefined) {
+      this.token_postproc_method = config.token_table_postproc_method;
+    } else {
+      console.log(
+        "Cannot find `tokenizer_info` or `token_table_postproc_method` in `mlc-chat-config.json`, " +
+          "using default token_postproc_method `byte_fallback`.\n" +
+          "Models that should not use `byte_fallback` include: Llama3, Qwen1.5-1.8B, StableLM-zerphyr-1.6B.\n" +
+          "This field is only used for json mode.",
+      );
+      this.token_postproc_method = "byte_fallback";
+    }
+    console.log("token_postproc_method: ", this.token_postproc_method);
 
     this.device = this.tvm.webgpu();
 
@@ -135,6 +154,9 @@ export class LLMChatPipeline {
     );
     this.fapplyBitmask = this.tvm.detachFromCurrentScope(
       this.vm.getFunction("apply_bitmask_inplace"),
+    );
+    this.fpostProcessTokenTable = this.tvm.detachFromCurrentScope(
+      tvm.getGlobalFunc("mlc.PostProcessTokenTable"),
     );
 
     // 2. Get json stored in the vm's metadata function
@@ -431,7 +453,12 @@ export class LLMChatPipeline {
           this.grammarStateMatcher.dispose();
         }
         if (this.tokenTable === undefined) {
-          this.tokenTable = getTokenTableFromTokenizer(this.tokenizer);
+          const rawTokenTable = getTokenTableFromTokenizer(this.tokenizer);
+          // Post process entire table
+          this.tokenTable = this.fpostProcessTokenTable(
+            rawTokenTable,
+            this.token_postproc_method,
+          );
         }
         const grammar: BNFGrammar =
           curSchema === undefined
@@ -440,7 +467,7 @@ export class LLMChatPipeline {
         this.grammarStateMatcher = this.tvm.detachFromCurrentScope(
           this.grammarFactory.getGrammarStateMatcherFromTokenTable(
             grammar,
-            this.tokenTable,
+            this.tokenTable!,
           ),
         );
         this.schema = curSchema;
@@ -862,7 +889,10 @@ export class LLMChatPipeline {
     let prompts;
     // beginning of the conversation
     if (this.filledKVCacheLength === 0) {
-      if (this.conversation.config.system_prefix_token_ids !== undefined) {
+      if (
+        this.conversation.config.system_prefix_token_ids !== undefined &&
+        this.conversation.config.system_prefix_token_ids !== null
+      ) {
         tokens = [...this.conversation.config.system_prefix_token_ids];
       }
       prompts = this.conversation.getPromptArray();

--- a/src/support.ts
+++ b/src/support.ts
@@ -52,47 +52,6 @@ export function getTopProbs(
 }
 
 /**
- * Post-process a raw token (which may be a raw byte or contain lower one eights block) to the
- * actual token. We do this in order to conform with the tokenizers' setup.
- *
- * Follow implementation of [https://github.com/mlc-ai/mlc-llm/blob/
- * bcb9b6a33a672a70d760c9a8b03234124aab50c4/cpp/tokenizers.cc#L99]
- */
-export function postProcessToken(token: string): string {
-  // 1. The token represents a byte.
-  const charCode0 = "0".charCodeAt(0);
-  const charCode9 = "9".charCodeAt(0);
-  const charCodeA = "A".charCodeAt(0);
-  if (
-    token.length == 6 &&
-    token.substring(0, 3) === "<0x" &&
-    token.slice(-1) === ">"
-  ) {
-    let byte = 0;
-    for (let i = 0; i < 2; i++) {
-      byte *= 16;
-      const curCharCode = token.charCodeAt(3 + i);
-      if (curCharCode >= charCode0 && curCharCode <= charCode9) {
-        byte += curCharCode - charCode0;
-      } else {
-        byte += curCharCode - charCodeA + 10;
-      }
-    }
-    if (byte < 0 || byte >= 256) {
-      throw Error("Expect byte to be in range [0, 256).");
-    }
-    return String.fromCharCode(byte);
-  }
-
-  // 2. The token contains lower one eight block which means space, e.g. `▁response` in Llama-2.
-  // https://www.compart.com/en/unicode/U+2581
-  const lowerOneEighthBlock = "\u2581";
-  token = token.split(lowerOneEighthBlock).join(" ");
-
-  return token;
-}
-
-/**
  * Get the token table in the form of a string list of tokens, ordered by their token id.
  * @param tokenizer A loaded tokenizer.
  */
@@ -100,8 +59,7 @@ export function getTokenTableFromTokenizer(tokenizer: Tokenizer): string[] {
   const tokenTable: string[] = [];
   const vocabSize = tokenizer.getVocabSize();
   for (let tokenId = 0; tokenId < vocabSize; tokenId++) {
-    const token = tokenizer.idToToken(tokenId);
-    tokenTable.push(postProcessToken(token));
+    tokenTable.push(tokenizer.idToToken(tokenId));
   }
   return tokenTable;
 }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,51 +1,28 @@
-import { getTopProbs, postProcessToken } from "../src/support"
+import { getTopProbs } from "../src/support";
 
-describe('Check getTopLogprobs correctness', () => {
-    test('Correctness test 1', () => {
-        const logitsOnCPUArray = new Float32Array([0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1]);
-        const actual = getTopProbs(3, logitsOnCPUArray);
-        const expected: Array<[number, number]> = [[2, 0.3], [5, 0.2], [3, 0.16]];
-        expect(actual.length).toBe(expected.length);
-        for (let i = 0; i < actual.length; i++) {
-            expect(actual[i][0]).toBe(expected[i][0]);
-            expect(actual[i][1]).toBeCloseTo(expected[i][1], 4);
-        }
-    });
+describe("Check getTopLogprobs correctness", () => {
+  test("Correctness test 1", () => {
+    const logitsOnCPUArray = new Float32Array([
+      0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1,
+    ]);
+    const actual = getTopProbs(3, logitsOnCPUArray);
+    const expected: Array<[number, number]> = [
+      [2, 0.3],
+      [5, 0.2],
+      [3, 0.16],
+    ];
+    expect(actual.length).toBe(expected.length);
+    for (let i = 0; i < actual.length; i++) {
+      expect(actual[i][0]).toBe(expected[i][0]);
+      expect(actual[i][1]).toBeCloseTo(expected[i][1], 4);
+    }
+  });
 
-    test('Zero top_logprobs', () => {
-        const logitsOnCPUArray = new Float32Array([0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1]);
-        const topLogProbs = getTopProbs(0, logitsOnCPUArray);
-        expect(topLogProbs).toEqual([]);
-    });
-});
-
-
-describe('Check postProcessToken correctness', () => {
-    test('Token represents a byte', () => {
-        const tokens = ["<0x00>", "<0x16>", "<0xB5>", "<0x8E>", "<0xDB>", "<0xFF>"];
-        const expectedCharCode = [0, 22, 181, 142, 219, 255];
-        for (let i = 0; i < tokens.length; i++) {
-            const actual = postProcessToken(tokens[i]);
-            const expected = String.fromCharCode(expectedCharCode[i]);
-            expect(actual).toBe(expected);
-        }
-    });
-
-    test('Token contains a space', () => {
-        const tokens = ["▁response", "▁▁▁▁"];
-        const expectedString = [" response", "    "];
-        for (let i = 0; i < tokens.length; i++) {
-            const actual = postProcessToken(tokens[i]);
-            const expected = expectedString[i];
-            expect(actual).toBe(expected);
-        }
-    });
-
-    test('Regular tokens', () => {
-        const tokens = ["es", "m", "Comment", "ho"];
-        for (let i = 0; i < tokens.length; i++) {
-            const actual = postProcessToken(tokens[i]);
-            expect(actual).toBe(tokens[i]);
-        }
-    });
+  test("Zero top_logprobs", () => {
+    const logitsOnCPUArray = new Float32Array([
+      0.05, 0.15, 0.3, 0.16, 0.04, 0.2, 0.1,
+    ]);
+    const topLogProbs = getTopProbs(0, logitsOnCPUArray);
+    expect(topLogProbs).toEqual([]);
+  });
 });


### PR DESCRIPTION
This PR updates models to v0.2.39 compiled with https://github.com/mlc-ai/binary-mlc-llm-libs/pull/123

The main change is the new MLC-LLM runtime, which supports grammar (i.e. json mode) for Llama3.
- Hence we now read in field `tokenizer_info` (or deprecated `token_table_postproc_method`) from `mlc-chat-config.json` when post processing token table for Grammar
  - If neither is available, we use the default `byte_fallback`

New prebuilt models introduced:
- Phi3-mini-4k
- Hermes-2-Pro-Llama-3-8B
- Qwen1.5-1.8B
- StableLM-2-zephyr_1.6B

Updates on examples:
- json-mode and json-schema now use Llama3 to demonstrate
- Function calling inside json-schema now uses `Hermes-2-Pro-Llama-3-8B` instead of `Hermes-2-Pro-Mistral`