### PR TITLE
[Version] Bump version to 0.2.79

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ npm install
 npm run build
 ```
 
-Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.78"` to `"@mlc-ai/web-llm": ../..`.
+Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.79"` to `"@mlc-ai/web-llm": ../..`.
 
 Then run:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@ copyright = "2023, %s" % author
 
 # Version information.
 
-version = "0.2.78"
-release = "0.2.78"
+version = "0.2.79"
+release = "0.2.79"
 
 extensions = [
     "sphinx_tabs.tabs",

--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/embeddings/package.json
+++ b/examples/embeddings/package.json
@@ -15,7 +15,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "langchain": "0.2.15"
   }
 }

--- a/examples/function-calling/function-calling-manual/package.json
+++ b/examples/function-calling/function-calling-manual/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/function-calling/function-calling-openai/package.json
+++ b/examples/function-calling/function-calling-openai/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/qwen3/package.json
+++ b/examples/qwen3/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/text-completion/package.json
+++ b/examples/text-completion/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/examples/vision-model/package.json
+++ b/examples/vision-model/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78"
+    "@mlc-ai/web-llm": "^0.2.79"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.78",
+      "version": "0.2.79",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/openai_api_protocols/chat_completion.ts
+++ b/src/openai_api_protocols/chat_completion.ts
@@ -262,8 +262,8 @@ export interface ChatCompletionRequestBase {
    */
   extra_body?: {
     /**
-     * If set to false, prepend a "<think></think>" to the response, preventing the model from
-     * generating thinking tokens. If set to true or undefined, does nothing.
+     * If set to false, prepend a "<think>\n\n</think>\n\n" to the response, preventing the
+     * model from generating thinking tokens. If set to true or undefined, does nothing.
      *
      * @note Currently only allowed to be used for Qwen3 models, though not explicitly checked.
      */

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.78",
+    "@mlc-ai/web-llm": "^0.2.79",
     "@mlc-ai/web-runtime": "0.18.0-dev2"
   }
 }


### PR DESCRIPTION
### Change
- The only change is https://github.com/mlc-ai/web-llm/pull/686, which
  - Add prebuilt models:
    - Qwen3-0.6B: `q0f16, q0f32, q4f16_1, q4f32_1`
    - Other Qwen3: `{1.7B, 4B, 8B} x {q4f16_1, q4f32_1}`
  - Support `extra_body: {enable_thinking: false}` for qwen3 models to toggle thinking
    - See `examples/qwen3` for more on Qwen3 usage
  - Also bumped `web-tokenizers` package to `0.1.6` to resolve rust-related issues


### TVMjs
- No change, version `0.18.0-dev2` just like 0.2.71