### PR TITLE
[Trivial] Generalize getModelStates

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -524,7 +524,7 @@ export class IncorrectPipelineLoadedError extends Error {
     requestName: string,
   ) {
     super(
-      `${requestName} expects model be loaded with ${expectedPipeline}. However, ` +
+      `${requestName} expects model to be loaded with ${expectedPipeline}. However, ` +
         `${selectedModelId} is not loaded with this pipeline.`,
     );
     this.name = "IncorrectPipelineLoadedError";


### PR DESCRIPTION
This PR reorganizes internal code a bit to reuse code. We rename internal helper method `getLLMStates()` to `getModelStates()` and add `getEmebeddingStates()`, so engine's methods `embedding()`, `completion()`, and `chatCompletion()` can share the same preprocessing helper method.