### PR TITLE
Fix typo

### DIFF
--- a/docs/user/get_started.rst
+++ b/docs/user/get_started.rst
@@ -19,7 +19,7 @@ Installation
 
 WebLLM offers a minimalist and modular interface to access the chatbot in the browser. The package is designed in a modular way to hook to any of the UI components.
 
-WebLLM is available as an `npm package <https://www.npmjs.com/package/@mlc-ai/web-llm>`_ and is also CDN-delivered. Therefore, you can install WebLLM using Node.js pacakage managers like npm, yarn, or pnpm, or directly import the pacakge via CDN.
+WebLLM is available as an `npm package <https://www.npmjs.com/package/@mlc-ai/web-llm>`_ and is also CDN-delivered. Therefore, you can install WebLLM using Node.js package managers like npm, yarn, or pnpm, or directly import the pacakge via CDN.
 
 Using Package Managers
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR fixes a typo in the getting started docs:

```diff
- pacakage
+ package
```

This documentation is published to https://webllm.mlc.ai/docs/user/get_started.html