### PR TITLE
[RAG] Add example for RAG with Langchain.js

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ Note that all examples below run in-browser and use WebGPU as a backend.
 - [next-simple-chat](next-simple-chat): a mininum and complete chat bot app with [Next.js](https://nextjs.org/).
 - [multi-round-chat](multi-round-chat): while APIs are functional, we internally optimize so that multi round chat usage can reuse KV cache
 - [text-completion](text-completion): demonstrates API `engine.completions.create()`, which is pure text completion with no conversation, as opposed to `engine.chat.completions.create()`
-- [embeddings](embeddings): demonstrates API `engine.embeddings.create()`, and integration with `EmbeddingsInterface` and `MemoryVectorStore` of [Langchain.js](js.langchain.com)
+- [embeddings](embeddings): demonstrates API `engine.embeddings.create()`, integration with `EmbeddingsInterface` and `MemoryVectorStore` of [Langchain.js](js.langchain.com), and RAG with Langchain.js using WebLLM for both LLM and Embedding in a single engine
 - [multi-models](multi-models): demonstrates loading multiple models in a single engine concurrently
 
 #### Advanced OpenAI API Capabilities


### PR DESCRIPTION
Add a simple example of RAG using Langchain.js, following [its cookbook](https://js.langchain.com/v0.1/docs/expression_language/cookbook/retrieval/).

We use WebLLM for both embedding and LLM, within a single engine. There are many possible ways to achieve RAG (e.g. degree of integration with Langchain, using WebWorker, etc.). We only provide a minimal example here.