### PR TITLE
[API][Engine] Support loading multiple models in a single engine

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Note that all examples below run in-browser and use WebGPU as a backend.
 - [multi-round-chat](multi-round-chat): while APIs are functional, we internally optimize so that multi round chat usage can reuse KV cache
 - [text-completion](text-completion): demonstrates API `engine.completions.create()`, which is pure text completion with no conversation, as opposed to `engine.chat.completions.create()`
 - [embeddings](embeddings): demonstrates API `engine.embeddings.create()`, and integration with `EmbeddingsInterface` and `MemoryVectorStore` of [Langchain.js](js.langchain.com)
+- [multi-models](multi-models): demonstrates loading multiple models in a single engine concurrently
 
 #### Advanced OpenAI API Capabilities
 

--- a/examples/multi-models/README.md
+++ b/examples/multi-models/README.md
@@ -1,0 +1,14 @@
+# WebLLM Get Started App
+
+This folder provides a minimum demo to show WebLLM API in a webapp setting.
+To try it out, you can do the following steps under this folder
+
+```bash
+npm install
+npm start
+```
+
+Note if you would like to hack WebLLM core package.
+You can change web-llm dependencies as `"file:../.."`, and follow the build from source
+instruction in the project to build webllm locally. This option is only recommended
+if you would like to hack WebLLM core package.

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "get-started",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "parcel src/multi_models.html  --port 8888",
+    "build": "parcel build src/multi_models.html --dist-dir lib"
+  },
+  "devDependencies": {
+    "buffer": "^5.7.1",
+    "parcel": "^2.8.3",
+    "process": "^0.11.10",
+    "tslib": "^2.3.1",
+    "typescript": "^4.9.5",
+    "url": "^0.11.3"
+  },
+  "dependencies": {
+    "@mlc-ai/web-llm": "file:../.."
+  }
+}

--- a/examples/multi-models/src/multi_models.html
+++ b/examples/multi-models/src/multi_models.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <script>
+    webLLMGlobal = {};
+  </script>
+  <body>
+    <h2>WebLLM Test Page</h2>
+    Open console to see output
+    <br />
+    <br />
+    <label id="init-label"> </label>
+
+    <h3>Prompt</h3>
+    <label id="prompt-label"> </label>
+
+    <h3>Response</h3>
+    <label id="generate-label"> </label>
+    <br />
+    <label id="stats-label"> </label>
+
+    <script type="module" src="./multi_models.ts"></script>
+  </body>
+</html>

--- a/examples/multi-models/src/multi_models.ts
+++ b/examples/multi-models/src/multi_models.ts
@@ -1,0 +1,76 @@
+import * as webllm from "@mlc-ai/web-llm";
+
+function setLabel(id: string, text: string) {
+  const label = document.getElementById(id);
+  if (label == null) {
+    throw Error("Cannot find label " + id);
+  }
+  label.innerText = text;
+}
+
+/**
+ * Chat completion (OpenAI style) with streaming, with two models in the pipeline.
+ */
+async function mainStreaming() {
+  const initProgressCallback = (report: webllm.InitProgressReport) => {
+    setLabel("init-label", report.text);
+  };
+  const selectedModel1 = "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k";
+  const selectedModel2 = "gemma-2-2b-it-q4f32_1-MLC-1k";
+
+  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
+    [selectedModel1, selectedModel2],
+    { initProgressCallback: initProgressCallback },
+  );
+
+  const request1: webllm.ChatCompletionRequest = {
+    stream: true,
+    stream_options: { include_usage: true },
+    messages: [
+      { role: "user", content: "Provide me three US states." },
+      { role: "assistant", content: "California, New York, Pennsylvania." },
+      { role: "user", content: "Two more please!" },
+    ],
+    model: selectedModel1, // without specifying it, error will throw due to ambiguity
+  };
+
+  const request2: webllm.ChatCompletionRequest = {
+    stream: true,
+    stream_options: { include_usage: true },
+    messages: [
+      { role: "user", content: "Provide me three cities in NY." },
+      { role: "assistant", content: "New York, Binghamton, Buffalo." },
+      { role: "user", content: "Two more please!" },
+    ],
+    model: selectedModel2, // without specifying it, error will throw due to ambiguity
+  };
+
+  const asyncChunkGenerator1 = await engine.chat.completions.create(request1);
+  let message = "";
+  for await (const chunk of asyncChunkGenerator1) {
+    console.log(chunk);
+    message += chunk.choices[0]?.delta?.content || "";
+    setLabel("generate-label", message);
+    if (chunk.usage) {
+      console.log(chunk.usage); // only last chunk has usage
+    }
+    // engine.interruptGenerate();  // works with interrupt as well
+  }
+  const asyncChunkGenerator2 = await engine.chat.completions.create(request2);
+  message += "\n\n";
+  for await (const chunk of asyncChunkGenerator2) {
+    console.log(chunk);
+    message += chunk.choices[0]?.delta?.content || "";
+    setLabel("generate-label", message);
+    if (chunk.usage) {
+      console.log(chunk.usage); // only last chunk has usage
+    }
+    // engine.interruptGenerate();  // works with interrupt as well
+  }
+
+  // without specifying from which model to get message, error will throw due to ambiguity
+  console.log("Final message 1:\n", await engine.getMessage(selectedModel1));
+  console.log("Final message 2:\n", await engine.getMessage(selectedModel2));
+}
+
+mainStreaming();

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -265,6 +265,10 @@ export class EmbeddingPipeline {
     await this.device.sync();
   }
 
