### PR TITLE
[Worker] Expose handler.engine as public property

### DIFF
--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -48,7 +48,7 @@ import { MLCEngine } from "./engine";
  * onmessage = handler.onmessage;
  */
 export class WebWorkerMLCEngineHandler {
-  protected engine: MLCEngine;
+  public engine: MLCEngine;
   protected chatCompletionAsyncChunkGenerator?: AsyncGenerator<
     ChatCompletionChunk,
     void,


### PR DESCRIPTION
In 7e11cf3f3a0cb1e295003e180ae15dee2329a5eb, we change the worker handler API to hide the engine creation internally. However, this also restricts the user's ability to directly operate the engine on the worker script for advanced use cases like eager loading (https://github.com/mlc-ai/web-llm/issues/469#issuecomment-2168470922).

Therefore, this PR exposes the `handler.engine` as a public property so users could directly operate it if they need.

Eg. They can do `handler.engine.reload()` to directly trigger a model load.