### PR TITLE
Bump modelVersion to v0_2_80

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -288,7 +288,7 @@ export interface AppConfig {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_48";
+export const modelVersion = "v0_2_80";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 


### PR DESCRIPTION
Bump modelVersion to v0_2_80 after binary-mlc-llm-libs update (https://github.com/mlc-ai/binary-mlc-llm-libs/commit/eb90a953b50c3dded4f23b932dabeb773591e07e)