### PR TITLE
[Version] Bump version to 0.2.42

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41",
+    "@mlc-ai/web-llm": "^0.2.42",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41",
+    "@mlc-ai/web-llm": "^0.2.42",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41",
+    "@mlc-ai/web-llm": "^0.2.42",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41"
+    "@mlc-ai/web-llm": "^0.2.42"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.41",
+      "version": "0.2.42",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.41",
+    "@mlc-ai/web-llm": "^0.2.42",
     "tvmjs": "file:./../../tvm_home/web"
   }
 }


### PR DESCRIPTION
### Changes
- New models:
  - Mistral-7B-Instruct-v0.3-q4f16_1-MLC (we had v0.2 before)
  - Mistral-7B-Instruct-v0.3-q4f32_1-MLC
  - TinyLlama-1.1B-Chat-v1.0-q4f16_1-MLC (we had v0.4 before)
  - TinyLlama-1.1B-Chat-v1.0-q4f32_1-MLC (we had v0.4 before)
- https://github.com/mlc-ai/web-llm/pull/457
  - **[Breaking] renamed `max_gen_len` to `max_tokens` in ChatCompletionRequest**
  - Remove usage of `mean_gen_len` and `shift_fill_factor`, throw error when request's prompt exceed contextWindowSize
  - Terminate generation with `"length"` stop reason when decoding exceed contextWindowSize
- https://github.com/mlc-ai/web-llm/pull/456
  - Add `include_usage` in streaming, add prefill/decode speed to `usage` to replace `runtimeStatsText()`
- https://github.com/mlc-ai/web-llm/pull/455
  - Allow overriding KVCache settings via `ModelRecord.overrides` or `chatOptions`
  - Can use sliding window on any model now by specifying `sliding_window_size` and `attention_sink_size`

### TVMjs
Compiled at https://github.com/apache/tvm/commit/140062705ea6fad1e1f34eedc4a9b2a62fda6751 with no changes

### WASM version
No change -- 0.2.39