### PR TITLE
[Fix] Implement lock to ensure FCFS of requests to same model

### DIFF
--- a/examples/multi-models/src/main.ts
+++ b/examples/multi-models/src/main.ts
@@ -93,10 +93,8 @@ async function parallelGeneration() {
   );
 
   // We can serve the two requests concurrently
-  let message1 = "";
-  let message2 = "";
-
   async function getModel1Response() {
+    let message1 = "";
     const asyncChunkGenerator1 = await engine.chat.completions.create(request1);
     for await (const chunk of asyncChunkGenerator1) {
       // console.log(chunk);
@@ -110,6 +108,7 @@ async function parallelGeneration() {
   }
 
   async function getModel2Response() {
+    let message2 = "";
     const asyncChunkGenerator2 = await engine.chat.completions.create(request2);
     for await (const chunk of asyncChunkGenerator2) {
       // console.log(chunk);
@@ -123,6 +122,10 @@ async function parallelGeneration() {
   }
 
   await Promise.all([getModel1Response(), getModel2Response()]);
+  // Note: concurrent requests to the same model are executed sequentially in FCFS,
+  // unlike to different models like above
+  // Fore more, see https://github.com/mlc-ai/web-llm/pull/549
+  // await Promise.all([getModel1Response(), getModel1Response()]);
 
   // without specifying from which model to get message, error will throw due to ambiguity
   console.log("Final message 1:\n", await engine.getMessage(selectedModel1));

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -49,6 +49,7 @@ import {
 } from "./conversation";
 import {
   cleanModelUrl,
+  CustomLock,
   findModelRecord,
   getModelIdToUse,
   getToolCallFromOutputMessage,
@@ -102,6 +103,7 @@ export async function CreateMLCEngine(
  * `webllm.MLCEngine().reload(modelId)`.
  */
 export class MLCEngine implements MLCEngineInterface {
+  // APIs
   /** For chat.completions.create() */
   public chat: API.Chat;
   /** For completions.create() */
@@ -109,6 +111,7 @@ export class MLCEngine implements MLCEngineInterface {
   /** For embeddings.create() */
   public embeddings: API.Embeddings;
 
+  // Maps to maintain states of loaded model(s)
   /** Maps each loaded model's modelId to its pipeline */
   private loadedModelIdToPipeline: Map<
     string,
@@ -116,13 +119,21 @@ export class MLCEngine implements MLCEngineInterface {
   >;
   /** Maps each loaded model's modelId to its chatConfig */
   private loadedModelIdToChatConfig: Map<string, ChatConfig>;
+  /** Maps each loaded model's modelId to a lock. Ensures
+   * each model only processes one request at at time.
+   */
+  private loadedModelIdToLock: Map<string, CustomLock>;
+
+  // Others
   private logger: (msg: string) => void = log.info;
   private logitProcessorRegistry?: Map<string, LogitProcessor>;
   private initProgressCallback?: InitProgressCallback;
+  private appConfig: AppConfig;
+
+  // Signals and flags
   private interruptSignal = false;
   private deviceLostIsError = true; // whether device.lost is due to actual error or model reload
   private reloadController: AbortController | undefined;
-  private appConfig: AppConfig;
 
   constructor(engineConfig?: MLCEngineConfig) {
     this.loadedModelIdToPipeline = new Map<
@@ -130,6 +141,7 @@ export class MLCEngine implements MLCEngineInterface {
       LLMChatPipeline | EmbeddingPipeline
     >();
     this.loadedModelIdToChatConfig = new Map<string, ChatConfig>();
+    this.loadedModelIdToLock = new Map<string, CustomLock>();
     this.appConfig = engineConfig?.appConfig || prebuiltAppConfig;
     this.setLogLevel(engineConfig?.logLevel || DefaultLogLevel);
     this.setInitProgressCallback(engineConfig?.initProgressCallback);
@@ -368,6 +380,7 @@ export class MLCEngine implements MLCEngineInterface {
     }
     await newPipeline.asyncLoadWebGPUPipelines();
     this.loadedModelIdToPipeline.set(modelId, newPipeline);
+    this.loadedModelIdToLock.set(modelId, new CustomLock());
 
     // Clean up
     const tend = performance.now();
@@ -396,6 +409,7 @@ export class MLCEngine implements MLCEngineInterface {
     }
     this.loadedModelIdToPipeline.clear();
     this.loadedModelIdToChatConfig.clear();
+    this.loadedModelIdToLock.clear();
     this.deviceLostIsError = true;
     if (this.reloadController) {
       this.reloadController.abort("Engine.unload() is called.");
@@ -421,13 +435,11 @@ export class MLCEngine implements MLCEngineInterface {
     }
     await this.prefill(input, pipeline, chatConfig, genConfig);
 
-    let counter = 1;
     while (!pipeline.stopped()) {
       if (this.interruptSignal) {
         pipeline.triggerStop();
         break;
       }
-      counter += 1;
       await this.decode(pipeline, genConfig);
     }
     return pipeline.getMessage();
@@ -457,20 +469,30 @@ export class MLCEngine implements MLCEngineInterface {
     chatConfig: ChatConfig,
     genConfig: GenerationConfig,
   ): AsyncGenerator<ChatCompletionChunk | Completion, void, void> {
+    // Since it is an async generator, we need to do fine-grained try-catch to ensure lock is
+    // released only when errors occur. Then release at the very end when no error occurs.
+    // TODO: This makes code less readable, is there a better way to do this?
+    const lock = this.loadedModelIdToLock.get(model)!;
+
     // 0. Pre-processing
     const isChatCompletion = "messages" in request;
     const isFunctionCalling =
       "tools" in request &&
       request.tools !== undefined &&
       request.tools !== null;
-    if (isFunctionCalling && !isChatCompletion) {
-      throw new Error(
-        "Expect `chat.completions` with tools, not `completions`.",
-      );
-    }
-    postInitAndCheckGenerationConfigValues(genConfig);
-    if (request.seed !== null && request.seed !== undefined) {
-      pipeline.setSeed(request.seed);
+    try {
+      if (isFunctionCalling && !isChatCompletion) {
+        throw new Error(
+          "Expect `chat.completions` with tools, not `completions`.",
+        );
+      }
+      postInitAndCheckGenerationConfigValues(genConfig);
+      if (request.seed !== null && request.seed !== undefined) {
+        pipeline.setSeed(request.seed);
+      }
+    } catch (err) {
+      await lock.release();
+      throw err;
     }
 
     // 1. Helper function that generates the chunk
@@ -549,8 +571,14 @@ export class MLCEngine implements MLCEngineInterface {
     }
 
     // 2. Auto-regressive loop
-    await this.prefill(request, pipeline, chatConfig, genConfig);
-    let curChunk = await _getChunk(pipeline); // prefill produces a chunk
+    let curChunk;
+    try {
+      await this.prefill(request, pipeline, chatConfig, genConfig);
+      curChunk = await _getChunk(pipeline); // prefill produces a chunk
+    } catch (err) {
+      await lock.release();
+      throw err;
+    }
     if (curChunk) {
       yield curChunk;
     }
@@ -560,8 +588,13 @@ export class MLCEngine implements MLCEngineInterface {
         pipeline.triggerStop();
         break;
       }
-      await this.decode(pipeline, genConfig);
-      curChunk = await _getChunk(pipeline);
+      try {
+        await this.decode(pipeline, genConfig);
+        curChunk = await _getChunk(pipeline);
+      } catch (err) {
+        await lock.release();
+        throw err;
+      }
       if (curChunk) {
         yield curChunk;
       }
@@ -578,15 +611,19 @@ export class MLCEngine implements MLCEngineInterface {
     let tool_calls:
       | Array<ChatCompletionChunk.Choice.Delta.ToolCall>
       | undefined;
-
-    if (pipeline.getFinishReason() === "stop" && isFunctionCalling) {
-      // If stopped due to length or abort, cannot output return tool_calls field
-      finish_reason = "tool_calls";
-      const outputMessage = pipeline.getMessage();
-      tool_calls = getToolCallFromOutputMessage(
-        outputMessage,
-        /*isStreaming=*/ true,
-      ) as Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
+    try {
+      if (pipeline.getFinishReason() === "stop" && isFunctionCalling) {
+        // If stopped due to length or abort, cannot output return tool_calls field
+        finish_reason = "tool_calls";
+        const outputMessage = pipeline.getMessage();
+        tool_calls = getToolCallFromOutputMessage(
+          outputMessage,
+          /*isStreaming=*/ true,
+        ) as Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
+      }
+    } catch (err) {
+      await lock.release();
+      throw err;
     }
 
     if (isChatCompletion) {
@@ -663,6 +700,8 @@ export class MLCEngine implements MLCEngineInterface {
         yield usageChunk;
       }
     }
+
+    await lock.release();
   }
 
   async interruptGenerate() {
@@ -710,6 +749,10 @@ export class MLCEngine implements MLCEngineInterface {
       response_format: request.response_format,
     };
 
+    // 0.5 Block wait until this pipeline finishes all previous requests
+    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
+    await lock.acquire();
+
     // 1. If request is streaming, return an AsyncIterable (an iterable version of `_generate()`)
     if (request.stream) {
       return this.asyncGenerate(
@@ -721,94 +764,102 @@ export class MLCEngine implements MLCEngineInterface {
       );
     }
 
-    if (request.seed !== null && request.seed !== undefined) {
-      selectedPipeline.setSeed(request.seed);
-    }
-
-    // 2. If request is non-streaming, directly reuse `_generate()`
-    const n = request.n ? request.n : 1;
-    const choices: Array<ChatCompletion.Choice> = [];
-    let completion_tokens = 0;
-    let prompt_tokens = 0;
-    let prefill_time = 0;
-    let decode_time = 0;
-    for (let i = 0; i < n; i++) {
-      let outputMessage: string;
-      if (this.interruptSignal) {
-        // A single interrupt signal should stop all choices' generations
-        selectedPipeline.triggerStop();
-        outputMessage = "";
-      } else {
-        outputMessage = await this._generate(
-          request,
-          selectedPipeline,
-          selectedChatConfig,
-          genConfig,
-        );
-      }
-      let finish_reason = selectedPipeline.getFinishReason()!;
-
-      // 3. Post processing for function calling
-      const isFunctionCalling =
-        request.tools !== undefined && request.tools !== null;
-      let tool_calls: Array<ChatCompletionMessageToolCall> | undefined;
-      if (selectedPipeline.getFinishReason() === "stop" && isFunctionCalling) {
-        // If stopped due to length or abort, cannot output return tool_calls field
-        finish_reason = "tool_calls";
-        tool_calls = getToolCallFromOutputMessage(
-          outputMessage,
-          /*isStreaming=*/ false,
-        );
+    // Big try-finally to release lock in case of errors
+    try {
+      if (request.seed !== null && request.seed !== undefined) {
+        selectedPipeline.setSeed(request.seed);
       }
 
-      choices.push({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        finish_reason: finish_reason,
-        index: i,
-        logprobs: request.logprobs
-          ? ({
-              content: selectedPipeline.getTokenLogprobArray(),
-            } as ChatCompletion.Choice.Logprobs)
-          : null,
-        message: isFunctionCalling
-          ? {
-              content: null,
-              tool_calls: tool_calls,
-              role: "assistant",
-            }
-          : {
-              content: outputMessage,
-              role: "assistant",
-            },
-      });
-      completion_tokens += selectedPipeline.getCurRoundDecodingTotalTokens();
-      prompt_tokens += selectedPipeline.getCurRoundPrefillTotalTokens();
-      prefill_time += selectedPipeline.getCurRoundPrefillTotalTime();
-      decode_time += selectedPipeline.getCurRoundDecodingTotalTime();
-    }
+      // 2. If request is non-streaming, directly reuse `_generate()`
+      const n = request.n ? request.n : 1;
+      const choices: Array<ChatCompletion.Choice> = [];
+      let completion_tokens = 0;
+      let prompt_tokens = 0;
+      let prefill_time = 0;
+      let decode_time = 0;
+      for (let i = 0; i < n; i++) {
+        let outputMessage: string;
+        if (this.interruptSignal) {
+          // A single interrupt signal should stop all choices' generations
+          selectedPipeline.triggerStop();
+          outputMessage = "";
+        } else {
+          outputMessage = await this._generate(
+            request,
+            selectedPipeline,
+            selectedChatConfig,
+            genConfig,
+          );
+        }
+        let finish_reason = selectedPipeline.getFinishReason()!;
 
-    const response: ChatCompletion = {
-      id: crypto.randomUUID(),
-      choices: choices,
-      model: selectedModelId,
-      object: "chat.completion",
-      created: Date.now(),
-      usage: {
-        completion_tokens: completion_tokens,
-        prompt_tokens: prompt_tokens,
-        total_tokens: completion_tokens + prompt_tokens,
-        extra: {
-          prefill_tokens_per_s: prompt_tokens / prefill_time,
-          decode_tokens_per_s: completion_tokens / decode_time,
-        },
-      } as CompletionUsage,
-    };
+        // 3. Post processing for function calling
+        const isFunctionCalling =
+          request.tools !== undefined && request.tools !== null;
+        let tool_calls: Array<ChatCompletionMessageToolCall> | undefined;
+        if (
+          selectedPipeline.getFinishReason() === "stop" &&
+          isFunctionCalling
+        ) {
+          // If stopped due to length or abort, cannot output return tool_calls field
+          finish_reason = "tool_calls";
+          tool_calls = getToolCallFromOutputMessage(
+            outputMessage,
+            /*isStreaming=*/ false,
+          );
+        }
 
-    // Reset seed -- we do not want this seed to affect future requests
-    if (request.seed !== null && request.seed !== undefined) {
-      selectedPipeline.setSeed(Date.now());
+        choices.push({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          finish_reason: finish_reason,
+          index: i,
+          logprobs: request.logprobs
+            ? ({
+                content: selectedPipeline.getTokenLogprobArray(),
+              } as ChatCompletion.Choice.Logprobs)
+            : null,
+          message: isFunctionCalling
+            ? {
+                content: null,
+                tool_calls: tool_calls,
+                role: "assistant",
+              }
+            : {
+                content: outputMessage,
+                role: "assistant",
+              },
+        });
+        completion_tokens += selectedPipeline.getCurRoundDecodingTotalTokens();
+        prompt_tokens += selectedPipeline.getCurRoundPrefillTotalTokens();
+        prefill_time += selectedPipeline.getCurRoundPrefillTotalTime();
+        decode_time += selectedPipeline.getCurRoundDecodingTotalTime();
+      }
+
+      const response: ChatCompletion = {
+        id: crypto.randomUUID(),
+        choices: choices,
+        model: selectedModelId,
+        object: "chat.completion",
+        created: Date.now(),
+        usage: {
+          completion_tokens: completion_tokens,
+          prompt_tokens: prompt_tokens,
+          total_tokens: completion_tokens + prompt_tokens,
+          extra: {
+            prefill_tokens_per_s: prompt_tokens / prefill_time,
+            decode_tokens_per_s: completion_tokens / decode_time,
+          },
+        } as CompletionUsage,
+      };
+
+      // Reset seed -- we do not want this seed to affect future requests
+      if (request.seed !== null && request.seed !== undefined) {
+        selectedPipeline.setSeed(Date.now());
+      }
+      return response;
+    } finally {
+      await lock.release();
     }
-    return response;
   }
 
   /**
@@ -847,6 +898,10 @@ export class MLCEngine implements MLCEngineInterface {
       top_logprobs: request.top_logprobs,
     };
 
+    // 0.5 Block wait until this pipeline finishes all previous requests
+    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
+    await lock.acquire();
+
     // 1. If request is streaming, return an AsyncIterable (an iterable version of `_generate()`)
     if (request.stream) {
       return this.asyncGenerate(
@@ -858,72 +913,77 @@ export class MLCEngine implements MLCEngineInterface {
       );
     }
 
-    if (request.seed !== null && request.seed !== undefined) {
-      selectedPipeline.setSeed(request.seed);
-    }
-
-    // 2. If request is non-streaming, directly reuse `_generate()`
-    const n = request.n ? request.n : 1;
-    const choices: Array<CompletionChoice> = [];
-    let completion_tokens = 0;
-    let prompt_tokens = 0;
-    let prefill_time = 0;
-    let decode_time = 0;
-    for (let i = 0; i < n; i++) {
-      let outputMessage: string;
-      if (this.interruptSignal) {
-        // A single interrupt signal should stop all choices' generations
-        selectedPipeline.triggerStop();
-        outputMessage = "";
-      } else {
-        outputMessage = await this._generate(
-          request,
-          selectedPipeline,
-          selectedChatConfig,
-          genConfig,
-        );
+    // Big try-finally to release lock in case of errors
+    try {
+      if (request.seed !== null && request.seed !== undefined) {
+        selectedPipeline.setSeed(request.seed);
       }
-      const finish_reason = selectedPipeline.getFinishReason()!;
 
-      choices.push({
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        finish_reason: finish_reason,
-        index: i,
-        logprobs: request.logprobs
-          ? ({
-              content: selectedPipeline.getTokenLogprobArray(),
-            } as ChatCompletion.Choice.Logprobs)
-          : null,
-        text: request.echo ? request.prompt + outputMessage : outputMessage,
-      });
-      completion_tokens += selectedPipeline.getCurRoundDecodingTotalTokens();
-      prompt_tokens += selectedPipeline.getCurRoundPrefillTotalTokens();
-      prefill_time += selectedPipeline.getCurRoundPrefillTotalTime();
-      decode_time += selectedPipeline.getCurRoundDecodingTotalTime();
+      // 2. If request is non-streaming, directly reuse `_generate()`
+      const n = request.n ? request.n : 1;
+      const choices: Array<CompletionChoice> = [];
+      let completion_tokens = 0;
+      let prompt_tokens = 0;
+      let prefill_time = 0;
+      let decode_time = 0;
+      for (let i = 0; i < n; i++) {
+        let outputMessage: string;
+        if (this.interruptSignal) {
+          // A single interrupt signal should stop all choices' generations
+          selectedPipeline.triggerStop();
+          outputMessage = "";
+        } else {
+          outputMessage = await this._generate(
+            request,
+            selectedPipeline,
+            selectedChatConfig,
+            genConfig,
+          );
+        }
+        const finish_reason = selectedPipeline.getFinishReason()!;
+
+        choices.push({
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          finish_reason: finish_reason,
+          index: i,
+          logprobs: request.logprobs
+            ? ({
+                content: selectedPipeline.getTokenLogprobArray(),
+              } as ChatCompletion.Choice.Logprobs)
+            : null,
+          text: request.echo ? request.prompt + outputMessage : outputMessage,
+        });
+        completion_tokens += selectedPipeline.getCurRoundDecodingTotalTokens();
+        prompt_tokens += selectedPipeline.getCurRoundPrefillTotalTokens();
+        prefill_time += selectedPipeline.getCurRoundPrefillTotalTime();
+        decode_time += selectedPipeline.getCurRoundDecodingTotalTime();
+      }
+
+      const response: Completion = {
+        id: crypto.randomUUID(),
+        choices: choices,
+        model: selectedModelId,
+        object: "text_completion",
+        created: Date.now(),
+        usage: {
+          completion_tokens: completion_tokens,
+          prompt_tokens: prompt_tokens,
+          total_tokens: completion_tokens + prompt_tokens,
+          extra: {
+            prefill_tokens_per_s: prompt_tokens / prefill_time,
+            decode_tokens_per_s: completion_tokens / decode_time,
+          },
+        } as CompletionUsage,
+      };
+
+      // Reset seed -- we do not want this seed to affect future requests
+      if (request.seed !== null && request.seed !== undefined) {
+        selectedPipeline.setSeed(Date.now());
+      }
+      return response;
+    } finally {
+      await lock.release();
     }
-
-    const response: Completion = {
-      id: crypto.randomUUID(),
-      choices: choices,
-      model: selectedModelId,
-      object: "text_completion",
-      created: Date.now(),
-      usage: {
-        completion_tokens: completion_tokens,
-        prompt_tokens: prompt_tokens,
-        total_tokens: completion_tokens + prompt_tokens,
-        extra: {
-          prefill_tokens_per_s: prompt_tokens / prefill_time,
-          decode_tokens_per_s: completion_tokens / decode_time,
-        },
-      } as CompletionUsage,
-    };
-
-    // Reset seed -- we do not want this seed to affect future requests
-    if (request.seed !== null && request.seed !== undefined) {
-      selectedPipeline.setSeed(Date.now());
-    }
-    return response;
   }
 
   async embedding(
@@ -936,34 +996,42 @@ export class MLCEngine implements MLCEngineInterface {
     );
     API.postInitAndCheckFieldsEmbedding(request, selectedModelId);
 
-    // 1. Call EmbeddingPipeline to get embeddings
-    const embedResult: Array<Array<number>> = await selectedPipeline.embedStep(
-      request.input,
-    );
+    // 0.5 Block wait until this pipeline finishes all previous requests
+    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
+    await lock.acquire();
 
-    // 2. Prepare response
-    const batchSize = embedResult.length;
-    const data: Array<Embedding> = [];
-    for (let i = 0; i < batchSize; i++) {
-      const curEmbedding: Embedding = {
-        embedding: embedResult[i],
-        index: i,
-        object: "embedding",
-      };
-      data.push(curEmbedding);
-    }
-    return {
-      data: data,
-      model: selectedModelId,
-      object: "list",
-      usage: {
-        prompt_tokens: selectedPipeline.getCurRoundEmbedTotalTokens(),
-        total_tokens: selectedPipeline.getCurRoundEmbedTotalTokens(),
-        extra: {
-          prefill_tokens_per_s: selectedPipeline.getCurRoundEmbedTokensPerSec(),
+    try {
+      // 1. Call EmbeddingPipeline to get embeddings
+      const embedResult: Array<Array<number>> =
+        await selectedPipeline.embedStep(request.input);
+
+      // 2. Prepare response
+      const batchSize = embedResult.length;
+      const data: Array<Embedding> = [];
+      for (let i = 0; i < batchSize; i++) {
+        const curEmbedding: Embedding = {
+          embedding: embedResult[i],
+          index: i,
+          object: "embedding",
+        };
+        data.push(curEmbedding);
+      }
+      return {
+        data: data,
+        model: selectedModelId,
+        object: "list",
+        usage: {
+          prompt_tokens: selectedPipeline.getCurRoundEmbedTotalTokens(),
+          total_tokens: selectedPipeline.getCurRoundEmbedTotalTokens(),
+          extra: {
+            prefill_tokens_per_s:
+              selectedPipeline.getCurRoundEmbedTokensPerSec(),
+          },
         },
-      },
-    };
+      };
+    } finally {
+      await lock.release();
+    }
   }
 
   //-----------------------------
@@ -1091,6 +1159,13 @@ export class MLCEngine implements MLCEngineInterface {
     if (selectedChatConfig === undefined) {
       throw new Error(
         `InternalError: chat config not registered for ${selectedModelId}.`,
+      );
+    }
+
+    // 3. Make sure lock is initialized
+    if (!this.loadedModelIdToLock.has(selectedModelId)) {
+      throw new Error(
+        `InternalError: loadedModelIdToLock does not contain ${selectedModelId}`,
       );
     }
     return [selectedModelId, selectedPipeline, selectedChatConfig];

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -585,6 +585,8 @@ export class MLCEngine implements MLCEngineInterface {
 
     while (!pipeline.stopped()) {
       if (this.interruptSignal) {
+        // TODO: should we directly release lock here and return the async
+        // generator? Though no issue observed as of now with interruptGenerate()
         pipeline.triggerStop();
         break;
       }

--- a/src/support.ts
+++ b/src/support.ts
@@ -272,7 +272,7 @@ export class CustomLock {
     } else {
       // Otherwise, push the request to the queue, and
       // a future release() will resolve it
-      return new Promise<void>((resolve, _) => {
+      return new Promise<void>((resolve) => {
         this.queue.push(resolve);
       });
     }

--- a/src/support.ts
+++ b/src/support.ts
@@ -251,3 +251,49 @@ export function getModelIdToUse(
   }
   return selectedModelId;
 }
+
+type Cont = () => void;
+
+/**
+ * A lock implemented using Promise.
+ *
+ * Referred to:
+ * - https://jackpordi.com/posts/locks-in-js-because-why-not
+ * - https://www.linkedin.com/pulse/asynchronous-locking-using-promises-javascript-abdul-ahad-o7smf/
+ */
+export class CustomLock {
+  private acquired = false;
+  private readonly queue: Cont[] = [];
+
+  public async acquire(): Promise<void> {
+    if (!this.acquired) {
+      // If lock is free, directly return
+      this.acquired = true;
+    } else {
+      // Otherwise, push the request to the queue, and
+      // a future release() will resolve it
+      return new Promise<void>((resolve, _) => {
+        this.queue.push(resolve);
+      });
+    }
+  }
+
+  public async release(): Promise<void> {
+    if (!this.acquired) {
+      throw Error("InternalError: expect lock is acquired upon release()");
+    }
+    if (this.queue.length === 0) {
+      // No one is waiting for the lock, so we free it
+      this.acquired = false;
+      return;
+    }
+
+    // Otherwise, hand the execution to the next in queue, and
+    // the lock is still acquired
+    const cont = this.queue.shift();
+    return new Promise((res: Cont) => {
+      cont!();
+      res();
+    });
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,7 +125,7 @@ export interface MLCEngineInterface {
    * maintaining the chat history. With that being said, as an implicit internal optimization, if we
    * detect that the user is performing multi-round chatting, we will preserve the KV cache and only
    * prefill the new tokens.
-   *
+   * @note For requests sent to the same modelId, will block until all previous requests finish.
    * @note For more, see https://platform.openai.com/docs/api-reference/chat
    */
   chatCompletion(
@@ -147,6 +147,7 @@ export interface MLCEngineInterface {
    *
    * @param request An OpenAI-style Completion request.
    *
+   * @note For requests sent to the same modelId, will block until all previous requests finish.
    * @note For more, see https://platform.openai.com/docs/api-reference/completions
    */
   completion(request: CompletionCreateParamsNonStreaming): Promise<Completion>;
@@ -166,6 +167,7 @@ export interface MLCEngineInterface {
    *
    * @param request An OpenAI-style Embeddings request.
    *
+   * @note For requests sent to the same modelId, will block until all previous requests finish.
    * @note For more, see https://platform.openai.com/docs/api-reference/embeddings/create
    */
   embedding(request: EmbeddingCreateParams): Promise<CreateEmbeddingResponse>;

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -4,7 +4,12 @@ import {
   SpecifiedModelNotFoundError,
   UnclearModelToUseError,
 } from "../src/error";
-import { cleanModelUrl, getModelIdToUse, getTopProbs } from "../src/support";
+import {
+  cleanModelUrl,
+  CustomLock,
+  getModelIdToUse,
+  getTopProbs,
+} from "../src/support";
 import { areChatOptionsListEqual } from "../src/utils";
 import { MLCEngine } from "../src/engine";
 
@@ -311,5 +316,23 @@ describe("Test areChatOptionsListEqual", () => {
       dummyChatOpts1,
     ];
     expect(areChatOptionsListEqual(options1, options2)).toEqual(true);
+  });
+});
+
+// Refers to https://jackpordi.com/posts/locks-in-js-because-why-not
+describe("Test CustomLock", () => {
+  test("Ensure five +1's give 5 with sleep between read/write", async () => {
+    let value = 0;
+    const lock = new CustomLock();
+
+    async function addOne() {
+      await lock.acquire();
+      const readValue = value;
+      await new Promise((r) => setTimeout(r, 100));
+      value = readValue + 1;
+      await lock.release();
+    }
+    await Promise.all([addOne(), addOne(), addOne(), addOne(), addOne()]);
+    expect(value).toEqual(5); // without a lock, most likely less than 5
   });
 });


### PR DESCRIPTION
A model cannot handle > 1 concurrent request (e.g. >1 calls to `chat.completions.create()`) since we do not support continuous batching, and each request requires its own resources such as the KV cache. (Though "concurrent" requests to different models in the same engine is supported)

 As a result, as pointed out in https://github.com/mlc-ai/web-llm/issues/522, when users try something like the following code:

```typescript
const engine = await CreateMLCEngine("Phi-3-mini-4k-instruct-q4f16_1-MLC")
async function sendRequest() {
  const reply = await engine.chat.completions.create({
    messages: [{ role: "user", content: "Hello!" }],
    max_tokens: 64,
  });
  console.log(reply.choices[0].message.content);
}
await Promise.all([sendRequest(), sendRequest()]);
```

the model's state and the generation result are messed up.

To resolve this, we implement `CustomLock` using Promise, maintaining a queue to ensure FCFS for incoming requests to a model, such that for a single model, a request only starts when all previous requests are finished. The code above now works.

### Implementation Details
- We add `loadedModelIdToLock` to MLCEngine, maintaining a lock for each loaded engine
  - Reminder: the need for a critical section is only per model, since each loaded model has its own `LLMChatPipeline` / `EmbeddingPipeline`
- `loadedModelIdToLock` is cleared in `unload()`, set in `reloadInternal()`
- We acquire lock at the very beginning of `completion()`, `chatCompletion()` and `embedding()`, after knowing which model this current call will use
- We release lock at the end of `embedding()`, `completion()` and `chatCompletion()` (for non-streaming cases), and `asyncGenerate()` (for streaming cases)
- Since we also want to release the lock when errors occur, we wrap the code with a big `try` `finally`
- Since `asyncGenerate()` is an async generator, we add `try` `catch` fine-grainedly, only in places that can throw errors
  - This makes the code less readable, but not sure if there is a better solution.
- For WebWorkerMLCEngine, no special handling is needed, since the WebWorkerMLCEngineHandler calls the underlying engine's APIs (e.g. `chatCompletion()`), which will block

### Tested
- Tested `CustomLock` implementation with unit test (implementation follows [this blog post](https://jackpordi.com/posts/locks-in-js-because-why-not))
- Above example now works
- [get-started, get-started-web-worker] x [streaming, non-streaming] x [concurrent requests, single request]
- examples/simple-chat-ts
- examples/multi-models
- WebLLMChat (with generation interrupts, manual termination of service worker)
  - Opening two tabs WebLLMChat, sending concurrent request, the latter request will wait for the previous one to finish (prior to this PR, garbage output will be generated just like the above simple example, since the two WebLLMChat shares the same service worker, hence the same engine).
