### PR TITLE
Fix VRAM required by Qwen2.5-Coder-1.5B-Instruct model

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1134,7 +1134,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelVersion +
         "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
       low_resource_required: false,
-      vram_required_MB: 5106.67,
+      vram_required_MB: 1629.75,
       overrides: {
         context_window_size: 4096,
       },
@@ -1148,7 +1148,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelVersion +
         "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
       low_resource_required: false,
-      vram_required_MB: 5900.09,
+      vram_required_MB: 1888.97,
       overrides: {
         context_window_size: 4096,
       },


### PR DESCRIPTION
Currently, it has the same VRAM values as the `Qwen2.5-Coder-7B-Instruct` model.

This change fixes it using the same values from the `Qwen2.5-1.5B-Instruct` model.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/68828d13-594f-4458-96f0-7611eeb2996b">
