### PR TITLE
Set `MLCEngineConfig.logLevel` optional in `config.ts`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ export interface MLCEngineConfig {
   appConfig?: AppConfig;
   initProgressCallback?: InitProgressCallback;
   logitProcessorRegistry?: Map<string, LogitProcessor>;
-  logLevel: LogLevel;
+  logLevel?: LogLevel;
 }
 
 /**


### PR DESCRIPTION
Follow up from #427 to prevent the following type issue introduced on `v0.2.39`:

<img width="1328" alt="image" src="https://github.com/mlc-ai/web-llm/assets/418083/3b2d028f-71af-4e77-a779-e4176225b92a">

This issue fails type-checking [[reference](https://github.com/felladrin/MiniSearch/actions/runs/9298738476/job/25591213310?pr=356)] and forces users to define the `logLevel` config.
But in fact, `logLevel` already has a default value and was intended to be an optional parameter.
This PR fixes it.