### PR TITLE
[WASM][Fix] Fix json mode for phi3, bump to v0_2_48 wasm

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,9 @@ export interface TokenizerInfo {
 export interface ChatConfig {
   // First three fields affect the entire conversation, i.e. used in `ChatModule.reload()`
   tokenizer_files: Array<string>;
+  tokenizer_info?: TokenizerInfo;
+  token_table_postproc_method?: string; // TODO: backward compatibility, remove soon
+  vocab_size: number;
   conv_config?: Partial<ConvTemplateConfig>;
   conv_template: string | ConvTemplateConfig;
   // KVCache settings
@@ -82,8 +85,6 @@ export interface ChatConfig {
   // Fields below can be swapped per-generation via `GenerationConfig`
   // Fields only used in MLC
   repetition_penalty: number;
-  tokenizer_info?: TokenizerInfo;
-  token_table_postproc_method?: string; // TODO: backward compatibility, remove soon
   // Fields shared by MLC and OpenAI APIs
   frequency_penalty: number;
   presence_penalty: number;
@@ -275,7 +276,7 @@ export interface AppConfig {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_43";
+export const modelVersion = "v0_2_48";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 
@@ -609,7 +610,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs2k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 944.62,
       overrides: {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -146,6 +146,7 @@ export class GrammarFactory {
       accepted = this.fGrammarSMAcceptToken(
         grammarStateMatcher,
         new tvmjs.Scalar(tokenID, "int32"),
+        /*verbose=*/ new tvmjs.Scalar(0, "int32"),
       );
     } catch (error) {
       throw Error(
@@ -160,12 +161,17 @@ export class GrammarFactory {
    * based on what tokens can/cannot be accepted by the current state of the grammar state matcher.
    *
    * @param grammarStateMatcher The grammar state matcher that will produce the bit mask.
+   * @param fullVocabSize The vocab size read from `config.json`, used to calculate size of bitmask.
    * @returns A bitmask in the form of an NDArray.
    */
   findNextTokenBitmask(
     grammarStateMatcher: GrammarStateMatcher,
+    fullVocabSize: number,
   ): tvmjs.TVMObject {
-    return this.fGrammarSMFindNextTokenBitmaskAsNDArray(grammarStateMatcher);
+    return this.fGrammarSMFindNextTokenBitmaskAsNDArray(
+      grammarStateMatcher,
+      new tvmjs.Scalar(fullVocabSize, "int32"),
+    );
   }
 
   /**

--- a/src/support.ts
+++ b/src/support.ts
@@ -55,6 +55,9 @@ export function getTopProbs(
 /**
  * Get the token table in the form of a string list of tokens, ordered by their token id.
  * @param tokenizer A loaded tokenizer.
+ * @note The size of the table (i.e. tokenizer.getVocabSize()) may be smaller than the `vocab_size`
+ * in config.json (length of logits), see https://github.com/QwenLM/Qwen2/issues/147 and
+ * https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/discussions/47.
  */
 export function getTokenTableFromTokenizer(tokenizer: Tokenizer): string[] {
   const tokenTable: string[] = [];


### PR DESCRIPTION
Before this PR, we may run into issues like the following when using json mode with Phi3:
```
index.js:1913 [FATAL] /Users/cfruan/Documents/mlc-llm/cpp/grammar/grammar_state_matcher.cc:202:
Check failed: (token_id >= 0 && token_id < init_ctx_->vocab_size) is false: Invalid token id 32042 for GrammarStateMatcher
```

This PR fixes this issue for models like Phi3, where the `vocab_size` in `config.json` may be larger than vocabs recorded in `tokenizer.json`. For more see:
- https://github.com/mlc-ai/mlc-llm/pull/2651

As a result, we had to recompile all WASMs, hence updating the wasm version to v0_2_48:
- https://github.com/mlc-ai/binary-mlc-llm-libs/pull/129

To support this in runtime, `ChatConfig` adds a new field `vocab_size` read from `mlc-chat-config.json` and update the signature of internal grammar function `findNextTokenBitmask()`.