### PR TITLE
[Engine] Allow manually aborting reload, fix unexpected deviceLostError

### DIFF
--- a/examples/abort-reload/README.md
+++ b/examples/abort-reload/README.md
@@ -1,0 +1,13 @@
+# WebLLM Get Started App
+
+This folder provides a demo for cancelling model fetching after calling `engine.reload()`.
+
+```bash
+npm install
+npm start
+```
+
+Note if you would like to hack WebLLM core package.
+You can change web-llm dependencies as `"file:../.."`, and follow the build from source
+instruction in the project to build webllm locally. This option is only recommended
+if you would like to hack WebLLM core package.

--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "get-started",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "parcel src/get_started.html  --port 8887",
+    "build": "parcel build src/get_started.html --dist-dir lib"
+  },
+  "devDependencies": {
+    "buffer": "^5.7.1",
+    "parcel": "^2.8.3",
+    "process": "^0.11.10",
+    "tslib": "^2.3.1",
+    "typescript": "^4.9.5",
+    "url": "^0.11.3"
+  },
+  "dependencies": {
+    "@mlc-ai/web-llm": "file:../../lib"
+  }
+}

--- a/examples/abort-reload/src/get_started.html
+++ b/examples/abort-reload/src/get_started.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <script>
+    webLLMGlobal = {};
+  </script>
+  <body>
+    <h2>WebLLM Test Page</h2>
+    Open console to see output
+    <br />
+    <br />
+    <label id="init-label"> </label>
+
+    <h3>Prompt</h3>
+    <label id="prompt-label"> </label>
+
+    <h3>Response</h3>
+    <label id="generate-label"> </label>
+    <br />
+    <label id="stats-label"> </label>
+
+    <script type="module" src="./get_started.js"></script>
+  </body>
+</html>

--- a/examples/abort-reload/src/get_started.js
+++ b/examples/abort-reload/src/get_started.js
@@ -1,0 +1,29 @@
+import * as webllm from "@mlc-ai/web-llm";
+
+let engine;
+
+function setLabel(id, text) {
+  const label = document.getElementById(id);
+  if (label == null) {
+    throw Error("Cannot find label " + id);
+  }
+  label.innerText = text;
+}
+
+async function main() {
+  const initProgressCallback = (report) => {
+    console.log(report.text);
+    setLabel("init-label", report.text);
+  };
+  // Option 1: If we do not specify appConfig, we use `prebuiltAppConfig` defined in `config.ts`
+  const selectedModel = "Llama-3.1-8B-Instruct-q4f32_1-MLC";
+  engine = new webllm.MLCEngine({
+    initProgressCallback,
+  });
+  engine.reload(selectedModel);
+}
+main();
+setTimeout(() => {
+  console.log("calling unload");
+  engine.unload();
+}, 5000);

--- a/examples/abort-reload/src/get_started.js
+++ b/examples/abort-reload/src/get_started.js
@@ -1,4 +1,5 @@
 import * as webllm from "@mlc-ai/web-llm";
+import { error } from "loglevel";
 
 let engine;
 
@@ -25,5 +26,7 @@ async function main() {
 main();
 setTimeout(() => {
   console.log("calling unload");
-  engine.unload();
+  engine.unload().catch((err) => {
+    console.log(err);
+  });
 }, 5000);

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -1033,6 +1033,14 @@ export class LLMChatPipeline {
     } as ChatCompletionTokenLogprob;
   }
 
+  /**
+   * Synchronize the device.
+   */
+  async sync(): Promise<void> {
+    // Is it equivalent to this.tvm.sync()?
+    await this.device.sync();
+  }
+
   async evaluate() {
     // run a canonical evaluation of the flow
     this.resetKVCache();


### PR DESCRIPTION
### Manually aborting reload
This PR updates the engine `reload()` and `unload()` methods to allow users to abort an uncompleted `reload()` by either:

- call `unload()` any time before `reload()` completed
- call `reload()` again before the previous `reload()` completed

Example added in `examples/abort-reload`.
Console output:
```
Start to fetch params
get_started.js:16 Fetching param cache[0/108]: 28MB fetched. 0% completed, 1 secs elapsed. It can take a while when we first visit this page to populate the cache. Later refreshes will become faster.
get_started.js:28 calling unload
engine.ts:154 Reload() is aborted. Failed to execute 'add' on 'Cache': Cache.add() was aborted
```

Related issues:
https://github.com/mlc-ai/web-llm/issues/484
https://github.com/mlc-ai/web-llm/issues/499

### Note on unload() and unexpected device lost error

Previously, we had an issue where a device lost error is reported when we simply switch a model intentionally (i.e. calling `reload()`). This is because `unload()` sets `deviceLostIsError` back to true immediately after calling `this.pipeline.dispose()`, which destroys the WebGPU device internally. However, WebGPU is asynchronous and may not finish after `dispose()` returns. This PR also fixes this issue by making `unload()` wait until the device is actually destroyed by introducing `LLMChatPipeline.sync()`. Otherwise, the old device's device-lost callback may still be triggered. See https://github.com/apache/tvm/pull/17250