### PR TITLE
[Model] Support Qwen2 0.5B, 1.5B, 7B, bump wasm version to 0.2.43

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -275,7 +275,7 @@ export interface AppConfig {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_39";
+export const modelVersion = "v0_2_43";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 
@@ -386,7 +386,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.2-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4033.28,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -455,7 +455,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -470,7 +470,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f32_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5619.27,
       low_resource_required: false,
       overrides: {
@@ -484,7 +484,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -499,7 +499,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -514,7 +514,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -528,7 +528,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-sw4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -595,57 +595,83 @@ export const prebuiltAppConfig: AppConfig = {
         context_window_size: 1024,
       },
     },
-    // Qwen-1.5-1.8B
+    // Qwen-2
     {
-      model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC",
-      model_id: "Qwen1.5-1.8B-Chat-q4f16_1-MLC",
+      model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q0f16-MLC",
+      model_id: "Qwen2-0.5B-Instruct-q0f16-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx4k_cs1k-webgpu.wasm",
-      vram_required_MB: 2404.94,
-      low_resource_required: false,
+        "/Qwen2-0.5B-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 1624.12,
       overrides: {
         context_window_size: 4096,
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC",
-      model_id: "Qwen1.5-1.8B-Chat-q4f32_1-MLC",
+      model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q0f32-MLC",
+      model_id: "Qwen2-0.5B-Instruct-q0f32-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx4k_cs1k-webgpu.wasm",
-      vram_required_MB: 3313.63,
-      low_resource_required: false,
+        "/Qwen2-0.5B-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 2654.75,
       overrides: {
         context_window_size: 4096,
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f16_1-MLC",
-      model_id: "Qwen1.5-1.8B-Chat-q4f16_1-MLC-1k",
+      model: "https://huggingface.co/mlc-ai/Qwen2-1.5B-Instruct-q4f16_1-MLC",
+      model_id: "Qwen2-1.5B-Instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f16_1-ctx4k_cs1k-webgpu.wasm",
-      vram_required_MB: 1828.94,
+        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       low_resource_required: true,
+      vram_required_MB: 1629.75,
       overrides: {
-        context_window_size: 1024,
+        context_window_size: 4096,
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Qwen1.5-1.8B-Chat-q4f32_1-MLC",
-      model_id: "Qwen1.5-1.8B-Chat-q4f32_1-MLC-1k",
+      model: "https://huggingface.co/mlc-ai/Qwen2-1.5B-Instruct-q4f32_1-MLC",
+      model_id: "Qwen2-1.5B-Instruct-q4f32_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen1.5-1.8B-Chat-q4f32_1-ctx4k_cs1k-webgpu.wasm",
-      vram_required_MB: 2161.63,
+        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       low_resource_required: true,
+      vram_required_MB: 1888.97,
       overrides: {
-        context_window_size: 1024,
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen2-7B-Instruct-q4f16_1-MLC",
+      model_id: "Qwen2-7B-Instruct-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      vram_required_MB: 5106.67,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen2-7B-Instruct-q4f32_1-MLC",
+      model_id: "Qwen2-7B-Instruct-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      vram_required_MB: 5900.09,
+      overrides: {
+        context_window_size: 4096,
       },
     },
     // StableLM-zephyr-1.6B
@@ -797,7 +823,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx1k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 675.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -812,7 +838,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx1k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 795.98,
       low_resource_required: true,
       overrides: {
@@ -854,7 +880,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f16_1-ct41k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 4618.52,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -1006,7 +1032,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/phi-1_5-q4f32_1-ctx12k_cs1k-webgpu.wasm",
+        "/phi-1_5-q4f32_1-ctx2k_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
       overrides: {

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -30,13 +30,10 @@ export class Conversation {
     if (this.override_system_message !== undefined) {
       system_message = this.override_system_message;
     }
-    let system_prompt = this.config.system_template.replace(
+    const system_prompt = this.config.system_template.replace(
       MessagePlaceholders.system,
       system_message,
     );
-    if (system_prompt) {
-      system_prompt += this.config.seps[0];
-    }
     const ret = addSystem ? [system_prompt] : [];
 
     // Process each message in this.messages
@@ -425,7 +422,7 @@ export function getConversation(
     });
   } else if (conv_template == "gorilla") {
     return new Conversation({
-      system_template: `${MessagePlaceholders.system}`,
+      system_template: `${MessagePlaceholders.system}\n`,
       system_message:
         "A chat between a curious user and an artificial intelligence assistant. " +
         "The assistant gives helpful, detailed, and polite answers to the user's questions.",

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -29,27 +29,27 @@ export class GrammarFactory {
     tvm.beginScope();
     // Get global functions.
     this.fBNFGrammarGetGrammarOfJSON = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.BNFGrammarGetGrammarOfJSON"),
+      tvm.getGlobalFunc("mlc.grammar.BNFGrammarGetGrammarOfJSON"),
     );
     this.fBNFGrammarFromSchema = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.BNFGrammarFromSchema"),
+      tvm.getGlobalFunc("mlc.grammar.BNFGrammarFromSchema"),
     );
     this.fGrammarSMFromTokenTable = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.GrammarStateMatcherFromTokenTable"),
+      tvm.getGlobalFunc("mlc.grammar.GrammarStateMatcherFromTokenTable"),
     );
     this.fGrammarSMAcceptToken = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.GrammarStateMatcherAcceptToken"),
+      tvm.getGlobalFunc("mlc.grammar.GrammarStateMatcherAcceptToken"),
     );
     this.fGrammarSMFindNextTokenBitmaskAsNDArray = tvm.detachFromCurrentScope(
       tvm.getGlobalFunc(
-        "mlc.serve.GrammarStateMatcherFindNextTokenBitmaskAsNDArray",
+        "mlc.grammar.GrammarStateMatcherFindNextTokenBitmaskAsNDArray",
       ),
     );
     this.fGrammarSMIsTerminated = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.GrammarStateMatcherIsTerminated"),
+      tvm.getGlobalFunc("mlc.grammar.GrammarStateMatcherIsTerminated"),
     );
     this.fGrammarSMResetState = tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.serve.GrammarStateMatcherResetState"),
+      tvm.getGlobalFunc("mlc.grammar.GrammarStateMatcherResetState"),
     );
     tvm.endScope();
   }

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -156,7 +156,7 @@ export class LLMChatPipeline {
       this.vm.getFunction("apply_bitmask_inplace"),
     );
     this.fpostProcessTokenTable = this.tvm.detachFromCurrentScope(
-      tvm.getGlobalFunc("mlc.PostProcessTokenTable"),
+      tvm.getGlobalFunc("mlc.tokenizers.PostProcessTokenTable"),
     );
 
     // 2. Get json stored in the vm's metadata function

--- a/tests/conv_template.test.ts
+++ b/tests/conv_template.test.ts
@@ -109,7 +109,7 @@ describe("Test conversation template", () => {
     conversation.appendReplyHeader(Role.assistant);
     const prompt = conversation.getPromptArray().join("");
     expect(prompt).toEqual(
-      "[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\n test1 [/INST] test2 [INST] test3 [/INST] ",
+      "[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant.\n<</SYS>>\n\ntest1 [/INST] test2 [INST] test3 [/INST] ",
     );
     console.log(prompt);
   });


### PR DESCRIPTION
This PR adds QWen2 0.5B, 1.5B, and 7B, hence deprecating Qwen1.5-1.8B

This PR also updates the model wasm version to 0.2.43 due to recent changes in MLC's renaming of TVM global function. As a result, we update how `grammar.ts` gets the global function.

Additionally, we remove 
```typescript
    if (system_prompt) {
      system_prompt += this.config.seps[0];
    }
```
to reflect the up-to-date conv template in `mlc-chat-config.json`.
