### PR TITLE
Add quantized qwen2-0.5b

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -603,13 +603,13 @@ export const prebuiltAppConfig: AppConfig = {
     // Qwen-2
     {
       model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q4f16_1-MLC",
-      model_id: "Qwen2-0.5B-Instruct-q4f16-MLC",
+      model_id: "Qwen2-0.5B-Instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f16_1-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs2k-webgpu.wasm",
       low_resource_required: true,
-      vram_required_MB: 500,//rough estimate
+      vram_required_MB: 944.62,
       overrides: {
         context_window_size: 4096,
       },

--- a/src/config.ts
+++ b/src/config.ts
@@ -602,6 +602,19 @@ export const prebuiltAppConfig: AppConfig = {
     },
     // Qwen-2
     {
+      model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q4f16_1-MLC",
+      model_id: "Qwen2-0.5B-Instruct-q4f16-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-0.5B-Instruct-q4f16_1-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 500,//rough estimate
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
       model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q0f16-MLC",
       model_id: "Qwen2-0.5B-Instruct-q0f16-MLC",
       model_lib:


### PR DESCRIPTION
Add quantized(q4f16) qwen2-0.5b to the list of supported models. [PR](https://github.com/mlc-ai/binary-mlc-llm-libs/pull/128) must be merged before merging this.