### PR TITLE
[Version][Breaking] Bump version to 0.2.44

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ async main() {
   // assuming that it is compatible to the model in myLlamaUrl.
   const engine = await CreateMLCEngine(
     "MyLlama-3b-v1-q4f32_0",
-    { chatOpts, appConfig } // engineConfig
+    { appConfig }, // engineConfig
+    chatOpts,
   );
 }
 ```

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43",
+    "@mlc-ai/web-llm": "^0.2.44",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43",
+    "@mlc-ai/web-llm": "^0.2.44",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43",
+    "@mlc-ai/web-llm": "^0.2.44",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43"
+    "@mlc-ai/web-llm": "^0.2.44"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.43",
+      "version": "0.2.44",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.43",
+  "version": "0.2.44",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.43",
+    "@mlc-ai/web-llm": "^0.2.44",
     "tvmjs": "file:./../../tvm_home/web"
   }
 }


### PR DESCRIPTION
This version bump has breaking changes to the API, mainly:
- `reload(selectedModel, chatOpts?, appConfig?)` --> `reload(selectedModel, chatOpts?)`
- Add `setAppConfig()`, as `appConfig` is now a field of `MLCEngine`
- `new MLCEngine()` --> `new MLCEngine(engineConfig?)`
- Remove `chatOpts` from `EngineConfig`, add it to `CreateMLCEngine()` args separately
- Corresponding changes in WebWorker and ServiceWorker
- `ServiceWorkerMLCEngineHandler` --> `MLCEngineServiceWorkerHandler`
- Remove `init()` in `ServiceWorkerMLCEngine`

For more, see:
- https://github.com/mlc-ai/web-llm/pull/466