### PR TITLE
[Chrome Extensions] Add new HF domain to content security policy

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/src/manifest.json
+++ b/examples/chrome-extension-webgpu-service-worker/src/manifest.json
@@ -10,7 +10,7 @@
     "128": "icons/icon-128.png"
   },
   "content_security_policy": {
-    "extension_pages": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://raw.githubusercontent.com https://cas-bridge.xethub.hf.co"
+    "extension_pages": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://raw.githubusercontent.com https://cdn-lfs-us-1.hf.co https://cas-bridge.xethub.hf.co"
   },
   "action": {
     "default_title": "MLCBot",

--- a/examples/chrome-extension/src/manifest.json
+++ b/examples/chrome-extension/src/manifest.json
@@ -10,7 +10,7 @@
     "128": "icons/icon-128.png"
   },
   "content_security_policy": {
-    "extension_pages": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://raw.githubusercontent.com https://cas-bridge.xethub.hf.co"
+    "extension_pages": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://raw.githubusercontent.com https://cdn-lfs-us-1.hf.co https://cas-bridge.xethub.hf.co"
   },
   "action": {
     "default_title": "MLCBot",

--- a/examples/chrome-extension/src/manifest_v2.json
+++ b/examples/chrome-extension/src/manifest_v2.json
@@ -9,7 +9,7 @@
     "64": "icons/icon-64.png",
     "128": "icons/icon-128.png"
   },
-  "content_security_policy": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://raw.githubusercontent.com https://cas-bridge.xethub.hf.co",
+  "content_security_policy": "style-src-elem 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-eval' 'wasm-unsafe-eval'; default-src 'self' data:; connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://raw.githubusercontent.com https://cdn-lfs-us-1.hf.co https://cas-bridge.xethub.hf.co",
   "browser_action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
# Error
`Refused to connect to 'https://cas-bridge.xethub.hf.co/xet-bridge-us/666272029ced3e13878614a5/e3688a36a442fbba06b423974ffebd0800ad4f516eb2da597443997ca430465f?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=cas%2F20260212%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260212T145042Z&X-Amz-Expires=3600&X-Amz-Signature=851193886bf372cba569e6d312f9d891f3a4205897d82a261ce04f890708222c&X-Amz-SignedHeaders=host&X-Xet-Cas-Uid=public&response-content-disposition=inline%3B+filename*%3DUTF-8%27%27para...YyNzIwMjljZWQzZTEzODc4NjE0YTUvZTM2ODhhMzZhNDQyZmJiYTA2YjQyMzk3NGZmZWJkMDgwMGFkNGY1MTZlYjJkYTU5NzQ0Mzk5N2NhNDMwNDY1ZioifV19&Signature=Ln5e0vOWLqVOH0boDzXttKHcbVvZnFNLkd5U7Th53z0ALeVpSe8H5-zS8-raBs3mwBgKkoCV3VuLgS8Y19IcegALs4DwP2tzKYecpEhFiHaTWWTU2vh5I6PacVmyuxVLAXLkzFMO%7EKQrBeDTQJM8HHYRW3pvZhXwVM8dq24OnaaXaglvXCeKkJERQBdMu6oi2O6vDq2sfGxXE0snlbDnnQMfeUAh8wYKuyqw6RsaysyaRIRkkV6h00c7KvprboLHkUIMtsEmXIvxlrhLYzhpN5gQTilp920DQKsbxZVN3bNilnBwc-QtPifgVKDWQ7tc%7E46SD6GSRdbW%7E6ce8JBqbg__&Key-Pair-Id=K2L8F4GPSG1IFC' because it violates the following Content Security Policy directive: "connect-src 'self' data: http://localhost:8000 https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co https://raw.githubusercontent.com https://cdn-lfs-us-1.hf.co".`

# Fix 
Add new Hugging Face domain(https://cas-bridge.xethub.hf.co) to content security policy in example projects

# Related issues
 - https://github.com/mlc-ai/web-llm/issues/763
 - https://github.com/mlc-ai/web-llm/issues/590