### PR TITLE
[API][Breaking] Consolidate Engine constructor, CreateMLCEngine, reload()

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ const selectedModel = "Llama-3-8B-Instruct-q4f32_1-MLC";
 
 const engine = await CreateMLCEngine(
   selectedModel,
-  { initProgressCallback }, // engineConfig
+  { initProgressCallback: initProgressCallback }, // engineConfig
 );
 ```
 
@@ -137,8 +137,9 @@ Under the hood, this factory function does the following steps for first creatin
 import { MLCEngine } from "@mlc-ai/web-llm";
 
 // This is a synchrounous call that returns immediately
-const engine = new MLCEngine();
-engine.setInitProgressCallback(initProgressCallback);
+const engine = new MLCEngine({
+  initProgressCallback: initProgressCallback
+});
 
 // This is an asynchrounous call and can take a long time to finish
 await engine.reload(selectedModel);

--- a/README.md
+++ b/README.md
@@ -197,14 +197,24 @@ console.log(fullReply);
 
 ## Advanced Usage
 
-### Using Web Worker
+### Using Workers
+
+You can put the heavy computation in a worker script to optimizing your application performance. To do so, you need to:
+
+1. Create an MLCEngine in the worker thread for the actual inference.
+2. Wrap the MLCEngine in the worker thread with a worker message handler to handle thread communications via messages under the hood.
+3. Create a Worker Engine in your main application as a proxy to sending operations to the MLCEngine in the worker thread via sending messages.
+
+For detailed implementation for different kinds of Workers, check the following sections.
+
+#### Dedicated Web Worker
 
 WebLLM comes with API support for WebWorker so you can hook
 the generation process into a separate worker thread so that
 the computing in the worker thread won't disrupt the UI.
 
 We will first create a worker script with a MLCEngine and
-hook it up to a handler that handles requests.
+hook it up to a worker message handler.
 
 ```typescript
 // worker.ts
@@ -218,7 +228,7 @@ self.onmessage = (msg: MessageEvent) => {
 };
 ```
 
-Then in the main logic, we create a `WebWorkerMLCEngine` that
+In the main logic, we create a `WebWorkerMLCEngine` that
 implements the same `MLCEngineInterface`. The rest of the logic remains the same.
 
 ```typescript
