### PR TITLE
[OpenAI] Handle exceeding context window size, rename max_gen_len to max_tokens

### DIFF
--- a/examples/get-started-web-worker/src/main.ts
+++ b/examples/get-started-web-worker/src/main.ts
@@ -40,7 +40,7 @@ async function mainNonStreaming() {
     ],
     n: 3,
     temperature: 1.5,
-    max_gen_len: 256,
+    max_tokens: 256,
   };
 
   const reply0 = await engine.chat.completions.create(request);
@@ -79,7 +79,7 @@ async function mainStreaming() {
       { role: "user", content: "Two more please!" },
     ],
     temperature: 1.5,
-    max_gen_len: 256,
+    max_tokens: 256,
   };
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);

--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -54,7 +54,7 @@ async function main() {
     // below configurations are all optional
     n: 3,
     temperature: 1.5,
-    max_gen_len: 256,
+    max_tokens: 256,
     // 46510 and 7188 are "California", and 8421 and 51325 are "Texas" in Llama-3-8B-Instruct
     // So we would have a higher chance of seeing the latter two, but never the first in the answer
     logit_bias: {

--- a/examples/json-mode/src/json_mode.ts
+++ b/examples/json-mode/src/json_mode.ts
@@ -27,7 +27,7 @@ async function main() {
       },
     ],
     n: 2,
-    max_gen_len: 128,
+    max_tokens: 128,
     response_format: { type: "json_object" } as webllm.ResponseFormat,
   };
 

--- a/examples/json-schema/src/json_schema.ts
+++ b/examples/json-schema/src/json_schema.ts
@@ -52,7 +52,7 @@ async function simpleStructuredTextExample() {
           "boolean field named is_accepted, and a float field named num.",
       },
     ],
-    max_gen_len: 128,
+    max_tokens: 128,
     response_format: {
       type: "json_object",
       schema: schema2,
@@ -119,7 +119,7 @@ async function harryPotterExample() {
           "Name is a string of character name. House is one of Gryffindor, Hufflepuff, Ravenclaw, Slytherin. Blood status is one of Pure-blood, Half-blood, Muggle-born. Occupation is one of Student, Professor, Ministry of Magic, Other. Wand is an object with wood, core, and length. Alive is a boolean. Patronus is a string.",
       },
     ],
-    max_gen_len: 128,
+    max_tokens: 128,
     response_format: {
       type: "json_object",
       schema: schema,

--- a/examples/seed-to-reproduce/src/seed.ts
+++ b/examples/seed-to-reproduce/src/seed.ts
@@ -31,7 +31,7 @@ async function main() {
     ],
     n: 3,
     temperature: 1.2, // high temperature gives much more random results
-    max_gen_len: 128, // To save time; enough to demonstrate the effect
+    max_tokens: 128, // To save time; enough to demonstrate the effect
     seed: 42,
   };
 

--- a/examples/service-worker/src/main.ts
+++ b/examples/service-worker/src/main.ts
@@ -58,7 +58,7 @@ async function mainNonStreaming() {
     ],
     n: 3,
     temperature: 1.5,
-    max_gen_len: 256,
+    max_tokens: 256,
   };
 
   const reply0 = await engine.chat.completions.create(request);
@@ -96,7 +96,7 @@ async function mainStreaming() {
       { role: "user", content: "Two more please!" },
     ],
     temperature: 1.5,
