### PR TITLE
[Chore] Reorganize engine.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -128,13 +128,18 @@ export interface MLCEngineInterface {
   ) => Promise<string>;
 
   /**
-   * OpenAI-style API. Generate a chat completion response for the given conversation and configuration.
+   * OpenAI-style API. Generate a chat completion response for the given conversation and
+   * configuration. Use `engine.chat.completions.create()` to invoke this API.
    *
-   * The API is completely functional in behavior. That is, a previous request would not affect
-   * the current request's result. Thus, for multi-round chatting, users are responsible for
+   * @param request A OpenAI-style ChatCompletion request.
+   *
+   * @note The API is completely functional in behavior. That is, a previous request would not
+   * affect the current request's result. Thus, for multi-round chatting, users are responsible for
    * maintaining the chat history. With that being said, as an implicit internal optimization, if we
-   * detect that the user is performing multiround chatting, we will preserve the KV cache and only
+   * detect that the user is performing multi-round chatting, we will preserve the KV cache and only
    * prefill the new tokens.
+   *
+   * @note For more, see https://platform.openai.com/docs/api-reference/chat
    */
   chatCompletion(
     request: ChatCompletionRequestNonStreaming,
@@ -149,6 +154,14 @@ export interface MLCEngineInterface {
     request: ChatCompletionRequest,
   ): Promise<AsyncIterable<ChatCompletionChunk> | ChatCompletion>;
 
+  /**
+   * OpenAI-style API. Completes a CompletionCreateParams, a text completion with no chat template.
+   * Use `engine.completions.create()` to invoke this API.
+   *
+   * @param request An OpenAI-style Completion request.
+   *
+   * @note For more, see https://platform.openai.com/docs/api-reference/completions
+   */
   completion(request: CompletionCreateParamsNonStreaming): Promise<Completion>;
   completion(
     request: CompletionCreateParamsStreaming,


### PR DESCRIPTION
This PR reorganizes `engine.ts` to keep it relatively more organized.
- We move `getToolCallFromOutputMessage()` from `engine.ts` to `support.ts` since it does not depend on any engine-related fields and is stateless
- We move `asyncLoadTokenizer()` from `engine.ts` to `cache_util.ts` for the same reason
- In future, we can implement a common helper for `chatCompletion()` and `completion()`
- For `engine.ts`, we break down the functions into sections:

0. Setters and getters
1. Model/pipeline loading and unloading: `reload()`, `unload()`
2. Underlying auto-regressive generation functions: `_generate()`, `asyncGenerate()`, `interruptGenerate()`
3. High-level generation APIs: `generate()` (deprecated), `chatCompletion()`, `completion()`
4. WebGPU info-querying helpers. Arguably, this can be implemented in `support.ts` as well. Currently these methods are in the MLCEngineInterface, and goes through the WebWorkerMLCEngine - MLCEngine message passing workflow
5. Low-level APIs that interact with pipeline