+  async asyncLoadWebGPUPipelines() {
+    await this.tvm.asyncLoadWebGPUPipelines(this.vm.getInternalModule());
+  }
+
   // Performance APIs below
 
   /**

--- a/src/error.ts
+++ b/src/error.ts
@@ -84,9 +84,11 @@ export class WebGPUNotFoundError extends Error {
 }
 
 export class ModelNotLoadedError extends Error {
-  constructor() {
+  constructor(requestName: string) {
     super(
-      "Model not loaded before calling chatCompletion(). Please ensure you have called `MLCEngine.reload(model)` to load the model before initiating chat operations, or initialize your engine using `CreateMLCEngine()` with a valid model configuration.",
+      `Model not loaded before trying to complete ${requestName}. Please ensure you have called ` +
+        `MLCEngine.reload(model) to load the model before initiating APIs, ` +
+        `or initialize your engine using CreateMLCEngine() with a valid model configuration.`,
     );
     this.name = "ModelNotLoadedError";
   }
@@ -477,5 +479,65 @@ export class EmbeddingInputEmptyError extends Error {
   constructor() {
     super("Embedding input cannot be empty string or empty token array.");
     this.name = "EmbeddingInputEmptyError";
+  }
+}
+
+export class ReloadArgumentSizeUnmatchedError extends Error {
+  constructor(numModelId: number, numChatOpts: number) {
+    super(
+      `Expect chatOpts, if specified, to match the size of modelId. However, got ` +
+        `${numModelId} modelId, but ${numChatOpts} chatOpts.`,
+    );
+    this.name = "ReloadArgumentSizeUnmatchedError";
+  }
+}
+
+export class UnclearModelToUseError extends Error {
+  constructor(loadedModels: string[], requestName: string) {
+    super(
+      `Multiple models are loaded in engine. Please specify the model in ${requestName}.\n` +
+        `Currently loaded models are:\n${loadedModels}`,
+    );
+    this.name = "UnclearModelToUseError";
+  }
+}
+
+export class SpecifiedModelNotFoundError extends Error {
+  constructor(
+    loadedModels: string[],
+    requestedModelId: string,
+    requestName: string,
+  ) {
+    super(
+      `Specified model ${requestedModelId} for ${requestName} is not found in loaded models. ` +
+        `Please check if the correct model is loaded/specified. ` +
+        `Currently loaded models are:\n${loadedModels}`,
+    );
+    this.name = "SpecifiedModelNotFoundError";
+  }
+}
+
+export class IncorrectPipelineLoadedError extends Error {
+  constructor(
+    selectedModelId: string,
+    expectedPipeline: string,
+    requestName: string,
+  ) {
+    super(
+      `${requestName} expects model be loaded with ${expectedPipeline}. However, ` +
+        `${selectedModelId} is not loaded with this pipeline.`,
+    );
+    this.name = "IncorrectPipelineLoadedError";
+  }
+}
+
+export class ReloadModelIdNotUniqueError extends Error {
+  constructor(modelId: string[]) {
+    super(
+      `Need to make models in modelId passed to reload() need to be unique. If you want to, ` +
+        `load copies of the same model, consider making copies of the ModelRecord with ` +
+        `different model_id. Received modelId: ${modelId}`,
+    );
+    this.name = "ReloadModelIdNotUniqueError";
   }
 }

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -117,7 +117,7 @@ export class ServiceWorkerMLCEngineHandler extends WebWorkerMLCEngineHandler {
  */
 export async function CreateServiceWorkerMLCEngine(
   modelId: string | string[],
-  engineConfig?: MLCEngineConfig,
+  engineConfig?: ExtensionMLCEngineConfig,
   chatOpts?: ChatOptions | ChatOptions[],
   keepAliveMs = 10000,
 ): Promise<ServiceWorkerMLCEngine> {

--- a/src/extension_service_worker.ts
+++ b/src/extension_service_worker.ts
@@ -7,7 +7,7 @@ import {
   WebWorkerMLCEngineHandler,
   WebWorkerMLCEngine,
 } from "./web_worker";
-import { areChatOptionsEqual } from "./utils";
+import { areArraysEqual, areChatOptionsListEqual } from "./utils";
 import { WebGPUNotFoundError } from "./error";
 
 export interface ExtensionMLCEngineConfig extends MLCEngineConfig {
@@ -66,8 +66,8 @@ export class ServiceWorkerMLCEngineHandler extends WebWorkerMLCEngineHandler {
         const params = msg.content as ReloadParams;
         // If the modelId, chatOpts, and appConfig are the same, immediately return
         if (
-          this.modelId === params.modelId &&
-          areChatOptionsEqual(this.chatOpts, params.chatOpts)
+          areArraysEqual(this.modelId, params.modelId) &&
+          areChatOptionsListEqual(this.chatOpts, params.chatOpts)
         ) {
           log.info("Already loaded the model. Skip loading");
           const gpuDetectOutput = await tvmjs.detectGPUDevice();
@@ -104,18 +104,21 @@ export class ServiceWorkerMLCEngineHandler extends WebWorkerMLCEngineHandler {
 /**
  * Create a ServiceWorkerMLCEngine.
  *
- * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
- * `engineConfig.appConfig`.
+ * @param modelId model_id of the model to load, either string or string[]. When multiple models
+ *   are provided, we load all models sequentially. Each modelId needs to either be in
+ *   `webllm.prebuiltAppConfig`, or in `engineCOnfig.appConfig`.
  * @param engineConfig Optionally configures the engine, see `webllm.MLCEngineConfig` for more.
+ * @param chatOpts Extra options to optionally override the `mlc-chat-config.json` of `modelId`.
+ *   The size of which needs to match that of `modelId`; chatOpts[i] will be used for modelId[i].
  * @param keepAliveMs The interval to send keep alive messages to the service worker.
  * See [Service worker lifecycle](https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle#idle-shutdown)
  * The default is 10s.
  * @returns An initialized `WebLLM.ServiceWorkerMLCEngine` with `modelId` loaded.
  */
 export async function CreateServiceWorkerMLCEngine(
-  modelId: string,
-  engineConfig?: ExtensionMLCEngineConfig,
-  chatOpts?: ChatOptions,
+  modelId: string | string[],
+  engineConfig?: MLCEngineConfig,
+  chatOpts?: ChatOptions | ChatOptions[],
   keepAliveMs = 10000,
 ): Promise<ServiceWorkerMLCEngine> {
   const serviceWorkerMLCEngine = new ServiceWorkerMLCEngine(

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,4 +1,4 @@
-import { AppConfig, ChatOptions, GenerationConfig } from "./config";
+import { AppConfig, ChatOptions } from "./config";
 import { InitProgressReport, LogLevel } from "./types";
 import {
   ChatCompletionRequestStreaming,
@@ -68,27 +68,27 @@ export interface ForwardTokensAndSampleParams {
 export interface ChatCompletionNonStreamingParams {
   request: ChatCompletionRequestNonStreaming;
   modelId: string[];
-  chatOpts: ChatOptions[];
+  chatOpts?: ChatOptions[];
 }
 export interface ChatCompletionStreamInitParams {
   request: ChatCompletionRequestStreaming;
   modelId: string[];
-  chatOpts: ChatOptions[];
+  chatOpts?: ChatOptions[];
 }
 export interface CompletionNonStreamingParams {
   request: CompletionCreateParamsNonStreaming;
   modelId: string[];
-  chatOpts: ChatOptions[];
+  chatOpts?: ChatOptions[];
 }
 export interface CompletionStreamInitParams {
   request: CompletionCreateParamsStreaming;
   modelId: string[];
-  chatOpts: ChatOptions[];
+  chatOpts?: ChatOptions[];
 }
 export interface EmbeddingParams {
   request: EmbeddingCreateParams;
   modelId: string[];
-  chatOpts: ChatOptions[];
+  chatOpts?: ChatOptions[];
 }
 
 export interface CustomRequestParams {
@@ -99,6 +99,7 @@ export type MessageContent =
   | ReloadParams
   | ResetChatParams
   | GetMessageParams
+  | RuntimeStatsTextParams
   | ForwardTokensAndSampleParams
   | ChatCompletionNonStreamingParams
   | ChatCompletionStreamInitParams

--- a/src/message.ts
+++ b/src/message.ts
@@ -40,55 +40,55 @@ type RequestKind =
 type ResponseKind = "return" | "throw" | "initProgressCallback";
 
 export interface ReloadParams {
-  modelId: string;
-  chatOpts?: ChatOptions;
+  modelId: string[];
+  chatOpts?: ChatOptions[];
 }
 export interface ResetChatParams {
   keepStats: boolean;
+  modelId?: string;
+}
+export interface GetMessageParams {
+  modelId?: string;
+}
+export interface RuntimeStatsTextParams {
+  modelId?: string;
 }
 export interface ForwardTokensAndSampleParams {
   inputIds: Array<number>;
   isPrefill: boolean;
+  modelId?: string;
 }
+
+// Notes on the following Params with modelId and chatOpts:
+// These fields are the model and chatOpts that the frontend engine expects the backend
+// to be loaded with. If not loaded due to web/service worker unexpectedly killed,
+// handler will call reload(). An engine can load multiple models, hence both are list.
+// TODO(webllm-team): should add appConfig here as well if rigorous.
+// Fore more, see https://github.com/mlc-ai/web-llm/pull/471
 export interface ChatCompletionNonStreamingParams {
   request: ChatCompletionRequestNonStreaming;
-  // The model and chatOpts that the frontend engine expects the backend to be loaded with.
-  // If not loaded due to service worker unexpectedly killed, handler will call reload().
-  // TODO(webllm-team): should add appConfig here as well.
-  modelId: string;
-  chatOpts: ChatOptions;
+  modelId: string[];
+  chatOpts: ChatOptions[];
 }
 export interface ChatCompletionStreamInitParams {
   request: ChatCompletionRequestStreaming;
-  // The model and chatOpts that the frontend engine expects the backend to be loaded with.
-  // If not loaded due to service worker unexpectedly killed, handler will call reload().
-  // TODO(webllm-team): should add appConfig here as well.
-  modelId: string;
-  chatOpts: ChatOptions;
+  modelId: string[];
+  chatOpts: ChatOptions[];
 }
 export interface CompletionNonStreamingParams {
   request: CompletionCreateParamsNonStreaming;
-  // The model and chatOpts that the frontend engine expects the backend to be loaded with.
-  // If not loaded due to service worker unexpectedly killed, handler will call reload().
-  // TODO(webllm-team): should add appConfig here as well.
-  modelId: string;
-  chatOpts: ChatOptions;
+  modelId: string[];
+  chatOpts: ChatOptions[];
 }
 export interface CompletionStreamInitParams {
   request: CompletionCreateParamsStreaming;
-  // The model and chatOpts that the frontend engine expects the backend to be loaded with.
-  // If not loaded due to service worker unexpectedly killed, handler will call reload().
-  // TODO(webllm-team): should add appConfig here as well.
-  modelId: string;
-  chatOpts: ChatOptions;
+  modelId: string[];
+  chatOpts: ChatOptions[];
 }
 export interface EmbeddingParams {
   request: EmbeddingCreateParams;
-  // The model and chatOpts that the frontend engine expects the backend to be loaded with.
-  // If not loaded due to service worker unexpectedly killed, handler will call reload().
-  // TODO(webllm-team): should add appConfig here as well.
-  modelId: string;
-  chatOpts: ChatOptions;
+  modelId: string[];
+  chatOpts: ChatOptions[];
 }
 
 export interface CustomRequestParams {
@@ -98,6 +98,7 @@ export interface CustomRequestParams {
 export type MessageContent =
   | ReloadParams
   | ResetChatParams
+  | GetMessageParams
   | ForwardTokensAndSampleParams
   | ChatCompletionNonStreamingParams
   | ChatCompletionStreamInitParams

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -233,12 +233,13 @@ export interface ChatCompletionRequestBase {
    */
   response_format?: ResponseFormat;
 
-  //////////////// BELOW FIELDS NOT SUPPORTED YET ////////////////
-
   /**
-   * Model to carry out this API.
+   * ID of the model to use. This equals to `ModelRecord.model_id`, which needs to either be in
+   * `webllm.prebuiltAppConfig` or in `engineConfig.appConfig`.
    *
-   * @note Not supported. Instead, call `CreateMLCEngine(model)` or `engine.reload(model)`.
+   * @note Call `CreateMLCEngine(model)` or `engine.reload(model)` ahead of time.
+   * @note If only one model is loaded in the engine, this field is optional. If multiple models
+   *   are loaded, this is required.
    */
   model?: string | null;
 }
@@ -363,7 +364,7 @@ export interface ChatCompletionChunk {
   usage?: CompletionUsage;
 }
 
-export const ChatCompletionRequestUnsupportedFields: Array<string> = ["model"];
+export const ChatCompletionRequestUnsupportedFields: Array<string> = []; // all supported as of now
 
 /**
  * Post init and verify whether the input of the request is valid. Thus, this function can throw

--- a/src/openai_api_protocols/completion.ts
+++ b/src/openai_api_protocols/completion.ts
@@ -182,13 +182,17 @@ export interface CompletionCreateParamsBase {
    */
   top_p?: number | null;
 
-  //////////////// BELOW FIELDS NOT SUPPORTED YET ////////////////
   /**
-   * Model to carry out this API.
+   * ID of the model to use. This equals to `ModelRecord.model_id`, which needs to either be in
+   * `webllm.prebuiltAppConfig` or in `engineConfig.appConfig`.
    *
-   * @note Not supported. Instead call `CreateMLCEngine(model)` or `engine.reload(model)` instead.
+   * @note Call `CreateMLCEngine(model)` or `engine.reload(model)` ahead of time.
+   * @note If only one model is loaded in the engine, this field is optional. If multiple models
+   *   are loaded, this is required.
    */
   model?: string | null;
+
+  //////////////// BELOW FIELDS NOT SUPPORTED YET ////////////////
 
   /**
    * The suffix that comes after a completion of inserted text.
@@ -305,7 +309,6 @@ export interface CompletionChoice {
 //////////////////////////////// 3. POST INIT ////////////////////////////////
 
 export const CompletionCreateParamsUnsupportedFields: Array<string> = [
-  "model",
   "suffix",
   "user",
   "best_of",

--- a/src/openai_api_protocols/embedding.ts
+++ b/src/openai_api_protocols/embedding.ts
@@ -118,18 +118,21 @@ export interface EmbeddingCreateParams {
   input: string | Array<string> | Array<number> | Array<Array<number>>;
 
   /**
+   * ID of the model to use. This equals to `ModelRecord.model_id`, which needs to either be in
+   * `webllm.prebuiltAppConfig` or in `engineConfig.appConfig`.
+   *
+   * @note Call `CreateMLCEngine(model)` or `engine.reload(model)` ahead of time.
+   * @note If only one model is loaded in the engine, this field is optional. If multiple models
+   *   are loaded, this is required.
+   */
+  model?: string | null;
+
+  /**
    * The format to return the embeddings in.
    *
    * @note Currently only support `float`.
    */
   encoding_format?: "float" | "base64";
-
-  /**
-   * ID of the model to use.
-   *
-   * @note Not supported. Instead, call `CreateMLCEngine(model)` or `engine.reload(model)`.
-   */
-  model?: string;
 
   // TODO: can support matryoshka embedding models in future, hence allow `dimensions` for those.
   /**
@@ -149,7 +152,6 @@ export interface EmbeddingCreateParams {
 }
 
 export const EmbeddingCreateParamsUnsupportedFields: Array<string> = [
-  "model",
   "dimensions",
   "user",
 ];

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -8,11 +8,7 @@ import {
   WebWorkerMLCEngine,
   ChatWorker,
 } from "./web_worker";
-import {
-  areArraysEqual,
-  areChatOptionsEqual,
-  areChatOptionsListEqual,
-} from "./utils";
+import { areArraysEqual, areChatOptionsListEqual } from "./utils";
 import {
   NoServiceWorkerAPIError,
   NonWorkerEnvironmentError,

--- a/src/service_worker.ts
+++ b/src/service_worker.ts
@@ -8,7 +8,11 @@ import {
   WebWorkerMLCEngine,
   ChatWorker,
 } from "./web_worker";
-import { areChatOptionsEqual } from "./utils";
+import {
+  areArraysEqual,
+  areChatOptionsEqual,
+  areChatOptionsListEqual,
+} from "./utils";
 import {
   NoServiceWorkerAPIError,
   NonWorkerEnvironmentError,
@@ -110,8 +114,8 @@ export class ServiceWorkerMLCEngineHandler extends WebWorkerMLCEngineHandler {
         const params = msg.content as ReloadParams;
         // If the modelId, chatOpts, and appConfig are the same, immediately return
         if (
-          this.modelId === params.modelId &&
-          areChatOptionsEqual(this.chatOpts, params.chatOpts)
+          areArraysEqual(this.modelId, params.modelId) &&
+          areChatOptionsListEqual(this.chatOpts, params.chatOpts)
         ) {
           log.info("Already loaded the model. Skip loading");
           const gpuDetectOutput = await tvmjs.detectGPUDevice();
@@ -181,15 +185,18 @@ export class ServiceWorker implements ChatWorker {
 /**
  * Create a ServiceWorkerMLCEngine.
  *
- * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
- * `engineConfig.appConfig`.
+ * @param modelId model_id of the model to load, either string or string[]. When multiple models
+ *   are provided, we load all models sequentially. Each modelId needs to either be in
+ *   `webllm.prebuiltAppConfig`, or in `engineCOnfig.appConfig`.
  * @param engineConfig Optionally configures the engine, see `webllm.MLCEngineConfig` for more.
+ * @param chatOpts Extra options to optionally override the `mlc-chat-config.json` of `modelId`.
+ *   The size of which needs to match that of `modelId`; chatOpts[i] will be used for modelId[i].
  * @returns An initialized `WebLLM.ServiceWorkerMLCEngine` with `modelId` loaded.
  */
 export async function CreateServiceWorkerMLCEngine(
-  modelId: string,
+  modelId: string | string[],
   engineConfig?: MLCEngineConfig,
-  chatOpts?: ChatOptions,
+  chatOpts?: ChatOptions | ChatOptions[],
   keepAliveMs = 10000,
 ): Promise<ServiceWorkerMLCEngine> {
   if (!("serviceWorker" in navigator)) {

--- a/src/support.ts
+++ b/src/support.ts
@@ -1,15 +1,18 @@
 /** Util methods. */
 import { Tokenizer } from "@mlc-ai/web-tokenizers";
-import { AppConfig, MessagePlaceholders } from "./config";
+import { AppConfig, MessagePlaceholders, ModelRecord } from "./config";
 import {
   ChatCompletionChunk,
   ChatCompletionMessageToolCall,
 } from "./openai_api_protocols/index";
 import {
   ModelNotFoundError,
+  ModelNotLoadedError,
+  SpecifiedModelNotFoundError,
   ToolCallOutputInvalidTypeError,
   ToolCallOutputMissingFieldsError,
   ToolCallOutputParseError,
+  UnclearModelToUseError,
 } from "./error";
 
 /**
@@ -199,10 +202,52 @@ export function getToolCallFromOutputMessage(
   }
 }
 
-export function findModelRecord(modelId: string, appConfig: AppConfig) {
+export function findModelRecord(
+  modelId: string,
+  appConfig: AppConfig,
+): ModelRecord {
   const matchedItem = appConfig.model_list.find(
     (item) => item.model_id == modelId,
   );
   if (matchedItem !== undefined) return matchedItem;
   throw new ModelNotFoundError(modelId);
+}
+
+/**
+ * Return the model to use given the loaded modelIds and requestModel. Throws error when unclear
+ * which model to load.
+ * @param loadedModelIds Models currently loaded in the engine.
+ * @param requestModel Model the user specified to load via the request. Required when multiple
+ *   models are loaded
+ * @param requestName The type of request or API to load the model for. Needed for error throwing.
+ */
+export function getModelIdToUse(
+  loadedModelIds: string[],
+  requestModel: string | undefined | null,
+  requestName: string,
+): string {
+  let selectedModelId: string;
+  if (loadedModelIds.length === 0) {
+    throw new ModelNotLoadedError(requestName);
+  }
+  if (requestModel) {
+    // If specified model
+    if (!(requestModel in loadedModelIds)) {
+      throw new SpecifiedModelNotFoundError(
+        loadedModelIds,
+        requestModel,
+        requestName,
+      );
+    } else {
+      selectedModelId = requestModel;
+    }
+  } else {
+    // If not specified
+    if (loadedModelIds.length > 1) {
+      throw new UnclearModelToUseError(loadedModelIds, requestName);
+    } else {
+      selectedModelId = loadedModelIds[0];
+    }
+  }
+  return selectedModelId;
 }

--- a/src/support.ts
+++ b/src/support.ts
@@ -232,7 +232,7 @@ export function getModelIdToUse(
   }
   if (requestModel) {
     // If specified model
-    if (!(requestModel in loadedModelIds)) {
+    if (loadedModelIds.indexOf(requestModel) === -1) {
       throw new SpecifiedModelNotFoundError(
         loadedModelIds,
         requestModel,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { AppConfig, ChatOptions, ModelRecord } from "./config";
 
 // Helper function to compare two arrays
-function areArraysEqual(arr1?: Array<any>, arr2?: Array<any>): boolean {
+export function areArraysEqual(arr1?: Array<any>, arr2?: Array<any>): boolean {
   if (!arr1 && !arr2) return true;
   if (!arr1 || !arr2) return false;
   if (arr1.length !== arr2.length) return false;
@@ -119,4 +119,29 @@ export function areChatOptionsEqual(
 
   // If all checks passed, the options are equal
   return true;
+}
+
+export function areChatOptionsListEqual(
+  options1?: ChatOptions[],
+  options2?: ChatOptions[],
+): boolean {
+  if (options1 && options2) {
+    // Both defined, need to compare
+    if (options1.length !== options2.length) {
+      return false;
+    } else {
+      for (let i = 0; i < options1.length; i++) {
+        if (!areChatOptionsEqual(options1[i], options2[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+  } else if (!options1 && !options2) {
+    // Both undefined, equal
+    return true;
+  } else {
+    // One defined, other not
+    return false;
+  }
 }

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -337,8 +337,9 @@ export class WebWorkerMLCEngineHandler {
    */
   async reloadIfUnmatched(
     expectedModelId: string[],
-    expectedChatOpts: ChatOptions[],
+    expectedChatOpts?: ChatOptions[],
   ) {
+    // TODO: should we also check expectedChatOpts here?
     if (!areArraysEqual(this.modelId, expectedModelId)) {
       log.warn(
         "WebWorkerMLCEngine expects model is loaded in WebWorkerMLCEngineHandler, " +

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -34,6 +34,8 @@ import {
   CompletionNonStreamingParams,
   EmbeddingParams,
   CompletionStreamInitParams,
+  GetMessageParams,
+  RuntimeStatsTextParams,
 } from "./message";
 import log from "loglevel";
 import { MLCEngine } from "./engine";
@@ -41,6 +43,7 @@ import {
   UnknownMessageKindError,
   WorkerEngineModelNotLoadedError,
 } from "./error";
+import { areArraysEqual } from "./utils";
 
 /**
  * Worker handler that can be used in a WebWorker
@@ -56,14 +59,15 @@ import {
 export class WebWorkerMLCEngineHandler {
   /**
    * The modelId and chatOpts that the underlying engine (backend) is currently loaded with.
+   * An engine can be loaded with multiple models, so modelId and chatOpts are lists.
    *
    * TODO(webllm-team): This is always in-sync with `this.engine` unless device is lost due to
    * unexpected reason. Therefore, we should get it from `this.engine` directly and make handler
    * stateless. Besides, consider if we should add appConfig, or use engine's API to find the
    * corresponding model record rather than relying on just the modelId.
    */
-  modelId?: string;
-  chatOpts?: ChatOptions;
+  modelId?: string[];
+  chatOpts?: ChatOptions[];
 
   public engine: MLCEngine;
   /** ChatCompletion and Completion share the same chunk generator. */
@@ -151,6 +155,7 @@ export class WebWorkerMLCEngineHandler {
           const res = await this.engine.forwardTokensAndSample(
             params.inputIds,
             params.isPrefill,
+            params.modelId,
           );
           onComplete?.(res);
           return res;
@@ -238,7 +243,8 @@ export class WebWorkerMLCEngineHandler {
       }
       case "runtimeStatsText": {
         this.handleTask(msg.uuid, async () => {
-          const res = await this.engine.runtimeStatsText();
+          const params = msg.content as RuntimeStatsTextParams;
+          const res = await this.engine.runtimeStatsText(params.modelId);
           onComplete?.(res);
           return res;
         });
@@ -266,7 +272,7 @@ export class WebWorkerMLCEngineHandler {
       case "resetChat": {
         this.handleTask(msg.uuid, async () => {
           const params = msg.content as ResetChatParams;
-          await this.engine.resetChat(params.keepStats);
+          await this.engine.resetChat(params.keepStats, params.modelId);
           onComplete?.(null);
           return null;
         });
@@ -290,7 +296,8 @@ export class WebWorkerMLCEngineHandler {
       }
       case "getMessage": {
         this.handleTask(msg.uuid, async () => {
-          const res = await this.engine.getMessage();
+          const params = msg.content as GetMessageParams;
+          const res = await this.engine.getMessage(params.modelId);
           onComplete?.(res);
           return res;
         });
@@ -329,10 +336,10 @@ export class WebWorkerMLCEngineHandler {
    * to possibly killed service worker), we reload here.
    */
   async reloadIfUnmatched(
-    expectedModelId: string,
-    expectedChatOpts: ChatOptions,
+    expectedModelId: string[],
+    expectedChatOpts: ChatOptions[],
   ) {
-    if (this.modelId !== expectedModelId) {
+    if (!areArraysEqual(this.modelId, expectedModelId)) {
       log.warn(
         "WebWorkerMLCEngine expects model is loaded in WebWorkerMLCEngineHandler, " +
           "but it is not. This may due to web/service worker is unexpectedly killed.\n" +
@@ -353,19 +360,22 @@ export interface ChatWorker {
  *
  * Equivalent to `new webllm.WebWorkerMLCEngine(worker).reload(...)`.
  *
- * @param worker The worker that holds the actual MLCEngine, intialized with `new Worker()`.
- * @param modelId The model to load, needs to either be in `webllm.prebuiltAppConfig`, or in
- * `engineConfig.appConfig`.
+ * @param worker The worker that holds the actual MLCEngine, initialized with `new Worker()`.
+ * @param modelId model_id of the model to load, either string or string[]. When multiple models
+ *   are provided, we load all models sequentially. Each modelId needs to either be in
+ *   `webllm.prebuiltAppConfig`, or in `engineCOnfig.appConfig`.
  * @param engineConfig Optionally configures the engine, see `webllm.MLCEngineConfig` for more.
+ * @param chatOpts Extra options to optionally override the `mlc-chat-config.json` of `modelId`.
+ *   The size of which needs to match that of `modelId`; chatOpts[i] will be used for modelId[i].
  * @returns An initialized `WebLLM.WebWorkerMLCEngine` with `modelId` loaded.
  *
  * @note engineConfig.logitProcessorRegistry is ignored for `CreateWebWorkMLCEngine()`.
  */
 export async function CreateWebWorkerMLCEngine(
   worker: any,
-  modelId: string,
+  modelId: string | string[],
   engineConfig?: MLCEngineConfig,
-  chatOpts?: ChatOptions,
+  chatOpts?: ChatOptions | ChatOptions[],
 ): Promise<WebWorkerMLCEngine> {
   const webWorkerMLCEngine = new WebWorkerMLCEngine(worker, engineConfig);
   await webWorkerMLCEngine.reload(modelId, chatOpts);
@@ -395,9 +405,10 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
    * The modelId and chatOpts that the frontend expects the backend engine is currently loaded
    * with. Needed for service worker. It is the backend and handler's job to match up with the
    * expectation despite the web/service worker possibly being killed.
+   * Since an engine can load multiple models, both modelId and chatOpts are lists.
    */
-  modelId?: string;
-  chatOpts?: ChatOptions;
+  modelId?: string[];
+  chatOpts?: ChatOptions[];
 
   private initProgressCallback?: InitProgressCallback;
   private pendingPromise = new Map<string, (msg: WorkerResponse) => void>();
@@ -481,7 +492,18 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
     return promise;
   }
 
-  async reload(modelId: string, chatOpts?: ChatOptions): Promise<void> {
+  async reload(
+    modelId: string | string[],
+    chatOpts?: ChatOptions | ChatOptions[],
+  ): Promise<void> {
+    // Always convert modelId and chatOpts to lists internally for ease of manipulation
+    if (!Array.isArray(modelId)) {
+      modelId = [modelId];
+    }
+    if (chatOpts !== undefined && !Array.isArray(chatOpts)) {
+      chatOpts = [chatOpts];
+    }
+
     const msg: WorkerRequest = {
       kind: "reload",
       uuid: crypto.randomUUID(),
@@ -513,20 +535,24 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
     return await this.getPromise<string>(msg);
   }
 
-  async getMessage(): Promise<string> {
+  async getMessage(modelId?: string): Promise<string> {
     const msg: WorkerRequest = {
       kind: "getMessage",
       uuid: crypto.randomUUID(),
-      content: null,
+      content: {
+        modelId: modelId,
+      },
     };
     return await this.getPromise<string>(msg);
   }
 
-  async runtimeStatsText(): Promise<string> {
+  async runtimeStatsText(modelId?: string): Promise<string> {
     const msg: WorkerRequest = {
       kind: "runtimeStatsText",
       uuid: crypto.randomUUID(),
-      content: null,
+      content: {
+        modelId: modelId,
+      },
     };
     return await this.getPromise<string>(msg);
   }
@@ -551,12 +577,13 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
     this.chatOpts = undefined;
   }
 
-  async resetChat(keepStats = false): Promise<void> {
+  async resetChat(keepStats = false, modelId?: string): Promise<void> {
     const msg: WorkerRequest = {
       kind: "resetChat",
       uuid: crypto.randomUUID(),
       content: {
         keepStats: keepStats,
+        modelId: modelId,
       },
     };
     await this.getPromise<null>(msg);
@@ -565,6 +592,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
   async forwardTokensAndSample(
     inputIds: Array<number>,
     isPrefill: boolean,
+    modelId?: string,
   ): Promise<number> {
     const msg: WorkerRequest = {
       kind: "forwardTokensAndSample",
@@ -572,6 +600,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
       content: {
         inputIds: inputIds,
         isPrefill: isPrefill,
+        modelId: modelId,
       },
     };
     return await this.getPromise<number>(msg);

--- a/tests/openai_chat_completion.test.ts
+++ b/tests/openai_chat_completion.test.ts
@@ -33,21 +33,6 @@ describe("Check chat completion unsupported requests", () => {
     }).toThrow("Only specify stream_options when stream=True.");
   });
 
-  test("High-level unsupported fields", () => {
-    expect(() => {
-      const request: ChatCompletionRequest = {
-        model: "phi-2-q4f32_1-MLC", // this raises error
-        messages: [
-          { role: "system", content: "You are a helpful assistant." },
-          { role: "user", content: "Hello! " },
-        ],
-      };
-      postInitAndCheckFields(request, "Llama-3.1-8B-Instruct-q4f32_1-MLC");
-    }).toThrow(
-      "The following fields in ChatCompletionRequest are not yet supported",
-    );
-  });
-
   test("Last message should be from user or tool", () => {
     expect(() => {
       const request: ChatCompletionRequest = {

--- a/tests/openai_completion.test.ts
+++ b/tests/openai_completion.test.ts
@@ -57,16 +57,6 @@ describe("Check completion unsupported requests", () => {
   test("High-level unsupported fields", () => {
     expect(() => {
       const request: CompletionCreateParams = {
-        model: "phi-2-q4f32_1-MLC", // this raises error
-        prompt: "Hello, ",
-      };
-      postInitAndCheckFields(request, "Llama-3.1-8B-Instruct-q4f32_1-MLC");
-    }).toThrow(
-      "The following fields in CompletionCreateParams are not yet supported",
-    );
-
-    expect(() => {
-      const request: CompletionCreateParams = {
         prompt: "Hello, ",
         suffix: "this is suffix", // this raises error
       };

--- a/tests/openai_embeddings.test.ts
+++ b/tests/openai_embeddings.test.ts
@@ -98,17 +98,6 @@ describe("Check embeddings unsupported requests", () => {
     }).toThrow(new EmbeddingUnsupportedEncodingFormatError());
   });
 
-  test("model", () => {
-    expect(() => {
-      const request: EmbeddingCreateParams = {
-        input: ["Hello", "Hi"],
-        encoding_format: "float",
-        model: "snowflake-arctic-embed-m-q0f32-MLC",
-      };
-      postInitAndCheckFields(request, "snowflake-arctic-embed-m-q0f32-MLC");
-    }).toThrow("The following fields in");
-  });
-
   test("user", () => {
     expect(() => {
       const request: EmbeddingCreateParams = {

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -156,9 +156,12 @@ describe("Test getModelIdToUse", () => {
     expect(async () => {
       await engine.getMessage();
     }).rejects.toThrow(new ModelNotLoadedError("getMessage"));
+
+    // resetChat should not throw error because it is allowed to resetChat before pipeline
+    // established, as a no-op
     expect(async () => {
       await engine.resetChat();
-    }).rejects.toThrow(new ModelNotLoadedError("resetChat"));
+    }).not.toThrow(new ModelNotLoadedError("resetChat"));
   });
 
   test("E2E test with MLCEngine with two models without specifying a model", () => {
@@ -223,9 +226,12 @@ describe("Test getModelIdToUse", () => {
         "runtimeStatsText",
       ),
     );
+
+    // resetChat should not throw error because it is allowed to resetChat before pipeline
+    // established, as a no-op
     expect(async () => {
       await engine.resetChat(false, requestedModelId);
-    }).rejects.toThrow(
+    }).not.toThrow(
       new SpecifiedModelNotFoundError(
         loadedModelIds,
         requestedModelId,

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -79,7 +79,7 @@ describe("Test getModelIdToUse", () => {
   });
 
   test("No model loaded", () => {
-    const loadedModelIds = [];
+    const loadedModelIds: string[] = [];
     const requestModel = "d";
     const requestName = "ChatCompletionRequest";
     expect(() => {


### PR DESCRIPTION
This PR does not change any behavior of existingly supported API/workflow, but only introduces new behaviors when multiple models are loaded in a single engine. For users, please refer to `examples/multi-models` and "User-facing changes" below.

```typescript
  const selectedModel1 = "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k";
  const selectedModel2 = "gemma-2-2b-it-q4f32_1-MLC-1k";
  const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(
    [selectedModel1, selectedModel2],
  );
```

## User-facing changes
- When multiple models are loaded in the engine:
  - `model` field is required to be specified in `ChatCompletionRequest`, `EmbeddingCreateParams`, and `CompletionCreateParams`
  - The following engine APIs need to specify the target model: `getMessage()`, `runtimeStatsText()`, `resetChat()`, `forwardTokensAndSample()`
- `reload()` / `unload()`:
  - To load multiple models, call `reload([model_id1, model_id2])`
  - To load a single model, as before, call `reload(model_id1)`
  - `unload()` unloads all loaded models, or interrupt a current `reload` (as before)
- `CreateMLCEngine()`, `CreateWebWorkerEngine()`, `CreateServiceWorkerEngine()` are all updated accordingly to allow `string[]` input for modelId

## Internal code change
Before diving in, we first identify the following APIs in MLCEngineInterface that directly interact with pipeline, as already mentioned above: `getMessage()`, `forwardTokensAndSample()`, `runtimeStatsText()`, `resetChat()`

### `support.ts`, `utils.ts`
- `getModelIdToUse()`: given the loaded model ids and the requestedModel (can be undefined), reconcile the model to use. Added unit test
- `areChatOptionsListEqual()`: called when the service worker decides whether to skip loading. Added unit test

### `src/openai_api_protocols`
- The only change is to remove `model` from the list of unsupported fields and update the documentation

### `types.ts`
- `reload()`'s `modelId` is now `string | string[]`. Update `reload()` and `unload()` documentation 
- For each of the user-facing APIs that directly interact with a pipeline, `modelId` is required when multiple models are loaded, as explained in "User-facing changes"

### `src/engine.ts` -- main changes happen here
- Introduce private fields `this.loadedModelIdToPipeline` and `this.loadedModelIdToChatConfig` to replace `this.currentModelId`, `this.config`, `this.pipeline`. Update `reloadInternal()` and `unload()` to reflect this.
- `reload()`: more preprocessing due to possible `string[]`. For reload abort, a single abort stops all models loading
- Add `getLLMStates()` to query the currently loaded pipeline, model id, and chatConfig
- Abandon any use case of `this.getPipeline()`. Instead, each internal API (`prefill()`, `decode()`, `_generate()`, `asyncGenerate()`) all know which pipeline to execute on from their parameter, passed by the high-level APIs (`embedding()`, `chatCompletion()`, `completion()`)
- Only user-facings APIs that directly interact with the pipeline cannot pinpoint the pipeline in the parameter, hence resorting to `getLLMStates()`. These are: `getMessage()`, `forwardTokensAndSample()`, `runtimeStatsText()`, `resetChat()`

### WebWorker changes: `message.ts`, `extension_service_worker.ts`, `service_worker.ts`, `web_worker.ts`
- Due to the additional `modelId?` parameter for the user-facing APIs that directly interact with a pipeline (`resetChat()`, etc. as mentioned earlier):
  - We modify or add their params message in `message.ts`
  - Correspondingly, change the handling of these messages in `WebWorkerMLCEngineHandler`, and the sending of these messages in `WebWorkerMLCEngine`
- To check out-of-sync of frontend/backend loaded models (fore more see https://github.com/mlc-ai/web-llm/pull/533)
  - Update `Handler.modelId` and `Handler.chatOpts` to `string[]` and `ChatOptions[]`
  - For each OpenAI-API-initaiting params (e.g. `ChatCompletionNonStreamingParams`), also send `string[]` and `chatOptions[]`. That is, we send all the expected loaded models, despite this API only requiring one. As a result, we reload if the `Handler.modelId` and `modelId` in API's message param do not strictly match
- Update `reload()`, `ReloadParams`, and reload-handling in Handler in `ServiceWorker`. To skip loading:
  - Before: `this.modelId === params.modelId`, Now: `areArraysEqual(this.modelId, params.modelId)`
  - Before: `areChatOptionsEqual(...)`, Now: `areChatOptionsListEqual(...)`

## Tested
- Unit tests
- `chat.completions.create()` and `embeddings.create()` for MLCEngine, web worker, and service worker
- `examples/multi-models`; also in web worker and service worker settings
- simple-chat-ts; test `abortController()` by removing `await` from `reload()` and `asyncInitChat()` in `simple_chat.ts`
- WebLLMChat; tested terminating service worker manually and re-send chat completion request