### PR TITLE
[Version] Bump version to 0.2.39, update prebuilt WASMs

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38",
+    "@mlc-ai/web-llm": "^0.2.39",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38",
+    "@mlc-ai/web-llm": "^0.2.39",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38",
+    "@mlc-ai/web-llm": "^0.2.39",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38"
+    "@mlc-ai/web-llm": "^0.2.39"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.38",
+      "version": "0.2.39",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.38",
+    "@mlc-ai/web-llm": "^0.2.39",
     "tvmjs": "file:./../../tvm_home/web"
   }
 }


### PR DESCRIPTION
### Changes
Main changes include:
- New prebuilt models:
  - Phi3-mini
  - StableLM-2-zephyr-1.6B
  - Qwen1.5-1.8B
  - Hermes2-Pro-Llama-3-8B to prebuilt models
- Updates on `ModelRecord` fields
  - For detail see: https://github.com/mlc-ai/web-llm/pull/435
- Update all WASMs
  - For detail see: https://github.com/mlc-ai/web-llm/pull/433
  - Update all WASMs to v0.2.39
  - Support grammar for Llama3, hence update examples/json-mode to use `Llama3` and `Hermes2-pro-Llama3-8B` for function calling in `examples/json-schema`
- Use `loglevel` package:
  - For details see https://github.com/mlc-ai/web-llm/pull/427
- Fix `index.js.map` issue for Vite
  - https://github.com/mlc-ai/web-llm/pull/420
- Enhance error handling and ServiceWorker

### TVMjs
TVMjs compiled at https://github.com/apache/tvm/commit/71f7af7985e2c883494a9aa80e0f5d12c154a990
- Main changes include: 
  - https://github.com/apache/tvm/pull/17031
  - https://github.com/apache/tvm/pull/17028
  - https://github.com/apache/tvm/pull/17021

### WASM version
- All wasms updated to 0.2.39 via https://github.com/mlc-ai/binary-mlc-llm-libs/pull/123 for new MLC-LLM runtime (mainly grammar)