### PR TITLE
[KVCache] Add KVCache settings to ChatOptions, add overrides to ModelRecord

### DIFF
--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -16,18 +16,33 @@ async function main() {
   const selectedModel = "Llama-3-8B-Instruct-q4f32_1-MLC";
   const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
     selectedModel,
-    { initProgressCallback: initProgressCallback },
+    {
+      initProgressCallback: initProgressCallback,
+      logLevel: "INFO", // specify the log level
+      // customize kv cache, use either context_window_size or sliding_window_size (with attention sink)
+      chatOpts: {
+        context_window_size: 2048,
+        // sliding_window_size: 1024,
+        // attention_sink_size: 4,
+      },
+    },
   );
 
   // Option 2: Specify your own model other than the prebuilt ones
   // const appConfig: webllm.AppConfig = {
   //   model_list: [
   //     {
-  //       "model": "https://huggingface.co/mlc-ai/Llama-3-8B-Instruct-q4f32_1-MLC",
-  //       "model_id": "Llama-3-8B-Instruct-q4f32_1-MLC",
-  //       "model_lib": webllm.modelLibURLPrefix + webllm.modelVersion + "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+  //       model: "https://huggingface.co/mlc-ai/Llama-3-8B-Instruct-q4f32_1-MLC",
+  //       model_id: "Llama-3-8B-Instruct-q4f32_1-MLC",
+  //       model_lib:
+  //         webllm.modelLibURLPrefix +
+  //         webllm.modelVersion +
+  //         "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+  //       overrides: {
+  //         context_window_size: 2048,
+  //       },
   //     },
-  //   ]
+  //   ],
   // };
   // const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
   //   selectedModel,

