### PR TITLE
[Version] Bump version to 0.2.65

### DIFF
--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64",
+    "@mlc-ai/web-llm": "^0.2.65",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64",
+    "@mlc-ai/web-llm": "^0.2.65",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/embeddings/package.json
+++ b/examples/embeddings/package.json
@@ -15,7 +15,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64",
+    "@mlc-ai/web-llm": "^0.2.65",
     "langchain": "0.2.15"
   }
 }

--- a/examples/function-calling/function-calling-manual/package.json
+++ b/examples/function-calling/function-calling-manual/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/function-calling/function-calling-openai/package.json
+++ b/examples/function-calling/function-calling-openai/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64",
+    "@mlc-ai/web-llm": "^0.2.65",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/text-completion/package.json
+++ b/examples/text-completion/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64"
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/examples/vision-model/package.json
+++ b/examples/vision-model/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "file:../.."
+    "@mlc-ai/web-llm": "^0.2.65"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.64",
+      "version": "0.2.65",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.64",
+    "@mlc-ai/web-llm": "^0.2.65",
     "tvmjs": "file:./../../tvm_home/web"
   }
 }


### PR DESCRIPTION
### Changes
- The only change is the support of Phi-3.5-vision:
  - https://github.com/mlc-ai/web-llm/pull/563
  - Added `Phi-3.5-vision-instruct-q4f16_1-MLC` and `Phi-3.5-vision-instruct-q4f32_1-MLC` to prebuilt model list
  - See `examples/vision-model` on how to use vision language model in WebLLM

### TVMjs
- Compiled at https://github.com/apache/tvm/commit/931efc72b2a80d3d21c227324217de9ce76256ca
  - Cherry-picked https://github.com/apache/tvm/pull/17404 on top
    - Note this does not require us to recompile non-vision models because text-only inputs will not need embeddings concatenation
- WASMs: still the same `v0_2_48` WASMs
