### PR TITLE
[Expose] Expose ModelType Enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export {
   ChatOptions,
   MLCEngineConfig,
   GenerationConfig,
+  ModelType,
   prebuiltAppConfig,
   modelVersion,
   modelLibURLPrefix,


### PR DESCRIPTION
This PR exports the `ModelType` enumeration defined in `config.ts` so that clients could use it to differentiate different types of models.