### PR TITLE
[Fix] Support using multiple JSON schemas per engine instance

### DIFF
--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -506,7 +506,7 @@ export class LLMChatPipeline {
         if (this.grammarStateMatcher) {
           this.grammarStateMatcher.dispose();
         }
-        if (this.tokenTable === undefined) {
+        if (this.tokenTable === undefined || !this.tokenTable.handle) {
           const rawTokenTable = getTokenTableFromTokenizer(this.tokenizer);
           // Post process entire table
           this.tokenTable = this.fpostProcessTokenTable(


### PR DESCRIPTION
This PR fixes https://github.com/mlc-ai/web-llm/issues/560 and possibly https://github.com/mlc-ai/web-llm/issues/486 by creating a new `tokenTable` if the old one has been disposed. 