### PR TITLE
[Streaming] Replace runtimeStatsText() with usage in examples

### DIFF
--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -278,19 +278,30 @@ class ChatUI {
 
     try {
       let curMessage = "";
+      let usage: webllm.CompletionUsage | undefined = undefined;
       const completion = await this.engine.chat.completions.create({
         stream: true,
         messages: this.chatHistory,
+        stream_options: { include_usage: true },
       });
       // TODO(Charlie): Processing of � requires changes
       for await (const chunk of completion) {
-        const curDelta = chunk.choices[0].delta.content;
+        const curDelta = chunk.choices[0]?.delta.content;
         if (curDelta) {
           curMessage += curDelta;
         }
         this.updateLastMessage("left", curMessage);
+        if (chunk.usage) {
+          usage = chunk.usage;
+        }
       }
-      this.uiChatInfoLabel.innerHTML = await this.engine.runtimeStatsText();
+      if (usage) {
+        this.uiChatInfoLabel.innerHTML =
+          `prompt_tokens: ${usage.prompt_tokens}, ` +
+          `completion_tokens: ${usage.completion_tokens}, ` +
+          `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +
+          `decoding: ${usage.extra.decode_tokens_per_s.toFixed(4)} tokens/sec`;
+      }
       const finalMessage = await this.engine.getMessage();
       this.updateLastMessage("left", finalMessage); // TODO: Remove this after � issue is fixed
       this.chatHistory.push({ role: "assistant", content: finalMessage });

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -635,6 +635,12 @@ export class MLCEngine implements MLCEngineInterface {
   }
 
   async runtimeStatsText(): Promise<string> {
+    log.warn(
+      "WARNING: `runtimeStatsText()` will soon be deprecated. " +
+        "Please use `ChatCompletion.usage` for non-streaming requests, or " +
+        "`ChatCompletionChunk.usage` for streaming requests, enabled by `stream_options`. " +
+        "The only flow that expects to use `runtimeStatsText()` as of now is `forwardTokensAndSample()`.",
+    );
     return this.getPipeline().runtimeStatsText();
   }
 


### PR DESCRIPTION
Recently we added `usage` to the last chunk in streaming if the user specifies `streamOptions: { include_usage: True}` in the request, to be compatible with the latest OpenAI API; for more see https://github.com/mlc-ai/web-llm/pull/456.

This PR updates our streaming examples to use `chunk.usage` instead of `runtimeStatsText()`. It is expected that we will deprecate `runtimeStatsText()` in the future. Currently, only low-level API `forwardTokenAndSample()` still needs it as they do not use OpenAI API (e.g. `examples/logit-processor`).

Such examples include:
- simple-chat-ts
- simple-chat-js
- next-simple-chat
- streaming (already updated)