### PR TITLE
Fix typo in building from source documentation

### DIFF
--- a/docs/developer/building_from_source.rst
+++ b/docs/developer/building_from_source.rst
@@ -25,7 +25,7 @@ Test Changes
 
 To test you changes, you can reuse any existing example or create a new example for your new functionality to test.
 
-Then, to test the effects of your code change in an example, inside ``examples/<example>/package.json``, change from ``"@mlc-ai/web-llm": "^0.2.xx"`` to ``"@mlc-ai/web-llm": ../...`` to let it reference you local code.
+Then, to test the effects of your code change in an example, inside ``examples/<example>/package.json``, change from ``"@mlc-ai/web-llm": "^0.2.xx"`` to ``"@mlc-ai/web-llm": ../...`` to let it reference your local code.
 
 .. code-block:: bash
 


### PR DESCRIPTION
It's just a typo