### PR TITLE
[Version] Bump version to 0.2.71

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ npm install
 npm run build
 ```
 
-Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.70"` to `"@mlc-ai/web-llm": ../..`.
+Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.71"` to `"@mlc-ai/web-llm": ../..`.
 
 Then run:
 
@@ -407,7 +407,7 @@ While it is also available as an npm package: https://www.npmjs.com/package/@mlc
     function="proc_exit": function import requires a callable
     ```
 
-2. In `./package.json`, change from `"@mlc-ai/web-runtime": "0.18.0-dev1",` to `"@mlc-ai/web-runtime": "file:./tvm_home/web",`.
+2. In `./package.json`, change from `"@mlc-ai/web-runtime": "0.18.0-dev2",` to `"@mlc-ai/web-runtime": "file:./tvm_home/web",`.
 
 3. Setup necessary environment
 

--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70",
+    "@mlc-ai/web-llm": "^0.2.71",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70",
+    "@mlc-ai/web-llm": "^0.2.71",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/embeddings/package.json
+++ b/examples/embeddings/package.json
@@ -15,7 +15,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70",
+    "@mlc-ai/web-llm": "^0.2.71",
     "langchain": "0.2.15"
   }
 }

--- a/examples/function-calling/function-calling-manual/package.json
+++ b/examples/function-calling/function-calling-manual/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/function-calling/function-calling-openai/package.json
+++ b/examples/function-calling/function-calling-openai/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70",
+    "@mlc-ai/web-llm": "^0.2.71",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/text-completion/package.json
+++ b/examples/text-completion/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/examples/vision-model/package.json
+++ b/examples/vision-model/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70"
+    "@mlc-ai/web-llm": "^0.2.71"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.70",
+      "version": "0.2.71",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"
       },
       "devDependencies": {
-        "@mlc-ai/web-runtime": "0.18.0-dev1",
+        "@mlc-ai/web-runtime": "0.18.0-dev2",
         "@mlc-ai/web-tokenizers": "^0.1.5",
         "@next/eslint-plugin-next": "^14.2.3",
         "@rollup/plugin-commonjs": "^20.0.0",
@@ -1221,9 +1221,9 @@
       }
     },
     "node_modules/@mlc-ai/web-runtime": {
-      "version": "0.18.0-dev1",
-      "resolved": "https://registry.npmjs.org/@mlc-ai/web-runtime/-/web-runtime-0.18.0-dev1.tgz",
-      "integrity": "sha512-VjUZNDyw0nafbID6wyVdb0JHtxzuuhiSulj5wB5H5JkckaWNn9tuR+YJRiyb9Njqwau0zGE7JYZA3hTvC7/g6g==",
+      "version": "0.18.0-dev2",
+      "resolved": "https://registry.npmjs.org/@mlc-ai/web-runtime/-/web-runtime-0.18.0-dev2.tgz",
+      "integrity": "sha512-1GQvvEXmZwU0XXVg2Y7aiueZ5xUy592BqfxyatUvuKGlcwjmfSKQ5atHR42AX5ysO4jGi6wngirBNg+UoMSKLw==",
       "dev": true
     },
     "node_modules/@mlc-ai/web-tokenizers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -50,7 +50,7 @@
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-jest": "^29.1.2",
     "tslib": "^2.3.1",
-    "@mlc-ai/web-runtime": "0.18.0-dev1",
+    "@mlc-ai/web-runtime": "0.18.0-dev2",
     "typescript": "^4.9.5"
   },
   "dependencies": {

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.70",
-    "@mlc-ai/web-runtime": "0.18.0-dev1"
+    "@mlc-ai/web-llm": "^0.2.71",
+    "@mlc-ai/web-runtime": "0.18.0-dev2"
   }
 }


### PR DESCRIPTION
### Change

- This version tries to solve the same issue in `0.2.70`, which bumped TVMjs from `0.18.0-dev0` to `0.18.0.dev1`
- This version bumps from `0.18.0.dev1` to `0.18.0.dev2`
- The previous issue described in https://github.com/mlc-ai/web-llm/pull/581 was not resolved as https://github.com/apache/tvm/pull/17420 missed an `await`. `0.18.0.dev2` resolves this. Confirmed in an older version of Brave browser: `Version 1.65.133 Chromium: 124.0.6367.208 (Official Build) (arm64)`

### TVMjs
- Updated TVMjs to `0.18.0-dev2`, compiled at https://github.com/apache/tvm/commit/5e85443e43f9befcf8319cdc4045597aa49bf724 with https://github.com/apache/tvm/pull/17420 cherry-picked on top
- The only diff is https://github.com/apache/tvm/pull/17420