### PR TITLE
[type] Add signature for overloading getToolCallFromOutputMessage()

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -548,7 +548,7 @@ export class MLCEngine implements MLCEngineInterface {
         tool_calls = this.getToolCallFromOutputMessage(
           outputMessage,
           /*isStreaming=*/ false,
-        ) as Array<ChatCompletionMessageToolCall>;
+        );
       }
 
       choices.push({
@@ -822,6 +822,14 @@ export class MLCEngine implements MLCEngineInterface {
    * Expect outputMessage to be a valid JSON string, and expect it to be an array of Function with
    * fields `arguments` and `name`.
    */
+  private getToolCallFromOutputMessage(
+    outputMessage: string,
+    isStreaming: false,
+  ): Array<ChatCompletionMessageToolCall>;
+  private getToolCallFromOutputMessage(
+    outputMessage: string,
+    isStreaming: true,
+  ): Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
   private getToolCallFromOutputMessage(
     outputMessage: string,
     isStreaming: boolean,


### PR DESCRIPTION
This PR is a tiny one, updating the signature of getToolCallFromOutputMessage() function to overload it so that TypeScript can correctly inference the retrun type based on parameter automatically.