### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
 
 [Documentation](https://webllm.mlc.ai/docs/) | [Blogpost](https://blog.mlc.ai/2024/06/13/webllm-a-high-performance-in-browser-llm-inference-engine) | [Paper](https://arxiv.org/abs/2412.15803) | [Examples](examples)
 
+Readme-i18n: <!-- Keep these links. Translations will automatically update with the README. -->
+[Deutsch](https://www.readme-i18n.com/mlc-ai/web-llm?lang=de) | 
+[Español](https://www.readme-i18n.com/mlc-ai/web-llm?lang=es) | 
+[français](https://www.readme-i18n.com/mlc-ai/web-llm?lang=fr) | 
+[日本語](https://www.readme-i18n.com/mlc-ai/web-llm?lang=ja) | 
+[한국어](https://www.readme-i18n.com/mlc-ai/web-llm?lang=ko) | 
+[Português](https://www.readme-i18n.com/mlc-ai/web-llm?lang=pt) | 
+[Русский](https://www.readme-i18n.com/mlc-ai/web-llm?lang=ru) | 
+[中文](https://www.readme-i18n.com/mlc-ai/web-llm?lang=zh)
 </div>
 
 ## Overview


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese.

The updated can be previewed in my forked repository: https://github.com/dowithless/web-llm/tree/patch-1