--- a/src/config.ts
+++ b/src/config.ts
@@ -347,6 +347,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 6101.01,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
@@ -357,6 +360,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5001.0,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-3-70B-Instruct-q3f16_1-MLC",
@@ -367,6 +373,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-3-70B-Instruct-q3f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 31153.13,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     // Phi3-mini-instruct
     {
@@ -378,6 +387,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 3672.07,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
@@ -388,6 +400,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5483.12,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
@@ -452,6 +467,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-2-7b-chat-hf-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 9109.03,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC",
@@ -463,6 +481,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 6749.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-2-13b-chat-hf-q4f16_1-MLC",
@@ -474,6 +495,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 11814.09,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     // Mistral variants
     {
@@ -486,6 +510,10 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 6079.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
     },
     {
       model:
@@ -498,6 +526,10 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 6079.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
     },
     {
       model:
@@ -510,6 +542,10 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 6079.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
     },
     {
       model:
@@ -522,6 +558,10 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 6079.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
     },
     // Hermes-2 Pro
     {
@@ -534,6 +574,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4976.13,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model:
@@ -545,6 +588,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 6051.27,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model:
@@ -557,6 +603,10 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 4033.28,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
     },
     // Gemma-2B
     {
@@ -570,6 +620,9 @@ export const prebuiltAppConfig: AppConfig = {
       low_resource_required: false,
       buffer_size_required_bytes: 262144000,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/gemma-2b-it-q4f32_1-MLC",
@@ -581,6 +634,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 1750.66,
       low_resource_required: false,
       buffer_size_required_bytes: 262144000,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/gemma-2b-it-q4f16_1-MLC",
@@ -621,6 +677,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Qwen1.5-1.8B-Chat-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2404.94,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC",
@@ -631,6 +690,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/Qwen1.5-1.8B-Chat-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 3313.63,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC",
@@ -668,6 +730,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/stablelm-2-zephyr-1_6b-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2087.66,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f32_1-MLC",
@@ -678,6 +743,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/stablelm-2-zephyr-1_6b-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2999.33,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f16_1-MLC",
@@ -717,6 +785,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 2972.09,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model:
@@ -728,6 +799,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 3928.09,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model:
@@ -769,6 +843,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 3053.97,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC",
@@ -779,6 +856,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/phi-2-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 4032.48,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC",
@@ -818,6 +898,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 1210.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC",
@@ -828,6 +911,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/phi-1_5-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f16_1-MLC",
@@ -868,6 +954,9 @@ export const prebuiltAppConfig: AppConfig = {
       vram_required_MB: 697.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model:
@@ -879,6 +968,9 @@ export const prebuiltAppConfig: AppConfig = {
         "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 839.98,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 2048,
+      },
     },
     {
       model:

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,6 +68,10 @@ export interface ChatConfig {
   tokenizer_files: Array<string>;
   conv_config?: Partial<ConvTemplateConfig>;
   conv_template: string | ConvTemplateConfig;
+  // KVCache settings
+  context_window_size: number;
+  sliding_window_size: number;
+  attention_sink_size: number;
   // Fields below can be swapped per-generation via `GenerationConfig`
   // Fields only used in MLC
   mean_gen_len: number;
@@ -244,6 +248,7 @@ export function postInitAndCheckGenerationConfigValues(
  *    - https://huggingface.co/{USERNAME}/{MODEL}/resolve/{BRANCH}/
  * @param model_id: what we call the model.
  * @param model_lib: link to the model library (wasm file) the model uses.
+ * @param overrides: partial ChatConfig to override mlc-chat-config.json; can be used to change KVCache settings.
  * @param vram_required_MB: amount of vram in MB required to run the model (can use
  *    `utils/vram_requirements` to calculate).
  * @param low_resource_required: whether the model can run on limited devices (e.g. Android phone).
@@ -254,6 +259,7 @@ export interface ModelRecord {
   model: string;
   model_id: string;
   model_lib: string;
+  overrides?: ChatOptions;
   vram_required_MB?: number;
   low_resource_required?: boolean;
   buffer_size_required_bytes?: number;
@@ -312,9 +318,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5295.7,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-3-8B-Instruct-q4f16_1-MLC",
@@ -322,9 +331,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4598.34,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-3-8B-Instruct-q4f32_1-MLC",
@@ -383,9 +395,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2520.07,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
@@ -393,9 +408,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 3179.12,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // Llama-2
     {
@@ -404,9 +422,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5284.01,
       low_resource_required: false,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f16_1-MLC",
@@ -414,10 +435,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f16_1-ct41k_cs1k-webgpu.wasm",
       vram_required_MB: 4618.52,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Llama-2-7b-chat-hf-q4f32_1-MLC",
@@ -564,11 +588,14 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 1476.52,
       low_resource_required: true,
       buffer_size_required_bytes: 262144000,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/gemma-2b-it-q4f32_1-MLC",
@@ -576,10 +603,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 1750.66,
       low_resource_required: true,
       buffer_size_required_bytes: 262144000,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // Qwen-1.5-1.8B
     {
@@ -608,9 +638,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 1828.94,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC",
@@ -618,9 +651,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2161.63,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // StableLM-zephyr-1.6B
     {
@@ -649,9 +685,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 1511.66,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/stablelm-2-zephyr-1_6b-q4f32_1-MLC",
@@ -659,9 +698,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 1847.33,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // RedPajama
     {
@@ -694,10 +736,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2041.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model:
@@ -706,9 +751,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2558.09,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // Phi-2
     {
@@ -738,10 +786,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/phi-2-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/phi-2-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 2131.97,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC",
@@ -749,9 +800,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/phi-2-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/phi-2-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 2740.48,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // Phi-1.5
     {
@@ -781,10 +835,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/phi-1_5-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/phi-1_5-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 1210.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC",
@@ -792,9 +849,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/phi-1_5-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/phi-1_5-q4f32_1-ctx12k_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     // TinyLlama
     {
@@ -827,10 +887,13 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 675.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
     },
     {
       model:
@@ -839,9 +902,12 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 795.98,
       low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
     },
   ],
 };

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -162,6 +162,7 @@ export class MLCEngine implements MLCEngineInterface {
     const configUrl = new URL("mlc-chat-config.json", modelUrl).href;
     this.config = {
       ...(await configCache.fetchWithCache(configUrl, "json")),
+      ...modelRecord.overrides,
       ...chatOpts,
     } as ChatConfig;
 


### PR DESCRIPTION
There are three KVCache-related fields: `context_window_size`, `sliding_window_size`, and `attention_sink_size`.

Prior to this PR, we read these three fields from the WASM, because a while back these affect the model's compilation. Now these things can be changed in runtime, so we read these in from `mlc-chat-config.json`.

Thus, we add these three fields into `ChatConfig`, hence `ChatOptions`, so users can override these in `reload()`.

Alternatively, users can override these in `ModelRecord.overrides` (i.e. a "default override"). As a result, we no longer need both `ctx4k.wasm` and `ctx1k.wasm`; instead we simply add `overrides: {context_window_size: 1024}` in the model record for the `-1k` models and share the same wasm.

We first override with `overrides`, then with `chatOpts` (i.e. prioritizing `chatOpts`), since `ModelRecord.overrides` is considered as a "default override"
```typescript
    this.config = {
      ...(await configCache.fetchWithCache(configUrl, "json")),
      ...modelRecord.overrides,
      ...chatOpts,
    } as ChatConfig;
```

Usage is demonstrated in `examples/get-started`. As a result, we can use sliding window with attention sink in models like llama3.