### PR TITLE
[Version][Trivial] Bump version to 0.2.48

### DIFF
--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47",
+    "@mlc-ai/web-llm": "^0.2.48",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47",
+    "@mlc-ai/web-llm": "^0.2.48",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/function-calling/package.json
+++ b/examples/function-calling/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47",
+    "@mlc-ai/web-llm": "^0.2.48",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.46"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47"
+    "@mlc-ai/web-llm": "^0.2.48"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.47",
+      "version": "0.2.48",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/tests/generation_config.test.ts
+++ b/tests/generation_config.test.ts
@@ -11,7 +11,7 @@ describe("Check generation config illegal values", () => {
         max_tokens: 0,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("`max_tokens` should be greater than zero.");
+    }).toThrow("Make sure `max_tokens` > 0");
   });
 
   test("logit_bias exceeds range", () => {
@@ -23,7 +23,7 @@ describe("Check generation config illegal values", () => {
         },
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("logit_bias should be in range [-100, 100];");
+    }).toThrow("Make sure -100 < logit_bias <= 100.");
   });
 
   test("logit_bias invalid key", () => {
@@ -35,7 +35,9 @@ describe("Check generation config illegal values", () => {
         },
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("Expect logit_bias's keys to be number represented in string");
+    }).toThrow(
+      "Make sure logit_bias's keys to be number represented in string.",
+    );
   });
 
   test("top_logprobs out of range", () => {
@@ -46,7 +48,7 @@ describe("Check generation config illegal values", () => {
         max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("`top_logprobs` should be in range [0,5]");
+    }).toThrow("Make sure 0 < top_logprobs <= 5.");
   });
 
   test("top_logprobs set without setting logprobs", () => {
@@ -56,7 +58,7 @@ describe("Check generation config illegal values", () => {
         max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("`logprobs` must be true if `top_logprobs` is set");
+    }).toThrow("top_logprobs requires logprobs to be true");
   });
 
   test("top_logprobs set though logprobs is false", () => {
@@ -67,7 +69,7 @@ describe("Check generation config illegal values", () => {
         max_tokens: 10,
       };
       postInitAndCheckGenerationConfigValues(genConfig);
-    }).toThrow("`logprobs` must be true if `top_logprobs` is set");
+    }).toThrow("top_logprobs requires logprobs to be true");
   });
 });
 

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -71,7 +71,9 @@ describe("Check chat completion unsupported requests", () => {
         ],
       };
       postInitAndCheckFields(request, "Llama-3-8B-Instruct-q4f32_1-MLC");
-    }).toThrow("System prompt should always be the first one in `messages`.");
+    }).toThrow(
+      "System prompt should always be the first message in `messages`.",
+    );
   });
 
   test("When streaming `n` needs to be 1", () => {
@@ -126,7 +128,9 @@ describe("Check chat completion unsupported requests", () => {
         ],
       };
       postInitAndCheckFields(request, "Llama-3-8B-Instruct-q4f32_1-MLC");
-    }).toThrow("User message only supports string `content` for now");
+    }).toThrow(
+      "User message only supports string content for now, but received:",
+    );
   });
 });
 

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.47",
+    "@mlc-ai/web-llm": "^0.2.48",
     "tvmjs": "file:./../../tvm_home/web"
   }
 }


### PR DESCRIPTION
### Changes
- Fixed potential error in json mode for some models like Phi3 and Qwen2; for more see
  - https://github.com/mlc-ai/web-llm/pull/501

### Model WASM Version
Due to the fix, updated WASMs to `v0_2_48`
- https://github.com/mlc-ai/binary-mlc-llm-libs/pull/129

### TVMjs
No change, compiled at https://github.com/apache/tvm/commit/32e9a48b1fbc78a58447f392f2530c98553eb3dc