### PR TITLE
Expose the tokenizer to clients

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -70,6 +70,7 @@ import {
 } from "./error";
 import { asyncLoadTokenizer } from "./cache_util";
 import { EmbeddingPipeline } from "./embedding";
+import { Tokenizer } from "@mlc-ai/web-tokenizers";
 
 /**
  * Creates `MLCEngine`, and loads `modelId` onto WebGPU.
@@ -131,6 +132,7 @@ export class MLCEngine implements MLCEngineInterface {
   private logitProcessorRegistry?: Map<string, LogitProcessor>;
   private initProgressCallback?: InitProgressCallback;
   private appConfig: AppConfig;
+  private tokenizer: Tokenizer | null = null;
 
   // Signals and flags
   private interruptSignal = false;
@@ -359,7 +361,7 @@ export class MLCEngine implements MLCEngineInterface {
     });
     tvm.initWebGPU(gpuDetectOutput.device);
 
-    const tokenizer = await asyncLoadTokenizer(
+    this.tokenizer = await asyncLoadTokenizer(
       modelUrl,
       curModelConfig,
       this.appConfig,
@@ -379,11 +381,11 @@ export class MLCEngine implements MLCEngineInterface {
     // embedding model, and prompt user to use ModelRecord.model_type
     let newPipeline: LLMChatPipeline | EmbeddingPipeline;
     if (modelRecord.model_type === ModelType.embedding) {
-      newPipeline = new EmbeddingPipeline(tvm, tokenizer, curModelConfig);
+      newPipeline = new EmbeddingPipeline(tvm, this.tokenizer, curModelConfig);
     } else {
       newPipeline = new LLMChatPipeline(
         tvm,
-        tokenizer,
+        this.tokenizer,
         curModelConfig,
         logitProcessor,
       );
@@ -1332,5 +1334,17 @@ export class MLCEngine implements MLCEngineInterface {
    */
   async decode(pipeline: LLMChatPipeline, genConfig?: GenerationConfig) {
     return pipeline.decodeStep(genConfig);
+  }
+
+  //-----------------------------------------------
+  // 8. Expose tokenizer
+  //-----------------------------------------------
+
+  async tokenize(text: string) {
+    return this.tokenizer!.encode(text);
+  }
+
+  async decodeTokens(ids: Int32Array) {
+    return this.tokenizer!.decode(ids);
   }
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -34,7 +34,9 @@ type RequestKind =
   | "customRequest"
   | "keepAlive"
   | "setLogLevel"
-  | "setAppConfig";
+  | "setAppConfig"
+  | "tokenize"
+  | "decodeTokens";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ResponseKind = "return" | "throw" | "initProgressCallback";
@@ -57,6 +59,12 @@ export interface ForwardTokensAndSampleParams {
   inputIds: Array<number>;
   isPrefill: boolean;
   modelId?: string;
+}
+export interface TokenizeParams {
+  text: string;
+}
+export interface DecodeTokensParams {
+  inputIds: Int32Array;
 }
 
 // Notes on the following Params with modelId and chatOpts:
@@ -128,6 +136,7 @@ export type MessageContent =
   | CreateEmbeddingResponse
   | Completion
   | AppConfig
+  | Int32Array
   | void;
 /**
  * The message used in exchange between worker

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,12 @@ export interface MLCEngineInterface {
   embedding(request: EmbeddingCreateParams): Promise<CreateEmbeddingResponse>;
 
   /**
+   * Exposes the tokenizer for clients to avoid needing to load it twice
+   */
+  tokenize(input: string): Promise<Int32Array>;
+  decodeTokens(input: Int32Array): Promise<string>;
+
+  /**
    * @returns A text summarizing the runtime stats.
    * @param modelId Only required when multiple models are loaded.
    * @note This is an async function


### PR DESCRIPTION
Some of the client exposed features of web-llm require tokenization and decoding of tokens to be used effectively. The tokenizer is already loaded for web-llm's internal functionality and can be made available to clients. When clients use the tokenizer that is already loaded, it avoids the need to load another copy and also provides immediate reliable access to a tokenizer for any model that is supported by web-llm, rather than requiring clients to manage different tokenizers for models themselves.