### PR TITLE
[Models] Add Mistral v0.3 and TinyLlama v1.0; bump web-tokenizer version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "loglevel": "^1.9.1"
       },
       "devDependencies": {
-        "@mlc-ai/web-tokenizers": "^0.1.3",
+        "@mlc-ai/web-tokenizers": "^0.1.4",
         "@next/eslint-plugin-next": "^14.2.3",
         "@rollup/plugin-commonjs": "^20.0.0",
         "@rollup/plugin-node-resolve": "^13.0.4",
@@ -1352,9 +1352,9 @@
       }
     },
     "node_modules/@mlc-ai/web-tokenizers": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@mlc-ai/web-tokenizers/-/web-tokenizers-0.1.3.tgz",
-      "integrity": "sha512-WSt3TvycV8MfRvOh6v6bfY7rRHIOebOUVOaqpCCZjCPlsEaiM/gcN850ASd2XYirSlAY0EwBTM0TtkZ0YPD/BQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-tokenizers/-/web-tokenizers-0.1.4.tgz",
+      "integrity": "sha512-i5HMDNwMl6DD9vk6BnJHAKwSGuBrt/AxEb83L8V36h1ys0oK2ruGCxDyCJ3bm5O8yuD79gJklCcqImJI27xUnA==",
       "dev": true
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1942,9 +1942,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.40.tgz",
-      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw==",
+      "version": "0.1.42",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.42.tgz",
+      "integrity": "sha512-uvJtt4OD1Vjdebrrz3kNLgpOicYbikwnM8WPG6YD2lkCOHDtPdEtCINJFIFtbOCtPfA8SreR/vKyUNbAt92IwQ==",
       "dev": true
     },
     "node_modules/abab": {
@@ -9220,7 +9220,7 @@
         "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
-        "@webgpu/types": "^0.1.40",
+        "@webgpu/types": "^0.1.42",
         "eslint": "^8.41.0",
         "jest": "^26.0.1",
         "rollup": "^2.56.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/mlc-ai/web-llm",
   "devDependencies": {
-    "@mlc-ai/web-tokenizers": "^0.1.3",
+    "@mlc-ai/web-tokenizers": "^0.1.4",
     "@next/eslint-plugin-next": "^14.2.3",
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",

--- a/src/config.ts
+++ b/src/config.ts
@@ -501,15 +501,31 @@ export const prebuiltAppConfig: AppConfig = {
     },
     // Mistral variants
     {
-      model: "https://huggingface.co/mlc-ai/WizardMath-7B-V1.1-q4f16_1-MLC",
-      model_id: "WizardMath-7B-V1.1-q4f16_1-MLC",
+      model:
+        "https://huggingface.co/mlc-ai/Mistral-7B-Instruct-v0.3-q4f16_1-MLC",
+      model_id: "Mistral-7B-Instruct-v0.3-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
-      vram_required_MB: 6079.02,
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Mistral-7B-Instruct-v0.3-q4f32_1-MLC",
+      model_id: "Mistral-7B-Instruct-v0.3-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Mistral-7B-Instruct-v0.3-q4f32_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 5619.27,
+      low_resource_required: false,
       overrides: {
         sliding_window_size: 4096,
         attention_sink_size: 4,
@@ -522,8 +538,8 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
-      vram_required_MB: 6079.02,
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
       overrides: {
@@ -538,8 +554,8 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
-      vram_required_MB: 6079.02,
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
       overrides: {
@@ -554,8 +570,23 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
-      vram_required_MB: 6079.02,
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4573.39,
+      low_resource_required: false,
+      required_features: ["shader-f16"],
+      overrides: {
+        sliding_window_size: 4096,
+        attention_sink_size: 4,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/WizardMath-7B-V1.1-q4f16_1-MLC",
+      model_id: "WizardMath-7B-V1.1-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+      vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
       overrides: {
@@ -942,7 +973,66 @@ export const prebuiltAppConfig: AppConfig = {
         context_window_size: 1024,
       },
     },
-    // TinyLlama
+    // TinyLlama v1.0
+    {
+      model:
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC",
+      model_id: "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 697.24,
+      low_resource_required: true,
+      required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 2048,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC",
+      model_id: "TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+      vram_required_MB: 839.98,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 2048,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC",
+      model_id: "TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC-1k",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 675.24,
+      low_resource_required: true,
+      required_features: ["shader-f16"],
+      overrides: {
+        context_window_size: 1024,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC",
+      model_id: "TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC-1k",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+      vram_required_MB: 795.98,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
+    },
+    // TinyLlama v0.4
     {
       model:
         "https://huggingface.co/mlc-ai/TinyLlama-1.1B-Chat-v0.4-q4f16_1-MLC",


### PR DESCRIPTION
Add new models:
- `Mistral-7B-Instruct-v0.3-q4f16_1-MLC` (we had v0.2 before)
- `Mistral-7B-Instruct-v0.3-q4f32_1-MLC`
- `TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC` (we had v0.4 before)
- `TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC` (we had v0.4 before)

To support Mistral v0.3, we also bump web-tokenizers to 0.1.4

Note: Mistral v0.3's WASM should be identical to v0.2; hence we can use it for models like Mistral v0.2, OpenHermes, WizardMath, etc.