### PR TITLE
[Kernels] Migrate sampling to WebGPU

### DIFF
--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -1055,6 +1055,8 @@ export class LLMChatPipeline {
       if (_hasValue(genConfig.top_p)) {
         top_p = genConfig.top_p!;
       }
+      // TODO: setting top_p to 1.0 by default might run into issues since
+      // top_p masking in relax uses < instead of <=
       // Set default top_p to 1.0 if not set
       if (!_hasValue(top_p)) {
         top_p = 1.0;
@@ -1068,7 +1070,7 @@ export class LLMChatPipeline {
       if (_hasValue(genConfig.presence_penalty)) {
         presence_penalty = genConfig.presence_penalty!;
       }
-      // If only one of frequency or presence penatly is set, make the other one 0.0
+      // If only one of frequency or presence penalty is set, make the other one 0.0
       if (_hasValue(frequency_penalty) && !_hasValue(presence_penalty)) {
         presence_penalty = 0.0;
       }


### PR DESCRIPTION
This PR completely replaces CPU sampling with WebGPU sampling. Based on the code in https://github.com/mlc-ai/mlc-llm/blob/main/cpp/serve/sampler/gpu_sampler.cc, the ```logprobs``` flag does not affect the kernels being called. Specifically, branching only occurs based on whether or not we wish to use ```top_p```. In the case where ```top_p``` is not set, we would need to use ```multinomial_sampling_func``` / ```parallel_sampling_from_prob```, which is currently not possible due to the use of ```i8s```. Most models have a default ```top_p``` value, and I set ```top_p = 1.0``` when this is not the case, which allows removal of the else branch.

Performance Comparison (decode tokens/s) with v0.2.79: Compared performance for "canonical" flows averaged across 10 runs with the following configuration:
```
const TEST_PROMPT = "Explain, in at least 100 words, why the phrase 'less errors' is considered non-standard in formal English. Include references to grammatical number agreement, comparative determiners, and prescriptive vs. descriptive norms.";
const reply0 = await engine.chat.completions.create({
    messages: [{ role: "user", content: TEST_PROMPT }],
    n: 1,
    temperature: 0,
    max_tokens: 1024,
    logprobs: false,
});
```
Specifically:
- No logit_bias
- No logitProcessor
- No frequency, presence, and repetition penalties (since the flow in v0.2.79 applies frequency/presence and repetition penalties separately and not together)
- No logprobs (since this is handled differently in v0.2.79—see above)

1. Phi-3.5-mini-instruct-q4f16_1-MLC: 31.765 (v0.2.79) vs 31.754 (this PR)
2. Qwen3-0.6B-q4f16_1-MLC: 39.681 (v0.2.79) vs 40.825 (this PR)
3. Llama-3-8B-Instruct-q4f16_1-MLC: 18.932 (v0.2.79) vs 18.939 (this PR)
4. gemma-2-9b-it-q4f16_1-MLC: 13.642 (v0.2.79) vs 13.863 (this PR)

Notes:
1. The minimal performance improvement is likely due to kernel launch overheads. Specifically, we need to call three kernels to perform sampling (fsoftmaxWithTemperature, fargsortProbs, fSampleWithTopP).
2. Currently, the path corresponding to logprobs takes place on CPU, though a call to the ```sampler_take_probs``` kernel can likely replace this. I will take a deeper look at this in the near future.
3. Added a TODO for exploring using ```multinomial_sampling_func``` for case where ```top_p``` is not explicitly set.
4. Setting ```top_p = 1.0``` by default might run into some correctness issues since masking in relax uses < instead of <= (https://github.com/apache/tvm/blob/main/python/tvm/relax/frontend/nn/op.py#L2795). 