### PR TITLE
[OpenAI] Add include_usage in streaming, add prefill decode speed to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,13 @@ const chunks = await engine.chat.completions.create({
 });
 
 let reply = "";
-let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
 for await (const chunk of chunks) {
-  reply += chunk.choices[0].delta.content || "";
-  lastChunk = chunk;
+  reply += chunk.choices[0]?.delta.content || "";
   console.log(reply);
 }
 
 const fullReply = await engine.getMessage()
 console.log(fullReply);
-console.log(lastChunk.usage);
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -180,16 +180,20 @@ const chunks = await engine.chat.completions.create({
   messages,
   temperature: 1,
   stream: true, // <-- Enable streaming
+  stream_options: { include_usage: true },
 });
 
 let reply = "";
+let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
 for await (const chunk of chunks) {
   reply += chunk.choices[0]?.delta.content || "";
   console.log(reply);
+  lastChunk = chunk;
 }
 
 const fullReply = await engine.getMessage()
 console.log(fullReply);
+console.log(lastChunk!.usage);
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ const reply = await engine.chat.completions.create({
   messages,
 });
 console.log(reply.choices[0].message);
-console.log(await engine.runtimeStatsText());
+console.log(reply.usage);
 ```
 
 ### Streaming
@@ -183,14 +183,16 @@ const chunks = await engine.chat.completions.create({
 });
 
 let reply = "";
+let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
 for await (const chunk of chunks) {
   reply += chunk.choices[0].delta.content || "";
+  lastChunk = chunk;
   console.log(reply);
 }
 
 const fullReply = await engine.getMessage()
 console.log(fullReply);
-console.log(await engine.runtimeStatsText());
+console.log(lastChunk.usage);
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -184,16 +184,16 @@ const chunks = await engine.chat.completions.create({
 });
 
 let reply = "";
-let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
 for await (const chunk of chunks) {
   reply += chunk.choices[0]?.delta.content || "";
   console.log(reply);
-  lastChunk = chunk;
+  if (chunk.usage) {
+    console.log(chunk.usage); // only last chunk has usage
+  }
 }
 
-const fullReply = await engine.getMessage()
+const fullReply = await engine.getMessage();
 console.log(fullReply);
-console.log(lastChunk!.usage);
 ```
 
 ## Advanced Usage

--- a/examples/function-calling/src/function_calling.ts
+++ b/examples/function-calling/src/function_calling.ts
@@ -55,6 +55,7 @@ async function main() {
   if (!request.stream) {
     const reply0 = await engine.chat.completions.create(request);
     console.log(reply0.choices[0]);
+    console.log(reply0.usage);
   } else {
     // If streaming, the last chunk returns tool calls
     const asyncChunkGenerator = await engine.chat.completions.create(request);
@@ -70,9 +71,8 @@ async function main() {
       lastChunk = chunk;
     }
     console.log(lastChunk!.choices[0].delta);
+    console.log(lastChunk!.usage);
   }
-
-  console.log(await engine.runtimeStatsText());
 }
 
 main();