-    max_gen_len: 256,
+    max_tokens: 256,
   };
 
   const asyncChunkGenerator = await engine.chat.completions.create(request);

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,9 +74,7 @@ export interface ChatConfig {
   attention_sink_size: number;
   // Fields below can be swapped per-generation via `GenerationConfig`
   // Fields only used in MLC
-  mean_gen_len: number;
   max_gen_len: number;
-  shift_fill_factor: number;
   repetition_penalty: number;
   tokenizer_info?: TokenizerInfo;
   token_table_postproc_method?: string; // TODO: backward compatibility, remove soon
@@ -123,8 +121,6 @@ export interface MLCEngineConfig {
  */
 export interface GenerationConfig {
   // Only used in MLC
-  mean_gen_len?: number;
-  shift_fill_factor?: number;
   repetition_penalty?: number;
   // Shared by MLC and OpenAI APIs
   top_p?: number | null;
@@ -165,15 +161,6 @@ export function postInitAndCheckGenerationConfigValues(
   }
   if (_hasValue(config.max_gen_len) && config.max_gen_len! <= 0) {
     throw new Error("`max_gen_len` should be greater than zero.");
-  }
-  if (_hasValue(config.mean_gen_len) && config.mean_gen_len! <= 0) {
-    throw new Error("`mean_gen_len` should be greater than zero.");
-  }
-  if (
-    (_hasValue(config.shift_fill_factor) && config.shift_fill_factor! <= 0) ||
-    config.shift_fill_factor! > 1
-  ) {
-    throw new Error("Make sure 0 < `shift_fill_factor` <= 1.");
   }
   if ((_hasValue(config.top_p) && config.top_p! <= 0) || config.top_p! > 1) {
     throw new Error("Make sure 0 < `top_p` <= 1.");

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,7 +74,6 @@ export interface ChatConfig {
   attention_sink_size: number;
   // Fields below can be swapped per-generation via `GenerationConfig`
   // Fields only used in MLC
-  max_gen_len: number;
   repetition_penalty: number;
   tokenizer_info?: TokenizerInfo;
   token_table_postproc_method?: string; // TODO: backward compatibility, remove soon
@@ -125,8 +124,8 @@ export interface GenerationConfig {
   // Shared by MLC and OpenAI APIs
   top_p?: number | null;
   temperature?: number | null;
-  max_gen_len?: number | null;
   // Only in OpenAI APIs
+  max_tokens?: number | null;
   frequency_penalty?: number | null;
   presence_penalty?: number | null;
   stop?: string | null | Array<string>;
@@ -159,8 +158,8 @@ export function postInitAndCheckGenerationConfigValues(
   if (_hasValue(config.repetition_penalty) && config.repetition_penalty! <= 0) {
     throw new Error("Make sure `repetition_penalty` > 0.");
   }
-  if (_hasValue(config.max_gen_len) && config.max_gen_len! <= 0) {
-    throw new Error("`max_gen_len` should be greater than zero.");
+  if (_hasValue(config.max_tokens) && config.max_tokens! <= 0) {
+    throw new Error("`max_tokens` should be greater than zero.");
   }
   if ((_hasValue(config.top_p) && config.top_p! <= 0) || config.top_p! > 1) {
     throw new Error("Make sure 0 < `top_p` <= 1.");

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -499,7 +499,7 @@ export class MLCEngine implements MLCEngineInterface {
     const genConfig: GenerationConfig = {
       frequency_penalty: request.frequency_penalty,
       presence_penalty: request.presence_penalty,
-      max_gen_len: request.max_gen_len,
+      max_tokens: request.max_tokens,
       stop: request.stop,
       top_p: request.top_p,
       temperature: request.temperature,

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -420,7 +420,7 @@ export class LLMChatPipeline {
     // initialize
     conversation.appendMessage(Role.user, inp, inp_role_str);
     conversation.appendReplyHeader(Role.assistant);
-    const promptTokens = this.getInputTokens(genConfig);
+    const promptTokens = this.getInputTokens();
 
     const tstart = performance.now();
     this.tvm.beginScope();
@@ -589,6 +589,17 @@ export class LLMChatPipeline {
     if (this.outputIds.length >= max_gen_len) {
       this.stopTriggered = true;
       this.finishReason = "length";
+      log.info("Generation stop due to exceeding max_gen_len.");
+    }
+
+    // Stop condition 4: exceed KVCache's context window size
+    if (
+      this.slidingWindowSize == -1 &&
+      this.filledKVCacheLength == this.contextWindowSize
+    ) {
+      this.stopTriggered = true;
+      this.finishReason = "length";
+      log.info("Generation stop due to exceeding context_window_size.");
     }
 
     // Finally, modify conversation history if stopped
@@ -860,34 +871,9 @@ export class LLMChatPipeline {
     return sampledToken;
   }
 
-  private getInputTokens(genConfig?: GenerationConfig): Array<number> {
-    // Get mean_gen_len and max_gen_len, possibly overridden by genConfig
-    let mean_gen_len = this.config.mean_gen_len;
-    let shift_fill_factor = this.config.shift_fill_factor;
-    if (genConfig !== undefined) {
-      if (
-        genConfig.mean_gen_len !== undefined &&
-        genConfig.mean_gen_len !== null
-      ) {
-        mean_gen_len = genConfig.mean_gen_len;
-      }
-      if (
-        genConfig.shift_fill_factor !== undefined &&
-        genConfig.shift_fill_factor !== null
-      ) {
-        shift_fill_factor = genConfig.shift_fill_factor;
-      }
-    }
-    // Check range validity
-    if (shift_fill_factor <= 0 || shift_fill_factor > 1) {
-      throw new Error("Make sure 0 < `shift_fill_factor` <= 1.");
-    }
-    if (mean_gen_len <= 0) {
-      throw new Error("`mean_gen_len` should be greater than zero.");
-    }
-
+  private getInputTokens(): Array<number> {
     let tokens: Array<number> = [];
-    let prompts;
+    let prompts: string[];
     // beginning of the conversation
     if (this.filledKVCacheLength === 0) {
       if (
@@ -900,74 +886,28 @@ export class LLMChatPipeline {
     } else {
       prompts = this.conversation.getPrompArrayLastRound();
     }
-    // keep system prompt when possible
-    tokens.push(...this.tokenizer.encode(prompts[0]));
 
-    let ctxLength = tokens.length;
-    let context = [];
-
-    // detect if we go out of the range
-    let needShiftWindow = false;
-    for (let i = prompts.length - 1; i > 0; --i) {
+    // Encode all prompts
+    let numPromptTokens = 0;
+    for (let i = 0; i < prompts.length; i++) {
       const encoded = this.tokenizer.encode(prompts[i]);
-      ctxLength += encoded.length;
-      if (
-        this.slidingWindowSize == -1 && // There is no contextWindowSize if we use sliding window
-        this.filledKVCacheLength + ctxLength + mean_gen_len >=
-          this.contextWindowSize
-      ) {
-        needShiftWindow = true;
-        break;
-      }
-      context.unshift(encoded);
+      numPromptTokens += encoded.length;
+      tokens.push(...encoded);
     }
-    if (!needShiftWindow) {
-      for (const ctx of context) {
-        tokens.push(...ctx);
-      }
-      return tokens;
-    }
-
-    // Code starting below should not be reached when using sliding window.
-    if (this.slidingWindowSize != -1) {
-      throw Error(
-        "Should not shift window when using sliding window attention.",
+    // Check if input tokens exceed context window size
+    if (
+      this.slidingWindowSize == -1 && // There is no limit on contextWindowSize for sliding window
+      numPromptTokens + this.filledKVCacheLength > this.contextWindowSize
+    ) {
+      throw new Error(
+        "Prompt tokens exceed context window size:" +
+          " number of prompt tokens: " +
+          numPromptTokens +
+          "; context window size: " +
+          this.contextWindowSize +
+          "\nConsider shortening the prompt, or increase `context_window_size`, or " +
+          "using sliding window via `sliding_window_size`.",
       );
-    }
-
-    // need shift window and re-encode
-    log.info("need shift window");
-    this.filledKVCacheLength = 0;
-    this.resetKVCache();
-
-    // abandon all tokens we collected
-    if (this.conversation.config.system_prefix_token_ids !== undefined) {
-      tokens = [...this.conversation.config.system_prefix_token_ids];
-    } else {
-      tokens = [];
-    }
-
-    const all_prompts = this.conversation.getPromptArray();
-    tokens.push(...this.tokenizer.encode(all_prompts[0]));
-    context = [];
-    ctxLength = tokens.length;
-    // only keep shift_fill_factor of the window context
-    for (let i = all_prompts.length - 1; i > 0; --i) {
-      const encoded = this.tokenizer.encode(all_prompts[i]);
-      ctxLength += encoded.length;
-      if (
-        ctxLength >= shift_fill_factor * this.contextWindowSize &&
-        i + 2 < all_prompts.length
-      ) {
-        break;
-      }
-      context.unshift(encoded);
-    }
-    for (const ctx of context) {
-      tokens.push(...ctx);
-    }
-    if (tokens.length + mean_gen_len >= this.contextWindowSize) {
-      throw Error("Exceed max window length curr=" + tokens.length);
     }
     return tokens;
   }

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -94,7 +94,7 @@ export interface ChatCompletionRequestBase {
    * completion.
    *
    * The total length of input tokens and generated tokens is limited by the model's
-   * context length, **determined during MLC's compilation phase**.
+   * context length.
    */
   max_gen_len?: number | null;
 
@@ -817,8 +817,9 @@ export interface CompletionUsage {
 /**
  * The reason the model stopped generating tokens. This will be `stop` if the model
  * hit a natural stop point or a provided stop sequence, `length` if the maximum
- * number of tokens specified in the request was reached, `tool_calls` if the
- * model called a tool, or `abort` if user manually stops the generation.
+ * number of tokens specified in the request was reached or the context_window_size will
+ * be exceeded, `tool_calls` if the model called a tool, or `abort` if user manually stops the
+ * generation.
  */
 export type ChatCompletionFinishReason =
   | "stop"

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -96,7 +96,7 @@ export interface ChatCompletionRequestBase {
    * The total length of input tokens and generated tokens is limited by the model's
    * context length.
    */
-  max_gen_len?: number | null;
+  max_tokens?: number | null;
 
   /**
    * Sequences where the API will stop generating further tokens.
@@ -200,7 +200,7 @@ export interface ChatCompletionRequestBase {
    * generate an unending stream of whitespace until the generation reaches the token
    * limit, resulting in a long-running and seemingly "stuck" request. Also note that
    * the message content may be partially cut off if `finish_reason="length"`, which
-   * indicates the generation exceeded `max_gen_len` or the conversation exceeded the
+   * indicates the generation exceeded `max_tokens` or the conversation exceeded the
    * max context length.
    */
   response_format?: ResponseFormat;
@@ -973,7 +973,7 @@ export namespace ChatCompletionChunk {
  * the model may generate an unending stream of whitespace until the generation reaches the token
  * limit, resulting in a long-running and seemingly "stuck" request. Also note that
  * the message content may be partially cut off if `finish_reason="length"`, which
- * indicates the generation exceeded `max_gen_len` or the conversation exceeded the
+ * indicates the generation exceeded `max_tokens` or the conversation exceeded the
  * max context length.
  */
 export interface ResponseFormat {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,9 +110,7 @@ export function areChatOptionsEqual(
   if (!areObjectsEqual(options1.conv_config, options2.conv_config))
     return false;
   if (options1.conv_template !== options2.conv_template) return false;
-  if (options1.mean_gen_len !== options2.mean_gen_len) return false;
   if (options1.max_gen_len !== options2.max_gen_len) return false;
-  if (options1.shift_fill_factor !== options2.shift_fill_factor) return false;
   if (options1.repetition_penalty !== options2.repetition_penalty) return false;
   if (options1.frequency_penalty !== options2.frequency_penalty) return false;
   if (options1.presence_penalty !== options2.presence_penalty) return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,7 +110,6 @@ export function areChatOptionsEqual(
   if (!areObjectsEqual(options1.conv_config, options2.conv_config))
     return false;
   if (options1.conv_template !== options2.conv_template) return false;
-  if (options1.max_gen_len !== options2.max_gen_len) return false;
   if (options1.repetition_penalty !== options2.repetition_penalty) return false;
   if (options1.frequency_penalty !== options2.frequency_penalty) return false;
   if (options1.presence_penalty !== options2.presence_penalty) return false;

--- a/tests/generation_config.test.ts
+++ b/tests/generation_config.test.ts
@@ -8,16 +8,16 @@ describe("Check generation config illegal values", () => {
   test("High-level unsupported fields", () => {
     expect(() => {
       const genConfig: GenerationConfig = {
-        max_gen_len: 0,
+        max_tokens: 0,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("`max_gen_len` should be greater than zero.");
+    }).toThrow("`max_tokens` should be greater than zero.");
   });
 
   test("logit_bias exceeds range", () => {
     expect(() => {
       const genConfig: GenerationConfig = {
-        max_gen_len: 10,
+        max_tokens: 10,
         logit_bias: {
           "1355": 155,
         },
@@ -29,7 +29,7 @@ describe("Check generation config illegal values", () => {
   test("logit_bias invalid key", () => {
     expect(() => {
       const genConfig: GenerationConfig = {
-        max_gen_len: 10,
+        max_tokens: 10,
         logit_bias: {
           thisRaisesError: 50,
         },
@@ -43,7 +43,7 @@ describe("Check generation config illegal values", () => {
       const genConfig: GenerationConfig = {
         logprobs: true,
         top_logprobs: 6,
-        max_gen_len: 10,
+        max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
     }).toThrow("`top_logprobs` should be in range [0,5]");
@@ -53,7 +53,7 @@ describe("Check generation config illegal values", () => {
     expect(() => {
       const genConfig: GenerationConfig = {
         top_logprobs: 3,
-        max_gen_len: 10,
+        max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
     }).toThrow("`logprobs` must be true if `top_logprobs` is set");
@@ -64,7 +64,7 @@ describe("Check generation config illegal values", () => {
       const genConfig: GenerationConfig = {
         logprobs: false,
         top_logprobs: 3,
-        max_gen_len: 10,
+        max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
     }).toThrow("`logprobs` must be true if `top_logprobs` is set");

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -68,7 +68,7 @@ describe("Check chat completion unsupported requests", () => {
     expect(() => {
       const request: ChatCompletionRequest = {
         messages: [{ role: "user", content: "Hello! " }],
-        max_gen_len: 10,
+        max_tokens: 10,
         seed: 42.2, // Note that Number.isInteger(42.0) is true
       };
       postInitAndCheckFields(request, "Llama-3-8B-Instruct-q4f32_1-MLC");
@@ -120,7 +120,7 @@ describe("Supported requests", () => {
       ],
       n: 3,
       temperature: 1.5,
-      max_gen_len: 25,
+      max_tokens: 25,
       frequency_penalty: 0.2,
       seed: 42,
       logprobs: true,


### PR DESCRIPTION
- **[Breaking]** Rename `max_gen_len` to `max_tokens` in `ChatCompletionRequest`
- Remove reading `max_gen_len` from `mlc-chat-config.json`, hence remove it from `ChatOptions`
- Remove reading `mean_gen_len` and `shift_fill_factor` from `mlc-chat-config.json`, hence:
  - Remove these two fields from `ChatOption`
  - Throw error when the input prompt tokens exceed `context_window_size`, prompting user to truncate input, or increase `context_window_size`, or use sliding window
  - Finish reason with `length` when decoding exceed `context_window_size` (when `prompt_size + max_tokens > context_window_size`)
    - Hence this error is never shown to user: https://github.com/mlc-ai/web-llm/issues/385

This change is needed in order to be compatible with new `mlc-chat-config.json` in hugginface due to https://github.com/mlc-ai/mlc-llm/pull/2493