### PR TITLE
[API] Deprecate engine.generate()

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -17,7 +17,6 @@ import {
  */
 type RequestKind =
   | "reload"
-  | "generate"
   | "runtimeStatsText"
   | "interruptGenerate"
   | "unload"
@@ -38,27 +37,14 @@ type RequestKind =
   | "setAppConfig";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-type ResponseKind =
-  | "return"
-  | "throw"
-  | "initProgressCallback"
-  | "generateProgressCallback";
+type ResponseKind = "return" | "throw" | "initProgressCallback";
 
 export interface ReloadParams {
   modelId: string;
   chatOpts?: ChatOptions;
 }
-export interface GenerateParams {
-  input: string | ChatCompletionRequestNonStreaming;
-  streamInterval?: number;
-  genConfig?: GenerationConfig;
-}
 export interface ResetChatParams {
   keepStats: boolean;
-}
-export interface GenerateProgressCallbackParams {
-  step: number;
-  currentMessage: string;
 }
 export interface ForwardTokensAndSampleParams {
   inputIds: Array<number>;
@@ -110,9 +96,7 @@ export interface CustomRequestParams {
   requestMessage: string;
 }
 export type MessageContent =
-  | GenerateProgressCallbackParams
   | ReloadParams
-  | GenerateParams
   | ResetChatParams
   | ForwardTokensAndSampleParams
   | ChatCompletionNonStreamingParams
@@ -160,17 +144,7 @@ type InitProgressWorkerResponse = {
   content: InitProgressReport;
 };
 
-type GenerateProgressWorkerResponse = {
-  kind: "generateProgressCallback";
-  uuid: string;
-  content: {
-    step: number;
-    currentMessage: string;
-  };
-};
-
 export type WorkerResponse =
   | OneTimeWorkerResponse
   | InitProgressWorkerResponse
-  | GenerateProgressWorkerResponse
   | HeartbeatWorkerResponse;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AppConfig, ChatOptions, GenerationConfig } from "./config";
+import { AppConfig, ChatOptions } from "./config";
 import {
   ChatCompletionRequest,
   ChatCompletionRequestBase,
@@ -29,14 +29,6 @@ export interface InitProgressReport {
  * Callbacks used to report initialization process.
  */
 export type InitProgressCallback = (report: InitProgressReport) => void;
-
-/**
- * Callbacks used to report initialization process.
- */
-export type GenerateProgressCallback = (
-  step: number,
-  currentMessage: string,
-) => void;
 
 /**
  * A stateful logitProcessor used to post-process logits after forwarding the input and before
@@ -113,26 +105,6 @@ export interface MLCEngineInterface {
    * @note This is an async function.
    */
   reload: (modelId: string, chatOpts?: ChatOptions) => Promise<void>;
-
-  /**
-   * Generate a response for a given input.
-   *
-   * @param input The input prompt or a non-streaming ChatCompletionRequest.
-   * @param progressCallback Callback that is being called to stream intermediate results.
-   * @param streamInterval callback interval to call progresscallback
-   * @param genConfig Configuration for this single generation that overrides pre-existing configs.
-   * @returns The final result.
-   *
-   * @note This will be deprecated soon. Please use `engine.chat.completions.create()` instead.
-   * For multi-round chatting, see `examples/multi-round-chat` on how to use
-   * `engine.chat.completions.create()` to achieve the same effect.
-   */
-  generate: (
-    input: string | ChatCompletionRequestNonStreaming,
-    progressCallback?: GenerateProgressCallback,
-    streamInterval?: number,
-    genConfig?: GenerationConfig,
-  ) => Promise<string>;
 
   /**
    * OpenAI-style API. Generate a chat completion response for the given conversation and


### PR DESCRIPTION
This PR deprecates `generate()` from all `MLCEngineInterface`. Its usage can be completely covered by `engine.chat.completions()` for conversation-style generation, and `engine.completions()` for raw text completion. 

Specifically for using the above two OpenAI APIs for multi-round chat with KV reuse, see `examples/multi-round-chat`.

We deprecate this because future changes on the engine (e.g. allowing multiple models to be loaded in engine) would break this `generate()` API and require extra effort to maintain.

Tested with streaming/non-streaming on MLCEngine/WebWorkerMLCEngine to ensure other APIs are not affected.