### PR TITLE
[Version] Bump version to 0.2.67

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ npm install
 npm run build
 ```
 
-Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.66"` to `"@mlc-ai/web-llm": ../..`.
+Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.67"` to `"@mlc-ai/web-llm": ../..`.
 
 Then run:
 

--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66",
+    "@mlc-ai/web-llm": "^0.2.67",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66",
+    "@mlc-ai/web-llm": "^0.2.67",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/embeddings/package.json
+++ b/examples/embeddings/package.json
@@ -15,7 +15,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66",
+    "@mlc-ai/web-llm": "^0.2.67",
     "langchain": "0.2.15"
   }
 }

--- a/examples/function-calling/function-calling-manual/package.json
+++ b/examples/function-calling/function-calling-manual/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/function-calling/function-calling-openai/package.json
+++ b/examples/function-calling/function-calling-openai/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66",
+    "@mlc-ai/web-llm": "^0.2.67",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/text-completion/package.json
+++ b/examples/text-completion/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/examples/vision-model/package.json
+++ b/examples/vision-model/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66"
+    "@mlc-ai/web-llm": "^0.2.67"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.66",
+  "version": "0.2.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.66",
+      "version": "0.2.67",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.66",
+  "version": "0.2.67",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.66",
+    "@mlc-ai/web-llm": "^0.2.67",
     "@mlc-ai/web-runtime": "0.18.0-dev0"
   }
 }


### PR DESCRIPTION
### Change
- https://github.com/mlc-ai/web-llm/pull/575
  - Added the following models to the prebuilt list:
    - `Llama-3.2-1B-Instruct-q4f16_1-MLC`
    - `Llama-3.2-1B-Instruct-q4f32_1-MLC`
    - `Llama-3.2-1B-Instruct-q0f16-MLC`
    - `Llama-3.2-1B-Instruct-q0f32-MLC`
    - `Llama-3.2-3B-Instruct-q4f16_1-MLC`
    - `Llama-3.2-3B-Instruct-q4f32_1-MLC`

### TVMjs
- No change, version `0.18.0-dev0` just like 0.2.66
- Built at https://github.com/apache/tvm/commit/30fb16a5e1d564ffa8533cf154c0ba2ea06dfd43