--- a/examples/function-calling/src/function_calling.ts
+++ b/examples/function-calling/src/function_calling.ts
@@ -41,6 +41,7 @@ async function main() {
 
   const request: webllm.ChatCompletionRequest = {
     stream: true, // works with stream as well, where the last chunk returns tool_calls
+    stream_options: { include_usage: true },
     messages: [
       {
         role: "user",
@@ -61,17 +62,18 @@ async function main() {
     const asyncChunkGenerator = await engine.chat.completions.create(request);
     let message = "";
     let lastChunk: webllm.ChatCompletionChunk | undefined;
+    let usageChunk: webllm.ChatCompletionChunk | undefined;
     for await (const chunk of asyncChunkGenerator) {
       console.log(chunk);
-      if (chunk.choices[0].delta.content) {
-        // Last chunk has undefined content
-        message += chunk.choices[0].delta.content;
-      }
+      message += chunk.choices[0]?.delta?.content || "";
       setLabel("generate-label", message);
-      lastChunk = chunk;
+      if (!chunk.usage) {
+        lastChunk = chunk;
+      }
+      usageChunk = chunk;
     }
     console.log(lastChunk!.choices[0].delta);
-    console.log(lastChunk!.usage);
+    console.log(usageChunk!.usage);
   }
 }
 

--- a/examples/get-started-web-worker/src/main.ts
+++ b/examples/get-started-web-worker/src/main.ts
@@ -67,6 +67,7 @@ async function mainStreaming() {
 
   const request: webllm.ChatCompletionRequest = {
     stream: true,
+    stream_options: { include_usage: true },
     messages: [
       {
         role: "system",
@@ -87,10 +88,7 @@ async function mainStreaming() {
   let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
-    if (chunk.choices[0].delta.content) {
-      // Last chunk has undefined content
-      message += chunk.choices[0].delta.content;
-    }
+    message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
     lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well

--- a/examples/get-started-web-worker/src/main.ts
+++ b/examples/get-started-web-worker/src/main.ts
@@ -46,7 +46,7 @@ async function mainNonStreaming() {
   const reply0 = await engine.chat.completions.create(request);
   console.log(reply0);
 
-  console.log(await engine.runtimeStatsText());
+  console.log(reply0.usage);
 }
 
 /**
@@ -84,6 +84,7 @@ async function mainStreaming() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
+  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     if (chunk.choices[0].delta.content) {
@@ -91,10 +92,11 @@ async function mainStreaming() {
       message += chunk.choices[0].delta.content;
     }
     setLabel("generate-label", message);
+    lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(await engine.runtimeStatsText());
+  console.log(lastChunk!.usage);
 }
 
 // Run one of the function below

--- a/examples/get-started-web-worker/src/main.ts
+++ b/examples/get-started-web-worker/src/main.ts
@@ -85,16 +85,16 @@ async function mainStreaming() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
-  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
-    lastChunk = chunk;
+    if (chunk.usage) {
+      console.log(chunk.usage); // only last chunk has usage
+    }
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(lastChunk!.usage);
 }
 
 // Run one of the function below

--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -52,7 +52,7 @@ async function main() {
     top_logprobs: 2,
   });
   console.log(reply0);
-  console.log(await engine.runtimeStatsText());
+  console.log(reply0.usage);
 
   // To change model, either create a new engine via `CreateMLCEngine()`, or call `engine.reload(modelId)`
 }

--- a/examples/json-mode/src/json_mode.ts
+++ b/examples/json-mode/src/json_mode.ts
@@ -34,7 +34,7 @@ async function main() {
   const reply0 = await engine.chatCompletion(request);
   console.log(reply0);
   console.log("First reply's last choice:\n" + (await engine.getMessage()));
-  console.log(await engine.runtimeStatsText());
+  console.log(reply0.usage);
 }
 
 main();

--- a/examples/json-schema/src/json_schema.ts
+++ b/examples/json-schema/src/json_schema.ts
@@ -62,7 +62,7 @@ async function simpleStructuredTextExample() {
   const reply0 = await engine.chatCompletion(request);
   console.log(reply0);
   console.log("Output:\n" + (await engine.getMessage()));
-  console.log(await engine.runtimeStatsText());
+  console.log(reply0.usage);
 }
 
 // The json schema and prompt is taken from
@@ -129,7 +129,7 @@ async function harryPotterExample() {
   const reply = await engine.chatCompletion(request);
   console.log(reply);
   console.log("Output:\n" + (await engine.getMessage()));
-  console.log(await engine.runtimeStatsText());
+  console.log(reply.usage);
 }
 
 async function functionCallingExample() {
@@ -207,7 +207,7 @@ async function functionCallingExample() {
   const reply = await engine.chat.completions.create(request);
   console.log(reply.choices[0].message.content);
 
-  console.log(await engine.runtimeStatsText());
+  console.log(reply.usage);
 }
 
 async function main() {

--- a/examples/multi-round-chat/src/multi_round_chat.ts
+++ b/examples/multi-round-chat/src/multi_round_chat.ts
@@ -43,6 +43,7 @@ async function main() {
   const replyMessage0 = await engine.getMessage();
   console.log(reply0);
   console.log(replyMessage0);
+  console.log(reply0.usage);
 
   // Round 1
   // Append generated response to messages
@@ -62,6 +63,7 @@ async function main() {
   const replyMessage1 = await engine.getMessage();
   console.log(reply1);
   console.log(replyMessage1);
+  console.log(reply1.usage);
 
   // If we used multiround chat, request1 should only prefill a small number of tokens
   const prefillTokens0 = reply0.usage?.prompt_tokens;
@@ -75,8 +77,6 @@ async function main() {
   ) {
     throw Error("Multi-round chat is not triggered as expected.");
   }
-
-  console.log(await engine.runtimeStatsText());
 }
 
 main();

--- a/examples/seed-to-reproduce/src/seed.ts
+++ b/examples/seed-to-reproduce/src/seed.ts
@@ -38,6 +38,7 @@ async function main() {
   const reply0 = await engine.chat.completions.create(request);
   console.log(reply0);
   console.log("First reply's last choice:\n" + (await engine.getMessage()));
+  console.log(reply0.usage);
 
   const reply1 = await engine.chat.completions.create(request);
   console.log(reply1);
@@ -56,7 +57,7 @@ async function main() {
     }
   }
 
-  console.log(await engine.runtimeStatsText());
+  console.log(reply1.usage);
 }
 
 // Run one of the functions

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -102,16 +102,16 @@ async function mainStreaming() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
-  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
-    lastChunk = chunk;
+    if (chunk.usage) {
+      console.log(chunk.usage); // only last chunk has usage
+    }
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(lastChunk!.usage);
 }
 
 registerServiceWorker();

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -65,7 +65,7 @@ async function mainNonStreaming() {
   console.log(reply0);
   setLabel("generate-label", reply0.choices[0].message.content || "");
 
-  console.log(await engine.runtimeStatsText());
+  console.log(reply0.usage);
 }
 
 /**
@@ -101,6 +101,7 @@ async function mainStreaming() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
+  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     if (chunk.choices[0].delta.content) {
@@ -108,10 +109,11 @@ async function mainStreaming() {
       message += chunk.choices[0].delta.content;
     }
     setLabel("generate-label", message);
+    lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(await engine.runtimeStatsText());
+  console.log(lastChunk!.usage);
 }
 
 registerServiceWorker();

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -84,6 +84,7 @@ async function mainStreaming() {
 
   const request: webllm.ChatCompletionRequest = {
     stream: true,
+    stream_options: { include_usage: true },
     messages: [
       {
         role: "system",
@@ -104,10 +105,7 @@ async function mainStreaming() {
   let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
-    if (chunk.choices[0].delta.content) {
-      // Last chunk has undefined content
-      message += chunk.choices[0].delta.content;
-    }
+    message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
     lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well

--- a/examples/streaming/src/streaming.ts
+++ b/examples/streaming/src/streaming.ts
@@ -23,6 +23,7 @@ async function main() {
 
   const request: webllm.ChatCompletionRequest = {
     stream: true,
+    stream_options: { include_usage: true },
     messages: [
       {
         role: "system",
@@ -40,19 +41,13 @@ async function main() {
   let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
-    if (chunk.choices[0].delta.content) {
-      // Last chunk has undefined content
-      message += chunk.choices[0].delta.content;
-    }
+    message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
     lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  if (lastChunk?.usage) {
-    // If streaming finished before ending, we would not have usage.
-    console.log(lastChunk.usage);
-  }
+  console.log(lastChunk!.usage);
 }
 
 main();

--- a/examples/streaming/src/streaming.ts
+++ b/examples/streaming/src/streaming.ts
@@ -37,6 +37,7 @@ async function main() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
+  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     if (chunk.choices[0].delta.content) {
@@ -44,10 +45,14 @@ async function main() {
       message += chunk.choices[0].delta.content;
     }
     setLabel("generate-label", message);
+    lastChunk = chunk;
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(await engine.runtimeStatsText());
+  if (lastChunk?.usage) {
+    // If streaming finished before ending, we would not have usage.
+    console.log(lastChunk.usage);
+  }
 }
 
 main();

--- a/examples/streaming/src/streaming.ts
+++ b/examples/streaming/src/streaming.ts
@@ -38,16 +38,16 @@ async function main() {
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);
   let message = "";
-  let lastChunk: webllm.ChatCompletionChunk | undefined = undefined;
   for await (const chunk of asyncChunkGenerator) {
     console.log(chunk);
     message += chunk.choices[0]?.delta?.content || "";
     setLabel("generate-label", message);
-    lastChunk = chunk;
+    if (chunk.usage) {
+      console.log(chunk.usage); // only last chunk has usage
+    }
     // engine.interruptGenerate();  // works with interrupt as well
   }
   console.log("Final message:\n", await engine.getMessage()); // the concatenated message
-  console.log(lastChunk!.usage);
 }
 
 main();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -446,14 +446,6 @@ export class MLCEngine implements MLCEngineInterface {
       ) as Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
     }
 
-    const completion_tokens =
-      this.getPipeline().getCurRoundDecodingTotalTokens();
-    const prompt_tokens = this.getPipeline().getCurRoundPrefillTotalTokens();
-    const prefill_tokens_per_s =
-      this.getPipeline().getCurRoundPrefillTokensPerSec();
-    const decode_tokens_per_s =
-      this.getPipeline().getCurRoundDecodingTokensPerSec();
-
     const lastChunk: ChatCompletionChunk = {
       id: id,
       choices: [
@@ -475,6 +467,13 @@ export class MLCEngine implements MLCEngineInterface {
     yield lastChunk;
 
     if (request.stream_options?.include_usage) {
+      const completion_tokens =
+        this.getPipeline().getCurRoundDecodingTotalTokens();
+      const prompt_tokens = this.getPipeline().getCurRoundPrefillTotalTokens();
+      const prefill_tokens_per_s =
+        this.getPipeline().getCurRoundPrefillTokensPerSec();
+      const decode_tokens_per_s =
+        this.getPipeline().getCurRoundDecodingTokensPerSec();
       const usageChunk: ChatCompletionChunk = {
         id: id,
         choices: [],

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -471,15 +471,28 @@ export class MLCEngine implements MLCEngineInterface {
       model: model,
       object: "chat.completion.chunk",
       created: created,
-      usage: {
-        completion_tokens: completion_tokens,
-        prompt_tokens: prompt_tokens,
-        total_tokens: completion_tokens + prompt_tokens,
-        prefill_tokens_per_s: prefill_tokens_per_s,
-        decode_tokens_per_s: decode_tokens_per_s,
-      } as CompletionUsage,
     };
     yield lastChunk;
+
+    if (request.stream_options?.include_usage) {
+      const usageChunk: ChatCompletionChunk = {
+        id: id,
+        choices: [],
+        usage: {
+          completion_tokens: completion_tokens,
+          prompt_tokens: prompt_tokens,
+          total_tokens: completion_tokens + prompt_tokens,
+          extra: {
+            prefill_tokens_per_s: prefill_tokens_per_s,
+            decode_tokens_per_s: decode_tokens_per_s,
+          },
+        } as CompletionUsage,
+        model: model,
+        object: "chat.completion.chunk",
+        created: created,
+      };
+      yield usageChunk;
+    }
   }
 
   /**
@@ -603,8 +616,10 @@ export class MLCEngine implements MLCEngineInterface {
         completion_tokens: completion_tokens,
         prompt_tokens: prompt_tokens,
         total_tokens: completion_tokens + prompt_tokens,
-        prefill_tokens_per_s: prompt_tokens / prefill_time,
-        decode_tokens_per_s: completion_tokens / decode_time,
+        extra: {
+          prefill_tokens_per_s: prompt_tokens / prefill_time,
+          decode_tokens_per_s: completion_tokens / decode_time,
+        },
       } as CompletionUsage,
     };
 

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -70,9 +70,11 @@ export class LLMChatPipeline {
   private decodingTotalTokens = 0;
   private prefillTotalTime = 0;
   private prefillTotalTokens = 0;
-  // same as `prefillTotalTokens` and `decodingTotalTokens`, but reset at every `prefillStep()`
+  // same stats as above, but reset at every `prefillStep()`
   private curRoundDecodingTotalTokens = 0;
   private curRoundPrefillTotalTokens = 0;
+  private curRoundDecodingTotalTime = 0;
+  private curRoundPrefillTotalTime = 0;
 
   // LogitProcessor
   private logitProcessor?: LogitProcessor = undefined;
@@ -357,6 +359,20 @@ export class LLMChatPipeline {
   }
 
   /**
+   * @returns the time spent on decode for a single request or a single choice in the request.
+   */
+  getCurRoundDecodingTotalTime(): number {
+    return this.curRoundDecodingTotalTime;
+  }
+
+  /**
+   * @returns the time spent on  for a single request or a single choice in the request.
+   */
+  getCurRoundPrefillTotalTime(): number {
+    return this.curRoundPrefillTotalTime;
+  }
+
+  /**
    * @returns Runtime stats information.
    */
   runtimeStatsText(): string {
@@ -364,6 +380,30 @@ export class LLMChatPipeline {
       `prefill: ${(this.prefillTotalTokens / this.prefillTotalTime).toFixed(4)} tokens/sec, ` +
       `decoding: ${(this.decodingTotalTokens / this.decodingTotalTime).toFixed(4)} tokens/sec`
     );
+  }
+
+  /**
+   * @returns Runtime stats information, starting from the last prefill performed.
+   */
+  curRoundRuntimeStatsText(): string {
+    return (
+      `prefill: ${this.getCurRoundPrefillTokensPerSec().toFixed(4)} tokens/sec, ` +
+      `decoding: ${this.getCurRoundDecodingTokensPerSec().toFixed(4)} tokens/sec`
+    );
+  }
+
+  /**
+   * @returns Prefill tokens per second, starting from the last prefill performed.
+   */
+  getCurRoundPrefillTokensPerSec(): number {
+    return this.curRoundPrefillTotalTokens / this.curRoundPrefillTotalTime;
+  }
+
+  /**
+   * @returns Prefill tokens per second, starting from the last prefill performed.
+   */
+  getCurRoundDecodingTokensPerSec(): number {
+    return this.curRoundDecodingTotalTokens / this.curRoundDecodingTotalTime;
   }
 
   /**
@@ -411,6 +451,8 @@ export class LLMChatPipeline {
     this.tokenLogprobArray = [];
     this.curRoundDecodingTotalTokens = 0;
     this.curRoundPrefillTotalTokens = 0;
+    this.curRoundPrefillTotalTime = 0;
+    this.curRoundDecodingTotalTime = 0;
     this.stopTriggered = false;
     const conversation = this.conversation;
 
@@ -481,6 +523,7 @@ export class LLMChatPipeline {
     this.prefillTotalTime += (tend - tstart) / 1e3;
     this.prefillTotalTokens += promptTokens.length;
     this.curRoundPrefillTotalTokens += promptTokens.length;
+    this.curRoundPrefillTotalTime += (tend - tstart) / 1e3;
 
     this.processNextToken(nextToken, genConfig);
   }
@@ -508,6 +551,7 @@ export class LLMChatPipeline {
     this.decodingTotalTime += (tend - tstart) / 1e3;
     this.decodingTotalTokens += 1;
     this.curRoundDecodingTotalTokens += 1;
+    this.curRoundDecodingTotalTime += (tend - tstart) / 1e3;
 
     this.processNextToken(nextToken, genConfig);
   }
@@ -991,10 +1035,12 @@ export class LLMChatPipeline {
       this.prefillTotalTime += (tend - tstart) / 1e3;
       this.prefillTotalTokens += inputIds.length;
       this.curRoundPrefillTotalTokens += inputIds.length;
+      this.curRoundPrefillTotalTime += (tend - tstart) / 1e3;
     } else {
       this.decodingTotalTime += (tend - tstart) / 1e3;
       this.decodingTotalTokens += 1;
       this.curRoundDecodingTotalTokens += 1;
+      this.curRoundDecodingTotalTime += (tend - tstart) / 1e3;
     }
     return nextToken;
   }

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -469,7 +469,7 @@ export function postInitAndCheckFields(
   }
 
   // 8. Only set stream_options when streaming
-  if (request.stream_options !== undefined && request.tools !== null) {
+  if (request.stream_options !== undefined && request.stream_options !== null) {
     if (!request.stream) {
       throw new Error("Only specify stream_options when stream=True.");
     }

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -62,9 +62,14 @@ export interface ChatCompletionRequestBase {
   messages: Array<ChatCompletionMessageParam>;
 
   /**
-   * If set, partial message deltas will be sent.
+   * If set, partial message deltas will be sent. It will be terminated by an empty chunk.
    */
   stream?: boolean | null;
+
+  /**
+   * Options for streaming response. Only set this when you set `stream: true`.
+   */
+  stream_options?: ChatCompletionStreamOptions | null;
 
   /**
    * How many chat completion choices to generate for each input message.
@@ -218,7 +223,7 @@ export interface ChatCompletionRequestBase {
 export interface ChatCompletionRequestNonStreaming
   extends ChatCompletionRequestBase {
   /**
-   * If set, partial message deltas will be sent.
+   * If set, partial message deltas will be sent. It will be terminated by an empty chunk.
    */
   stream?: false | null;
 }
@@ -226,7 +231,7 @@ export interface ChatCompletionRequestNonStreaming
 export interface ChatCompletionRequestStreaming
   extends ChatCompletionRequestBase {
   /**
-   * If set, partial message deltas will be sent.
+   * If set, partial message deltas will be sent. It will be terminated by an empty chunk.
    */
   stream: true;
 }
@@ -295,8 +300,9 @@ export interface ChatCompletionChunk {
   id: string;
 
   /**
-   * A list of chat completion choices. Can be more than one if `n` is greater
-   * than 1.
+   * A list of chat completion choices. Can contain more than one elements if `n` is
+   * greater than 1. Can also be empty for the last chunk if you set
+   * `stream_options: {"include_usage": true}`.
    */
   choices: Array<ChatCompletionChunk.Choice>;
 
@@ -326,7 +332,9 @@ export interface ChatCompletionChunk {
   system_fingerprint?: string;
 
   /**
-   * It contains a null value except for the last chunk which contains the token usage
+   * An optional field that will only be present when you set
+   * `stream_options: {"include_usage": true}` in your request. When present, it
+   * contains a null value except for the last chunk which contains the token usage
    * statistics for the entire request.
    */
   usage?: CompletionUsage;
@@ -459,6 +467,13 @@ export function postInitAndCheckFields(
       } as ChatCompletionSystemMessageParam);
     }
   }
+
+  // 8. Only set stream_options when streaming
+  if (request.stream_options !== undefined && request.tools !== null) {
+    if (!request.stream) {
+      throw new Error("Only specify stream_options when stream=True.");
+    }
+  }
 }
 
 //////////////// BELOW ARE INTERFACES THAT SUPPORT THE ONES ABOVE ////////////////
@@ -554,6 +569,19 @@ export type ChatCompletionRole =
   | "assistant"
   | "tool"
   | "function";
+
+/**
+ * Options for streaming response. Only set this when you set `stream: true`.
+ */
+export interface ChatCompletionStreamOptions {
+  /**
+   * If set, an additional chunk will be streamed after the last empty chunk.
+   * The `usage` field on this chunk shows the token usage statistics for the entire
+   * request, and the `choices` field will always be an empty array. All other chunks
+   * will also include a `usage` field, but with a null value.
+   */
+  include_usage?: boolean;
+}
 
 export interface ChatCompletionSystemMessageParam {
   /**
@@ -820,14 +848,19 @@ export interface CompletionUsage {
   total_tokens: number;
 
   /**
-   * Number of tokens per second for prefilling.
+   * Fields specific to WebLLM, not present in OpenAI.
    */
-  prefill_tokens_per_s: number;
+  extra: {
+    /**
+     * Number of tokens per second for prefilling.
+     */
+    prefill_tokens_per_s: number;
 
-  /**
-   * Number of tokens per second for autoregressive decoding.
-   */
-  decode_tokens_per_s: number;
+    /**
+     * Number of tokens per second for autoregressive decoding.
+     */
+    decode_tokens_per_s: number;
+  };
 }
 
 /**

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -324,6 +324,12 @@ export interface ChatCompletionChunk {
    * @note Not supported yet.
    */
   system_fingerprint?: string;
+
+  /**
+   * It contains a null value except for the last chunk which contains the token usage
+   * statistics for the entire request.
+   */
+  usage?: CompletionUsage;
 }
 
 export const ChatCompletionRequestUnsupportedFields: Array<string> = ["model"];
@@ -812,6 +818,16 @@ export interface CompletionUsage {
    * Total number of tokens used in the request (prompt + completion).
    */
   total_tokens: number;
+
+  /**
+   * Number of tokens per second for prefilling.
+   */
+  prefill_tokens_per_s: number;
+
+  /**
+   * Number of tokens per second for autoregressive decoding.
+   */
+  decode_tokens_per_s: number;
 }
 
 /**

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -11,6 +11,27 @@ import { MessagePlaceholders } from "../src/config";
 import { describe, expect, test } from "@jest/globals";
 
 describe("Check chat completion unsupported requests", () => {
+  test("stream_options without stream specified", () => {
+    expect(() => {
+      const request: ChatCompletionRequest = {
+        messages: [{ role: "user", content: "Hello! " }],
+        stream_options: { include_usage: true },
+      };
+      postInitAndCheckFields(request, "Llama-3-8B-Instruct-q4f32_1-MLC");
+    }).toThrow("Only specify stream_options when stream=True.");
+  });
+
+  test("stream_options with stream=false", () => {
+    expect(() => {
+      const request: ChatCompletionRequest = {
+        stream: false,
+        messages: [{ role: "user", content: "Hello! " }],
+        stream_options: { include_usage: true },
+      };
+      postInitAndCheckFields(request, "Llama-3-8B-Instruct-q4f32_1-MLC");
+    }).toThrow("Only specify stream_options when stream=True.");
+  });
+
   test("High-level unsupported fields", () => {
     expect(() => {
       const request: ChatCompletionRequest = {


### PR DESCRIPTION
This change is not breaking. Behavior only changes when `stream_options: {include_usage: True}` is set for streaming, during which we yield another chunk with empty `choices` after the last chunk. 

Also include `prefill_tokens_per_s` and `decode_tokens_per_s` for `usage` in both streaming and non-streaming, hence replacing the previous usage of `runtimeStatsText()`.