### PR TITLE
[Model] Add Phi3.5-mini

### DIFF
--- a/examples/multi-models/src/main.ts
+++ b/examples/multi-models/src/main.ts
@@ -21,7 +21,7 @@ const initProgressCallback = (report: webllm.InitProgressReport) => {
 };
 
 // Prepare request for each model, same for both methods
-const selectedModel1 = "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k";
+const selectedModel1 = "Phi-3.5-mini-instruct-q4f32_1-MLC-1k";
 const selectedModel2 = "gemma-2-2b-it-q4f32_1-MLC-1k";
 const prompt1 = "Tell me about California in 3 short sentences.";
 const prompt2 = "Tell me about New York City in 3 short sentences.";

--- a/src/config.ts
+++ b/src/config.ts
@@ -431,14 +431,14 @@ export const prebuiltAppConfig: AppConfig = {
         sliding_window_size: -1,
       },
     },
-    // Phi3-mini-instruct
+    // Phi3.5-mini-instruct
     {
-      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
-      model_id: "Phi-3-mini-4k-instruct-q4f16_1-MLC",
+      model: "https://huggingface.co/mlc-ai/Phi-3.5-mini-instruct-q4f16_1-MLC",
+      model_id: "Phi-3.5-mini-instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 3672.07,
       low_resource_required: false,
       overrides: {
@@ -446,12 +446,12 @@ export const prebuiltAppConfig: AppConfig = {
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
-      model_id: "Phi-3-mini-4k-instruct-q4f32_1-MLC",
+      model: "https://huggingface.co/mlc-ai/Phi-3.5-mini-instruct-q4f32_1-MLC",
+      model_id: "Phi-3.5-mini-instruct-q4f32_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 5483.12,
       low_resource_required: false,
       overrides: {
@@ -459,12 +459,12 @@ export const prebuiltAppConfig: AppConfig = {
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
-      model_id: "Phi-3-mini-4k-instruct-q4f16_1-MLC-1k",
+      model: "https://huggingface.co/mlc-ai/Phi-3.5-mini-instruct-q4f16_1-MLC",
+      model_id: "Phi-3.5-mini-instruct-q4f16_1-MLC-1k",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 2520.07,
       low_resource_required: true,
       overrides: {
@@ -472,12 +472,12 @@ export const prebuiltAppConfig: AppConfig = {
       },
     },
     {
-      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
-      model_id: "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k",
+      model: "https://huggingface.co/mlc-ai/Phi-3.5-mini-instruct-q4f32_1-MLC",
+      model_id: "Phi-3.5-mini-instruct-q4f32_1-MLC-1k",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       vram_required_MB: 3179.12,
       low_resource_required: true,
       overrides: {
@@ -1222,6 +1222,59 @@ export const prebuiltAppConfig: AppConfig = {
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
+      },
+    },
+    // Phi3-mini-instruct
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
+      model_id: "Phi-3-mini-4k-instruct-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 3672.07,
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
+      model_id: "Phi-3-mini-4k-instruct-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 5483.12,
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
+      model_id: "Phi-3-mini-4k-instruct-q4f16_1-MLC-1k",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 2520.07,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f32_1-MLC",
+      model_id: "Phi-3-mini-4k-instruct-q4f32_1-MLC-1k",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+      vram_required_MB: 3179.12,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 1024,
       },
     },
     // Llama-2


### PR DESCRIPTION
This PR adds the newly release Phi3.5-mini, adding the following `model_id`s to our prebuilt model list:
- `Phi-3.5-mini-instruct-q4f16_1-MLC` (4k KVCache)
- `Phi-3.5-mini-instruct-q4f32_1-MLC` (4k KVCache)
- `Phi-3.5-mini-instruct-q4f16_1-MLC-1k` (1k KVCache)
- `Phi-3.5-mini-instruct-q4f16_1-MLC-1k` (1k KVCache)

See https://github.com/mlc-ai/binary-mlc-llm-libs/pull/136 for on which commits of TVM and MLC-LLM this is compiled with.

Note that Phi-3.5-mini comes with support up to 128K context (unlike Phi-3-mini which only has 4k) thanks to rope scaling which MLC-LLM supports, which you can take advantage of in WebLLM by increasing `ModelRecord.overrides.context_window_size` or specifying it in `ChatOptions` when loading a model, as long as there is enough VRAM.