### PR TITLE
Update cleanModelUrl to support non-main branches

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -236,7 +236,11 @@ export function postInitAndCheckGenerationConfigValues(
 
 /**
  * Information for a model.
- * @param model: the huggingface link to download the model weights.
+ * @param model: the huggingface link to download the model weights, e.g.
+ *    - https://huggingface.co/mlc-ai/model
+ *    - https://huggingface.co/mlc-ai/model/
+ *    - https://huggingface.co/mlc-ai/model/resolve/main
+ *    - https://huggingface.co/mlc-ai/model/resolve/main/
  * @param model_id: what we call the model.
  * @param model_lib: link to the model library (wasm file) the model uses.
  * @param vram_required_MB: amount of vram in MB required to run the model (can use

--- a/src/support.ts
+++ b/src/support.ts
@@ -65,18 +65,14 @@ export function getTokenTableFromTokenizer(tokenizer: Tokenizer): string[] {
 }
 
 /**
- * Postprocess the suffix of ModelRecord.model to be "/resolve/main/".
+ * Postprocess the suffix of ModelRecord.model to be "/resolve/main/" if it is not specified otherwise.
  * e.g. https://huggingface.co/mlc-ai/OpenHermes-2.5-Mistral-7B-q4f16_1-MLC/resolve/main/
  * @return the href of the final URL.
  */
 export function cleanModelUrl(modelUrl: string): string {
-  if (modelUrl.endsWith("resolve/main") || modelUrl.endsWith("resolve/main/")) {
-    throw Error(
-      "Expect ModelRecord.model to not include `resolve/main` suffix.",
-    );
-  }
   // https://huggingface.co/USER/MODEL -> https://huggingface.co/USER/MODEL/
   modelUrl += modelUrl.endsWith("/") ? "" : "/";
+  if (!modelUrl.match(/.+\/resolve\/.+\//)) modelUrl += "resolve/main/"
   // https://huggingface.co/USER/MODEL/ -> https://huggingface.co/USER/MODEL/resolve/main/
-  return new URL("resolve/main/", modelUrl).href;
+  return new URL(modelUrl).href;
 }

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -28,33 +28,29 @@ describe("Check getTopLogprobs correctness", () => {
 });
 
 describe("Test clean model URL", () => {
-  test("Already have resolve/main, throw error", () => {
-    expect(() => {
-      const input = "https://huggingface.co/mlc-ai/model/resolve/main";
-      cleanModelUrl(input);
-    }).toThrow(
-      "Expect ModelRecord.model to not include `resolve/main` suffix.",
-    );
-  });
-
-  test("Already have resolve/main/, throw error", () => {
-    expect(() => {
-      const input = "https://huggingface.co/mlc-ai/model/resolve/main/";
-      cleanModelUrl(input);
-    }).toThrow(
-      "Expect ModelRecord.model to not include `resolve/main` suffix.",
-    );
-  });
-
-  test("Input does not have /", () => {
+  test("Input does not have branch or trailing /", () => {
     const input = "https://huggingface.co/mlc-ai/model";
     const output = cleanModelUrl(input);
     const expected = "https://huggingface.co/mlc-ai/model/resolve/main/";
     expect(output).toEqual(expected);
   });
 
-  test("Input has /", () => {
+  test("Input does not have branch but has trailing /", () => {
     const input = "https://huggingface.co/mlc-ai/model/";
+    const output = cleanModelUrl(input);
+    const expected = "https://huggingface.co/mlc-ai/model/resolve/main/";
+    expect(output).toEqual(expected);
+  });
+
+  test("Input has branch but does not have trailing /", () => {
+    const input = "https://huggingface.co/mlc-ai/model/resolve/main";
+    const output = cleanModelUrl(input);
+    const expected = "https://huggingface.co/mlc-ai/model/resolve/main/";
+    expect(output).toEqual(expected);
+  });
+
+  test("Input has branch and trailing /", () => {
+    const input = "https://huggingface.co/mlc-ai/model/resolve/main/";
     const output = cleanModelUrl(input);
     const expected = "https://huggingface.co/mlc-ai/model/resolve/main/";
     expect(output).toEqual(expected);


### PR DESCRIPTION
This is a small change to `cleanModelUrl` to allow for more flexibility and backwards compatibility in the modelUrl. The function will now only append "resolve/main/" if the provided URL does not already contain "resolve". Tested with the following URL formats to ensure that all work.

- https://huggingface.co/USER/MODEL
- https://huggingface.co/USER/MODEL/
- https://huggingface.co/USER/MODEL/resolve/branch
- https://huggingface.co/USER/MODEL/resolve/branch/