### PR TITLE
[Fix][Vite] Fix string escape in index.js.map

### DIFF
--- a/cleanup-index-js.sh
+++ b/cleanup-index-js.sh
@@ -7,14 +7,15 @@ sed -e s/"const{createRequire:createRequire}=await import('module');"//g -i .bac
 # Replace string "new (require('u' + 'rl').URL)('file:' + __filename).href" with "MLC_DUMMY_PATH"
 # This is required for building nextJS projects -- its compile time would complain about `require()`
 # See https://github.com/mlc-ai/web-llm/issues/383 and the fixing PR's description for more.
-sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\\\"MLC_DUMMY_PATH\\\""/g -i .backup lib/index.js
-sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\\\"MLC_DUMMY_PATH\\\""/g -i .backup lib/index.js.map
+sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\"MLC_DUMMY_PATH\""/g -i .backup lib/index.js
+# Replace with \"MLC_DUMMY_PATH\"
+sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/'\\\"MLC_DUMMY_PATH\\\"'/g -i .backup lib/index.js.map
 
 # Replace "import require$$3 from 'perf_hooks';" with a string "const require$$3 = "MLC_DUMMY_REQUIRE_VAR""
 # This is to prevent `perf_hooks` not found error
 # For more see https://github.com/mlc-ai/web-llm/issues/258 and https://github.com/mlc-ai/web-llm/issues/127
 sed -e s/"import require\$\$3 from 'perf_hooks';"/"const require\$\$3 = \"MLC_DUMMY_REQUIRE_VAR\""/g -i .backup lib/index.js
-# Similarly replace `const performanceNode = require(\"perf_hooks\")` with `const performanceNode = "MLC_DUMMY_REQUIRE_VAR"`
+# Similarly replace `const performanceNode = require(\"perf_hooks\")` with `const performanceNode = \"MLC_DUMMY_REQUIRE_VAR\"`
 sed -e s/'require(\\\"perf_hooks\\\")'/'\\\"MLC_DUMMY_REQUIRE_VAR\\\"'/g -i .backup lib/index.js.map
 
 # Cleanup backup files


### PR DESCRIPTION
This PR fixes `\"` issue in `index.js.map`, which breaks Vite deployment, follows the thread https://github.com/mlc-ai/web-llm/issues/414

This PR undoes the change in `cleanup-index-js.sh` to `index.js` in https://github.com/mlc-ai/web-llm/pull/420, and update `"` to `'` for `index.js.map`.