### PR TITLE
[TVMjs] Bump TVMjs version to fix WebGPU backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ While it is also available as an npm package: https://www.npmjs.com/package/@mlc
     function="proc_exit": function import requires a callable
     ```
 
-2. In `./package.json`, change from `"@mlc-ai/web-runtime": "0.18.0-dev0",` to `"tvmjs": "file:./tvm_home/web",`.
+2. In `./package.json`, change from `"@mlc-ai/web-runtime": "0.18.0-dev1",` to `"@mlc-ai/web-runtime": "file:./tvm_home/web",`.
 
 3. Setup necessary environment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "loglevel": "^1.9.1"
       },
       "devDependencies": {
-        "@mlc-ai/web-runtime": "0.18.0-dev0",
+        "@mlc-ai/web-runtime": "0.18.0-dev1",
         "@mlc-ai/web-tokenizers": "^0.1.5",
         "@next/eslint-plugin-next": "^14.2.3",
         "@rollup/plugin-commonjs": "^20.0.0",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@mlc-ai/web-runtime": {
-      "version": "0.18.0-dev0",
-      "resolved": "https://registry.npmjs.org/@mlc-ai/web-runtime/-/web-runtime-0.18.0-dev0.tgz",
-      "integrity": "sha512-fLk/b3CWh4rFhxPzXQxKheaRO3d32DuRDbZENxXfkvgfCgHoxkbVrotuU1XLF7R+rJAtFdkU00T5fEbOLbwJAQ==",
+      "version": "0.18.0-dev1",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-runtime/-/web-runtime-0.18.0-dev1.tgz",
+      "integrity": "sha512-VjUZNDyw0nafbID6wyVdb0JHtxzuuhiSulj5wB5H5JkckaWNn9tuR+YJRiyb9Njqwau0zGE7JYZA3hTvC7/g6g==",
       "dev": true
     },
     "node_modules/@mlc-ai/web-tokenizers": {
@@ -1535,9 +1535,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.5.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
-      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "version": "22.7.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.3.tgz",
+      "integrity": "sha512-qXKfhXXqGTyBskvWEzJZPUxSslAiLaB6JGP1ic/XTH9ctGgzdgYguuLP1C601aRTSDNlLb0jbKqXjZ48GNraSA==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -2075,9 +2075,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "dev": true,
       "funding": [
         {
@@ -2094,8 +2094,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
         "node-releases": "^2.0.18",
         "update-browserslist-db": "^1.1.0"
       },
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001663",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
-      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
+      "version": "1.0.30001664",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
+      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
       "dev": true,
       "funding": [
         {
@@ -2501,9 +2501,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.27",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.27.tgz",
-      "integrity": "sha512-o37j1vZqCoEgBuWWXLHQgTN/KDKe7zwpiY5CPeq2RvUqOyJw9xnrULzZAEVQ5p4h+zjMk7hgtOoPdnLxr7m/jw==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
+      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -5054,9 +5054,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-jest": "^29.1.2",
     "tslib": "^2.3.1",
-    "@mlc-ai/web-runtime": "0.18.0-dev0",
+    "@mlc-ai/web-runtime": "0.18.0-dev1",
     "typescript": "^4.9.5"
   },
   "dependencies": {

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "@mlc-ai/web-llm": "^0.2.69",
-    "@mlc-ai/web-runtime": "0.18.0-dev0"
+    "@mlc-ai/web-runtime": "0.18.0-dev1"
   }
 }


### PR DESCRIPTION
This PR bumps TVMjs (i.e. `@mlc-ai/web-runtime`) from `0.18.0-dev0` to `0.18.0-dev1`.

The only change is:
- https://github.com/apache/tvm/pull/17420

TVMjs `0.18.0-dev1` is compiled at https://github.com/apache/tvm/commit/5e85443e43f9befcf8319cdc4045597aa49bf724 with https://github.com/apache/tvm/pull/17420 cherry-picked on top
 
This should fix:
- https://github.com/mlc-ai/web-llm/issues/572