@@ -250,22 +260,22 @@ your application's offline experience.
 
 (Note, Service Worker's life cycle is managed by the browser and can be killed any time without notifying the webapp. `ServiceWorkerMLCEngine` will try to keep the service worker thread alive by periodically sending heartbeat events, but your application should also include proper error handling. Check `keepAliveMs` and `missedHeatbeat` in [`ServiceWorkerMLCEngine`](https://github.com/mlc-ai/web-llm/blob/main/src/service_worker.ts#L234) for more details.)
 
-We first create a service worker script with a MLCEngine and hook it up to a handler
+We first create a service worker script with a MLCEngine and hook it up to a worker message handler
 that handles requests when the service worker is ready.
 
 
 ```typescript
 // sw.ts
 import {
-  ServiceWorkerMLCEngineHandler,
+  MLCEngineServiceWorkerHandler,
   MLCEngine,
 } from "@mlc-ai/web-llm";
 
 const engine = new MLCEngine();
-let handler: ServiceWorkerMLCEngineHandler;
+let handler: MLCEngineServiceWorkerHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new ServiceWorkerMLCEngineHandler(engine);
+  handler = new MLCEngineServiceWorkerHandler(engine);
   console.log("Service Worker is ready");
 });
 ```

--- a/examples/cache-usage/src/cache_usage.ts
+++ b/examples/cache-usage/src/cache_usage.ts
@@ -52,7 +52,7 @@ async function main() {
 
   // 3. We reload, and we should see this time it is much faster because the weights are cached.
   console.log("Reload model start");
-  await engine.reload(selectedModel, undefined, appConfig);
+  await engine.reload(selectedModel);
   console.log("Reload model end");
   reply = await engine.chat.completions.create(request);
   console.log(reply);
@@ -70,7 +70,7 @@ async function main() {
 
   // 5. If we reload, we should expect the model to start downloading again
   console.log("Reload model start");
-  await engine.reload(selectedModel, undefined, appConfig);
+  await engine.reload(selectedModel);
   console.log("Reload model end");
   reply = await engine.chat.completions.create(request);
   console.log(reply);

--- a/examples/chrome-extension-webgpu-service-worker/src/background.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/background.ts
@@ -1,5 +1,5 @@
 import {
-  ExtensionServiceWorkerMLCEngineHandler,
+  MLCEngineExtensionServiceWorkerHandler,
   MLCEngine,
 } from "@mlc-ai/web-llm";
 
@@ -10,7 +10,7 @@ let handler;
 chrome.runtime.onConnect.addListener(function (port) {
   console.assert(port.name === "web_llm_service_worker");
   if (handler === undefined) {
-    handler = new ExtensionServiceWorkerMLCEngineHandler(engine, port);
+    handler = new MLCEngineExtensionServiceWorkerHandler(engine, port);
   } else {
     handler.setPort(port);
   }

--- a/examples/get-started/src/get_started.ts
+++ b/examples/get-started/src/get_started.ts
@@ -19,12 +19,12 @@ async function main() {
     {
       initProgressCallback: initProgressCallback,
       logLevel: "INFO", // specify the log level
-      // customize kv cache, use either context_window_size or sliding_window_size (with attention sink)
-      chatOpts: {
-        context_window_size: 2048,
-        // sliding_window_size: 1024,
-        // attention_sink_size: 4,
-      },
+    },
+    // customize kv cache, use either context_window_size or sliding_window_size (with attention sink)
+    {
+      context_window_size: 2048,
+      // sliding_window_size: 1024,
+      // attention_sink_size: 4,
     },
   );
 
@@ -46,8 +46,15 @@ async function main() {
   // };
   // const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
   //   selectedModel,
-  //   { appConfig: appConfig, initProgressCallback: initProgressCallback }
+  //   { appConfig: appConfig, initProgressCallback: initProgressCallback },
   // );
+
+  // Option 3: Instantiate MLCEngine() and call reload() separately
+  // const engine: webllm.MLCEngineInterface = new webllm.MLCEngine({
+  //   appConfig: appConfig, // if do not specify, we use webllm.prebuiltAppConfig
+  //   initProgressCallback: initProgressCallback,
+  // });
+  // await engine.reload(selectedModel);
 
   const reply0 = await engine.chat.completions.create({
     messages: [{ role: "user", content: "List three US states." }],

--- a/examples/multi-round-chat/src/multi_round_chat.ts
+++ b/examples/multi-round-chat/src/multi_round_chat.ts
@@ -9,7 +9,7 @@ function setLabel(id: string, text: string) {
 }
 
 /**
- * We domnstrate multiround chatting. Though users are required to maintain chat history, internally
+ * We demonstrate multiround chatting. Though users are required to maintain chat history, internally
  * we compare provided `messages` with the internal chat history. If it matches, we will reuse KVs
  * and hence save computation -- essentially an implicit internal optimization.
  */

--- a/examples/service-worker/src/sw.ts
+++ b/examples/service-worker/src/sw.ts
@@ -1,13 +1,13 @@
 import {
-  ServiceWorkerMLCEngineHandler,
+  MLCEngineServiceWorkerHandler,
   MLCEngineInterface,
   MLCEngine,
 } from "@mlc-ai/web-llm";
 
 const engine: MLCEngineInterface = new MLCEngine();
-let handler: ServiceWorkerMLCEngineHandler;
+let handler: MLCEngineServiceWorkerHandler;
 
 self.addEventListener("activate", function (event) {
-  handler = new ServiceWorkerMLCEngineHandler(engine);
+  handler = new MLCEngineServiceWorkerHandler(engine);
   console.log("Web-LLM Service Worker Activated");
 });

--- a/examples/simple-chat-ts/src/simple_chat.ts
+++ b/examples/simple-chat-ts/src/simple_chat.ts
@@ -260,7 +260,7 @@ class ChatUI {
     this.engine.setInitProgressCallback(initProgressCallback);
 
     try {
-      await this.engine.reload(this.selectedModel, undefined, this.config);
+      await this.engine.reload(this.selectedModel);
     } catch (err) {
       this.appendMessage("error", "Init error, " + err.toString());
       console.log(err.stack);
@@ -342,8 +342,9 @@ let engine: webllm.MLCEngineInterface;
 if (useWebWorker) {
   engine = new webllm.WebWorkerMLCEngine(
     new Worker(new URL("./worker.ts", import.meta.url), { type: "module" }),
+    { appConfig },
   );
 } else {
-  engine = new webllm.MLCEngine();
+  engine = new webllm.MLCEngine({ appConfig });
 }
 ChatUI.CreateAsync(engine);

--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -240,7 +240,7 @@ class ChatUI {
     this.engine.setInitProgressCallback(initProgressCallback);
 
     try {
-      await this.engine.reload(this.selectedModel, undefined, this.config);
+      await this.engine.reload(this.selectedModel);
     } catch (err) {
       this.appendMessage("error", "Init error, " + err.toString());
       console.log(err.stack);
@@ -322,9 +322,10 @@ let engine: webllm.MLCEngineInterface;
 if (useWebWorker) {
   engine = new webllm.WebWorkerMLCEngine(
     new Worker(new URL("./worker.ts", import.meta.url), { type: "module" }),
+    { appConfig },
   );
 } else {
-  engine = new webllm.MLCEngine();
+  engine = new webllm.MLCEngine({ appConfig });
 }
 ChatUI.CreateAsync(engine);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,16 +94,14 @@ export interface ChatOptions extends Partial<ChatConfig> {}
 /**
  * Optional configurations for `CreateMLCEngine()` and `CreateWebWorkerMLCEngine()`.
  *
- * chatOpts: To optionally override the `mlc-chat-config.json` of `modelId`.
  * appConfig: Configure the app, including the list of models and whether to use IndexedDB cache.
  * initProgressCallback: A callback for showing the progress of loading the model.
  * logitProcessorRegistry: A register for stateful logit processors, see `webllm.LogitProcessor`.
  *
- * @note All fields are optional, and `logitProcessorRegistry` is only used for `CreateMLCEngine()`
- * not `CreateWebWorkerMLCEngine()`.
+ * @note All fields are optional, and `logitProcessorRegistry` is only used for `MLCEngine` and not
+ * other `MLCEngine`s.
  */
 export interface MLCEngineConfig {
-  chatOpts?: ChatOptions;
   appConfig?: AppConfig;
   initProgressCallback?: InitProgressCallback;
   logitProcessorRegistry?: Map<string, LogitProcessor>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,13 +36,13 @@ export {
 export { WorkerRequest, WorkerResponse, CustomRequestParams } from "./message";
 
 export {
-  ServiceWorkerMLCEngineHandler,
+  MLCEngineServiceWorkerHandler,
   ServiceWorkerMLCEngine,
   CreateServiceWorkerMLCEngine,
 } from "./service_worker";
 
 export {
-  ServiceWorkerMLCEngineHandler as ExtensionServiceWorkerMLCEngineHandler,
+  MLCEngineServiceWorkerHandler as MLCEngineExtensionServiceWorkerHandler,
   ServiceWorkerMLCEngine as ExtensionServiceWorkerMLCEngine,
   CreateServiceWorkerMLCEngine as CreateExtensionServiceWorkerMLCEngine,
 } from "./extension_service_worker";

--- a/src/message.ts
+++ b/src/message.ts
@@ -17,7 +17,6 @@ type RequestKind =
   | "interruptGenerate"
   | "unload"
   | "resetChat"
-  | "init"
   | "getMaxStorageBufferBindingSize"
   | "getGPUVendor"
   | "forwardTokensAndSample"
@@ -27,7 +26,6 @@ type RequestKind =
   | "chatCompletionStreamNextChunk"
   | "customRequest"
   | "keepAlive"
-  | "heartbeat"
   | "setLogLevel"
   | "setAppConfig";
 
@@ -85,6 +83,7 @@ export type MessageContent =
   | number
   | ChatCompletion
   | ChatCompletionChunk
+  | AppConfig
   | void;
 /**
  * The message used in exchange between worker
@@ -97,19 +96,24 @@ export type WorkerRequest = {
   content: MessageContent;
 };
 
-export type OneTimeWorkerResponse = {
+type HeartbeatWorkerResponse = {
+  kind: "heartbeat";
+  uuid: string;
+};
+
+type OneTimeWorkerResponse = {
   kind: "return" | "throw";
   uuid: string;
   content: MessageContent;
 };
 
-export type InitProgressWorkerResponse = {
+type InitProgressWorkerResponse = {
   kind: "initProgressCallback";
   uuid: string;
   content: InitProgressReport;
 };
 
-export type GenerateProgressWorkerResponse = {
+type GenerateProgressWorkerResponse = {
   kind: "generateProgressCallback";
   uuid: string;
   content: {
@@ -121,4 +125,5 @@ export type GenerateProgressWorkerResponse = {
 export type WorkerResponse =
   | OneTimeWorkerResponse
   | InitProgressWorkerResponse
-  | GenerateProgressWorkerResponse;
+  | GenerateProgressWorkerResponse
+  | HeartbeatWorkerResponse;

--- a/src/message.ts
+++ b/src/message.ts
@@ -28,7 +28,8 @@ type RequestKind =
   | "customRequest"
   | "keepAlive"
   | "heartbeat"
-  | "setLogLevel";
+  | "setLogLevel"
+  | "setAppConfig";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ResponseKind =
@@ -40,7 +41,6 @@ type ResponseKind =
 export interface ReloadParams {
   modelId: string;
   chatOpts?: ChatOptions;
-  appConfig?: AppConfig;
 }
 export interface GenerateParams {
   input: string | ChatCompletionRequestNonStreaming;

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -82,7 +82,7 @@ export class MLCEngineServiceWorkerHandler extends MLCEngineWorkerHandler {
       if (message.kind === "return" || message.kind === "throw") {
         this.clientRegistry.delete(message.uuid);
       } else {
-        // TODO: Delete clientRegistry after complete to avoid memory leak?
+        // TODO(nestor): Delete clientRegistry after complete to avoid memory leak?
       }
     }
   }
@@ -149,9 +149,6 @@ export class MLCEngineServiceWorkerHandler extends MLCEngineWorkerHandler {
 }
 
 /* Webapp Client */
-/**
- * PostMessageHandler wrapper for sending message from client to service worker
- */
 export class ServiceWorker implements ChatWorker {
   _onmessage: (event: MessageEvent) => void = () => {};
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,19 +83,19 @@ export interface MLCEngineInterface {
   getInitProgressCallback: () => InitProgressCallback | undefined;
 
   /**
+   * Setter for the engine's appConfig.
+   */
+  setAppConfig: (appConfig: AppConfig) => void;
+
+  /**
    * Reload the chat with a new model.
    *
    * @param modelId model_id of the model to load.
    * @param chatOpts Extra options to override chat behavior.
-   * @param appConfig Override the app config in this load.
    * @returns A promise when reload finishes.
    * @note This is an async function.
    */
-  reload: (
-    modelId: string,
-    chatOpts?: ChatOptions,
-    appConfig?: AppConfig,
-  ) => Promise<void>;
+  reload: (modelId: string, chatOpts?: ChatOptions) => Promise<void>;
 
   /**
    * Generate a response for a given input.

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -34,10 +34,6 @@ import {
 } from "./message";
 import log from "loglevel";
 
-export interface PostMessageHandler {
-  postMessage: (message: any) => void;
-}
-
 /**
  * Worker handler that can be used in a WebWorker
  *
@@ -91,7 +87,7 @@ export class MLCEngineWorkerHandler {
         uuid: uuid,
         content: res,
       };
-      postMessage(msg);
+      this.postMessage(msg);
     } catch (err) {
       const errStr = (err as object).toString();
       const msg: WorkerResponse = {
@@ -99,7 +95,7 @@ export class MLCEngineWorkerHandler {
         uuid: uuid,
         content: errStr,
       };
-      postMessage(msg);
+      this.postMessage(msg);
     }
   }
 
@@ -136,7 +132,7 @@ export class MLCEngineWorkerHandler {
                 currentMessage: currentMessage,
               },
             };
-            postMessage(cbMessage);
+            this.postMessage(cbMessage);
           };
           const res = await this.engine.generate(
             params.input,


### PR DESCRIPTION
### TLDR
- `reload(selectedModel, chatOpts?, appConfig?)` --> `reload(selectedModel, chatOpts?)`
- Add `setAppConfig()` as `appConfig` is now a field of `MLCEngine`
- `new MLCEngine()` --> `new MLCEngine(engineConfig?)`
- Remove `chatOpts` from `EngineConfig`, add it to `CreateMLCEngine()` args separately
- Corresponding changes in WebWorker and ServiceWorker
- `ServiceWorkerMLCEngineHandler` --> `MLCEngineServiceWorkerHandler`
- Remove `init()` in `ServiceWorkerMLCEngine`

### Details
The motivation is to separate the creation of an engine (sync, instant, like an endpoint), and loading a model (async, can take long). This PR consolidates `MLCEngine` initialization, hence affecting WebWorker and ServiceWorker as well.

After this PR, there are two equivalent ways to create an engine:
```typescript
const engine = new MLCEngine(engineConfig);
await engine.reload(selectedModel, chatOpts);
```

`CreateMLCEngine()` is a factory method that combines the two above
```typescript
const engine = await CreateMLCEngine(selectedModel, engineConfig, chatOpts);
```
The first method allows users to postpone the loading of a model, which may take long.

To support the high-level goal above, changes include:
#### 1. Remove `chatOpts` from `MLCEngineConfig`
`chatOpts` should be per-model-loading rather than per-engine. After https://github.com/mlc-ai/web-llm/issues/429, users can specify KVCache config (e.g. context length, attention sink, whether to use sliding window) via `chatOpts`, making it even more per-model.

As a result, `CreateMLCEngine()` needs to also take in chatOpts separately.

#### 2. Pass `MLCEngineConfig` to `MLCEngine` constructor
We allow initializing `MLCEngine` with `MLCEngineConfig` so users do not need to call setters themselves (e.g. `setInitProgressCallback()`.

#### 3. Remove `appConfig` from `reload()`, make it a persisting field of `MLCEngine` and expose `setAppConfig()`
In the past, if user uses something other than the default `webllm.prebuiltAppConfig`, they need to pass the `appConfig` into `reload()` every time. Since `appConfig` should characterize an engine, we make it a field instead.
