### PR TITLE
[VLM] Add Qwen3.5 Vision support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ export type VisionModelConfig = {
   eoi_token_index?: number;
   vision_start_token_id?: number;
   vision_end_token_id?: number;
+  image_size?: number;
 };
 
 export enum Role {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,18 @@ export interface ConvTemplateConfig {
   add_role_after_system_message?: boolean;
 }
 
+/**
+ * Common vision model config fields. Model-specific fields are accessed
+ * via the Record<string, unknown> extension.
+ */
+export type VisionModelConfig = {
+  mm_tokens_per_image?: number;
+  boi_token_index?: number;
+  eoi_token_index?: number;
+  vision_start_token_id?: number;
+  vision_end_token_id?: number;
+};
+
 export enum Role {
   user = "user",
   assistant = "assistant",
@@ -96,7 +108,7 @@ export interface ChatConfig {
   // Model type identifier from mlc-chat-config.json (e.g. "phi3_v", "gemma3_v")
   model_type?: string;
   // Nested model config from mlc-chat-config.json, contains model-specific parameters
-  model_config?: Record<string, any>;
+  model_config?: VisionModelConfig & Record<string, unknown>;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,6 +93,10 @@ export interface ChatConfig {
   top_p: number;
   temperature: number;
   bos_token_id?: number;
+  // Model type identifier from mlc-chat-config.json (e.g. "phi3_v", "gemma3_v")
+  model_type?: string;
+  // Nested model config from mlc-chat-config.json, contains model-specific parameters
+  model_config?: Record<string, any>;
 }
 
 /**

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -67,6 +67,7 @@ export class Conversation {
   private getPromptArrayInternal(
     addSystem: boolean,
     startPos: number,
+    config?: ChatConfig,
   ): Array<string | Array<string | ImageURL>> {
     if (this.config.seps.length == 0) {
       throw Error("Need seps to work");
@@ -193,14 +194,16 @@ export class Conversation {
             this.config.seps[i % this.config.seps.length],
         );
       } else {
-        // If has image input, currently we hard code it to Phi3.5-vision's format:
-        // `<|user|>\n<|image_1|>\n<|image_2|>\n{prompt}<|end|>\n`
-        // So we will return a list for this:
-        // [`<|user|>\n`, imageUrl1, `\n`, imageUrl2, `\n`, `{prompt}<|end|>\n`]
+        // Per-model image layout
         const curMessageList: Array<string | ImageURL> = [role_prefix];
+        const modelType = config?.model_type ?? "";
         imageContentParts.forEach((curImage: ImageURL) => {
-          curMessageList.push(curImage);
-          curMessageList.push("\n");
+          if (modelType === "phi3_v") {
+            curMessageList.push(curImage);
+            curMessageList.push("\n");
+          } else {
+            curMessageList.push(curImage);
+          }
         });
         curMessageList.push(
           message_str + this.config.seps[i % this.config.seps.length],
@@ -233,11 +236,13 @@ export class Conversation {
    *
    * @returns The prompt array.
    */
-  getPromptArray(): Array<string | Array<string | ImageURL>> {
+  getPromptArray(
+    config?: ChatConfig,
+  ): Array<string | Array<string | ImageURL>> {
     if (this.isTextCompletion) {
       throw new TextCompletionConversationError("getPromptArray");
     }
-    return this.getPromptArrayInternal(true, 0);
+    return this.getPromptArrayInternal(true, 0, config);
   }
 
   /**
@@ -248,14 +253,14 @@ export class Conversation {
    *
    * @returns The prompt array.
    */
-  getPromptArrayLastRound() {
+  getPromptArrayLastRound(config?: ChatConfig) {
     if (this.isTextCompletion) {
       throw new TextCompletionConversationError("getPromptArrayLastRound");
     }
     if (this.messages.length < 3) {
       throw Error("needs to call getPromptArray for the first message");
     }
-    return this.getPromptArrayInternal(false, this.messages.length - 2);
+    return this.getPromptArrayInternal(false, this.messages.length - 2, config);
   }
 
   /**
@@ -360,7 +365,6 @@ export function getConversation(
   conv_config?: Partial<ConvTemplateConfig>,
   isTextCompletion = false,
 ): Conversation {
-  // Update with conv_config
   return new Conversation(
     { ...conv_template, ...conv_config },
     isTextCompletion,

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -1135,7 +1135,7 @@ export class LLMChatPipeline {
       return mmTokens;
     }
     throw new Error(
-      "Cannot determine image embed size. " +
+      `Cannot determine image embed size for model type '${modelType}'. ` +
         "Please add mm_tokens_per_image to model_config in mlc-chat-config.json.",
     );
   }

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -11,7 +11,6 @@ import {
   getRGBArrayFromImageData,
   getTokenTableFromTokenizer,
   getTopProbs,
-  IMAGE_EMBED_SIZE,
 } from "./support";
 import {
   ChatCompletionFinishReason,
@@ -29,7 +28,6 @@ import {
   WindowSizeSpecificationError,
   MessageOrderError,
   TextCompletionExpectsKVEmptyError,
-  PrefillChunkSizeSmallerThanImageError,
   CannotFindImageEmbedError,
 } from "./error";
 
@@ -849,23 +847,10 @@ export class LLMChatPipeline {
         conversation.appendReplyHeader(Role.assistant);
       }
     }
-    const retGetInputData = this.getInputData();
-    const inputData: Array<Array<number> | ImageURL> = retGetInputData[0];
-    const promptLen: number = retGetInputData[1];
+    const [inputData, promptLen, getEmbedSize] = await this.getInputData();
 
     // Check if LLMChatPipeline fits for forwarding image input
-    let hasImageInput = false;
-    inputData.forEach((data) => {
-      if (!Array.isArray(data)) {
-        hasImageInput = true;
-      }
-    });
-    if (hasImageInput && this.prefillChunkSize < IMAGE_EMBED_SIZE) {
-      throw new PrefillChunkSizeSmallerThanImageError(
-        this.prefillChunkSize,
-        IMAGE_EMBED_SIZE,
-      );
-    }
+    const hasImageInput = inputData.some((data) => !Array.isArray(data));
     if (hasImageInput && this.image_embed === undefined) {
       throw new CannotFindImageEmbedError();
     }
@@ -874,6 +859,7 @@ export class LLMChatPipeline {
     const retGetChunks = getChunkedPrefillInputData(
       inputData,
       this.prefillChunkSize,
+      getEmbedSize,
     );
     const chunks: Array<Array<number> | ImageURL>[] = retGetChunks[0];
     const chunkLens: Array<number> = retGetChunks[1];
@@ -1128,6 +1114,33 @@ export class LLMChatPipeline {
   }
 
   /**
+   * Compute the number of embedding tokens an image will produce.
+   * Must match the model's image_embed output size.
+   * Based on mlc_llm/serve/data.py _compute_embed_size.
+   */
+  private computeImageEmbedSize(
+    imageHeight: number,
+    imageWidth: number,
+  ): number {
+    const modelType = this.config.model_type;
+    if (modelType === "phi3_v") {
+      const [cropH, cropW] = this.calculateCropShape(imageHeight, imageWidth);
+      const subTokens = cropH * 12 * (cropW * 12 + 1);
+      const glbTokens = 12 * (12 + 1);
+      return subTokens + 1 + glbTokens;
+    }
+    // For models with fixed embed size (e.g. Gemma3V)
+    const mmTokens = this.config.model_config?.mm_tokens_per_image;
+    if (mmTokens !== undefined) {
+      return mmTokens;
+    }
+    throw new Error(
+      "Cannot determine image embed size. " +
+        "Please add mm_tokens_per_image to model_config in mlc-chat-config.json.",
+    );
+  }
+
+  /**
    * Embed an image input.
    */
   private async getImageEmbeddings(
@@ -1169,9 +1182,13 @@ export class LLMChatPipeline {
         this.params,
       ),
     );
-    if (embed.shape[0] !== IMAGE_EMBED_SIZE) {
+    const expectedSize = this.computeImageEmbedSize(
+      imgData.height,
+      imgData.width,
+    );
+    if (embed.shape[0] !== expectedSize) {
       throw new Error(
-        `InternalError: expect embed.shape[0] to be ${IMAGE_EMBED_SIZE}, ` +
+        `InternalError: expect embed.shape[0] to be ${expectedSize}, ` +
           `but got ${embed.shape[0]}`,
       );
     }
@@ -1981,7 +1998,9 @@ export class LLMChatPipeline {
    *   imageUrl2,
    *   token array for "\nSome user input<|end|>\n"
    */
-  private getInputData(): [Array<Array<number> | ImageURL>, number] {
+  private async getInputData(): Promise<
+    [Array<Array<number> | ImageURL>, number, (image: ImageURL) => number]
+  > {
     const ret: Array<Array<number> | ImageURL> = [];
     let curTokens: Array<number> = [];
     let prompts: Array<string | Array<string | ImageURL>>;
@@ -2008,6 +2027,32 @@ export class LLMChatPipeline {
       }
     }
 
+    // 1.5. Preload image dimensions to compute per-image embed sizes
+    const imageDimensions = new Map<string, [number, number]>();
+    const uniqueImageUrls = new Set<string>();
+    for (const prompt of prompts) {
+      if (typeof prompt !== "string") {
+        for (const content of prompt) {
+          if (typeof content !== "string") {
+            uniqueImageUrls.add(content.url);
+          }
+        }
+      }
+    }
+    await Promise.all(
+      Array.from(uniqueImageUrls).map(async (url) => {
+        const imgData = await getImageDataFromURL(url);
+        imageDimensions.set(url, [imgData.height, imgData.width]);
+      }),
+    );
+    const getEmbedSize = (image: ImageURL): number => {
+      const dims = imageDimensions.get(image.url);
+      if (!dims) {
+        throw new Error("InternalError: image dimensions not preloaded");
+      }
+      return this.computeImageEmbedSize(dims[0], dims[1]);
+    };
+
     // 2. Encode all prompts. Iterate through each message in the prompt array, where each
     // prompt can either be a string, or an array of a mixture of string and ImageURLs.
     let numPromptTokens = 0;
@@ -2025,11 +2070,36 @@ export class LLMChatPipeline {
             numPromptTokens += encoded.length;
             curTokens.push(...encoded);
           } else {
+            // Insert BOI wrapping if configured
+            const boiToken =
+              this.config.model_config?.boi_token_index ??
+              this.config.model_config?.vision_start_token_id;
+            if (boiToken !== undefined) {
+              // Insert newline before BOI for models using legacy boi_token_index
+              if (
+                this.config.model_config?.boi_token_index !== undefined &&
+                this.config.model_config?.vision_start_token_id === undefined
+              ) {
+                const nlTokens = this.tokenizer.encode("\n");
+                curTokens.push(...nlTokens);
+                numPromptTokens += nlTokens.length;
+              }
+              curTokens.push(boiToken);
+              numPromptTokens += 1;
+            }
             // push curTokens to ret, push imageUrl, create a new curTokens
             ret.push([...curTokens]);
             ret.push(curPromptContent);
-            numPromptTokens += IMAGE_EMBED_SIZE;
+            numPromptTokens += getEmbedSize(curPromptContent);
             curTokens = [];
+            // Insert EOI token after image if configured
+            const eoiToken =
+              this.config.model_config?.eoi_token_index ??
+              this.config.model_config?.vision_end_token_id;
+            if (eoiToken !== undefined) {
+              curTokens.push(eoiToken);
+              numPromptTokens += 1;
+            }
           }
         }
       }
@@ -2049,7 +2119,7 @@ export class LLMChatPipeline {
         this.contextWindowSize,
       );
     }
-    return [ret, numPromptTokens];
+    return [ret, numPromptTokens, getEmbedSize];
   }
 
   async forwardTokensAndSample(
@@ -2063,6 +2133,7 @@ export class LLMChatPipeline {
     const retGetChunks = getChunkedPrefillInputData(
       inputData,
       this.prefillChunkSize,
+      () => 0, // text-only path, no images
     );
     const chunks: Array<Array<number> | ImageURL>[] = retGetChunks[0];
     const chunkLens: Array<number> = retGetChunks[1];

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -1094,6 +1094,14 @@ export class LLMChatPipeline {
       const glbTokens = 12 * (12 + 1);
       return subTokens + 1 + glbTokens;
     }
+    if (modelType === "qwen3_5_vision") {
+      // (image_size / patch_size / spatial_merge_size)^2 = (448/16/2)^2 = 196
+      const imageSize = this.config.model_config?.image_size ?? 448;
+      const patchSize = 16;
+      const spatialMergeSize = 2;
+      const side = imageSize / patchSize / spatialMergeSize;
+      return side * side;
+    }
     // For models with fixed embed size (e.g. Gemma3V)
     const mmTokens = this.config.model_config?.mm_tokens_per_image;
     if (mmTokens !== undefined) {
@@ -1126,6 +1134,15 @@ export class LLMChatPipeline {
         const newH = Math.floor(newW / ratio);
         return [newH, newW];
       }
+      case "qwen3_5_vision": {
+        const imageSize = this.config.model_config?.image_size;
+        if (imageSize === undefined) {
+          throw new Error(
+            "qwen3_5_vision requires image_size in model_config for resize.",
+          );
+        }
+        return [imageSize, imageSize];
+      }
       default:
         throw new Error(
           `Unsupported model type "${this.config.model_type}" for image resize.`,
@@ -1150,6 +1167,8 @@ export class LLMChatPipeline {
         const padH = Math.ceil(resizedHeight / 336) * 336;
         return [Math.floor(padH / 336), Math.floor(resizedWidth / 336)];
       }
+      case "qwen3_5_vision":
+        return [1, 1];
       default:
         throw new Error(
           `Unsupported model type "${this.config.model_type}" for image crop.`,

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -113,6 +113,7 @@ export class LLMChatPipeline {
   private finishReason: ChatCompletionFinishReason | undefined = undefined;
   // frequency of appeared token ids till now (refresh after PrefillStep); token_id mapped to freq
   private appearedTokensFreq = new Map<number, number>();
+  private imageDataCache = new Map<string, ImageData>();
   private conversation: Conversation;
   // The logprob information of all tokens for this current round (cleared upon each prefillStep)
   // Cleared & updated at the exact same spots as `outputMessage`. Only updated when
@@ -880,6 +881,7 @@ export class LLMChatPipeline {
         );
       }
     }
+    this.imageDataCache.clear();
     this.tvm.endScope();
 
     // 4. Sample, stats, post process token sampled.
@@ -1077,43 +1079,6 @@ export class LLMChatPipeline {
   }
 
   /**
-   * Calculate resize dimensions for Phi3-V model.
-   * Based on vlm_utils.cc CalculateResizeShape
-   */
-  private calculateResizeShape(
-    imageHeight: number,
-    imageWidth: number,
-  ): [number, number] {
-    const hdNum = 16;
-    const ratio = imageWidth / imageHeight;
-    let scale = 1;
-    while (scale * Math.ceil(scale / ratio) <= hdNum) {
-      scale += 1;
-    }
-    scale -= 1;
-    const newW = scale * 336;
-    const newH = Math.floor(newW / ratio);
-    return [newH, newW];
-  }
-
-  /**
-   * Calculate crop dimensions for Phi3-V model.
-   * Based on vlm_utils.cc CalculateCropShape / CalculatePadShape
-   */
-  private calculateCropShape(
-    imageHeight: number,
-    imageWidth: number,
-  ): [number, number] {
-    const [resizedHeight, resizedWidth] = this.calculateResizeShape(
-      imageHeight,
-      imageWidth,
-    );
-    const padH = Math.ceil(resizedHeight / 336) * 336;
-    const padW = resizedWidth;
-    return [Math.floor(padH / 336), Math.floor(padW / 336)];
-  }
-
-  /**
    * Compute the number of embedding tokens an image will produce.
    * Must match the model's image_embed output size.
    * Based on mlc_llm/serve/data.py _compute_embed_size.
@@ -1135,9 +1100,61 @@ export class LLMChatPipeline {
       return mmTokens;
     }
     throw new Error(
-      `Cannot determine image embed size for model type '${modelType}'. ` +
+      `Cannot determine image embed size for model type "${modelType}". ` +
         "Please add mm_tokens_per_image to model_config in mlc-chat-config.json.",
     );
+  }
+
+  /**
+   * Calculate resize dimensions per model type.
+   * Based on vlm_utils.cc CalculateResizeShape
+   */
+  private calculateResizeShape(
+    imageHeight: number,
+    imageWidth: number,
+  ): [number, number] {
+    switch (this.config.model_type) {
+      case "phi3_v": {
+        const hdNum = 16;
+        const ratio = imageWidth / imageHeight;
+        let scale = 1;
+        while (scale * Math.ceil(scale / ratio) <= hdNum) {
+          scale += 1;
+        }
+        scale -= 1;
+        const newW = scale * 336;
+        const newH = Math.floor(newW / ratio);
+        return [newH, newW];
+      }
+      default:
+        throw new Error(
+          `Unsupported model type "${this.config.model_type}" for image resize.`,
+        );
+    }
+  }
+
+  /**
+   * Calculate crop dimensions per model type.
+   * Based on vlm_utils.cc CalculateCropShape / CalculatePadShape
+   */
+  private calculateCropShape(
+    imageHeight: number,
+    imageWidth: number,
+  ): [number, number] {
+    switch (this.config.model_type) {
+      case "phi3_v": {
+        const [resizedHeight, resizedWidth] = this.calculateResizeShape(
+          imageHeight,
+          imageWidth,
+        );
+        const padH = Math.ceil(resizedHeight / 336) * 336;
+        return [Math.floor(padH / 336), Math.floor(resizedWidth / 336)];
+      }
+      default:
+        throw new Error(
+          `Unsupported model type "${this.config.model_type}" for image crop.`,
+        );
+    }
   }
 
   /**
@@ -1149,8 +1166,8 @@ export class LLMChatPipeline {
     this.tvm.beginScope();
     // 1. Transform ImageURL into image input in TVMArray
     const url = inputImage.url;
-    // url starting with `data:image` and `http` share the same loading method
-    const imgData: ImageData = await getImageDataFromURL(url);
+    const imgData: ImageData =
+      this.imageDataCache.get(url) ?? (await getImageDataFromURL(url));
     const pixelValues: Uint8ClampedArray = getRGBArrayFromImageData(imgData);
     const pixelArray = this.tvm
       .empty([imgData.height, imgData.width, 3], "uint32", this.device)
@@ -2021,9 +2038,9 @@ export class LLMChatPipeline {
         ) {
           curTokens = [...this.conversation.config.system_prefix_token_ids];
         }
-        prompts = this.conversation.getPromptArray();
+        prompts = this.conversation.getPromptArray(this.config);
       } else {
-        prompts = this.conversation.getPromptArrayLastRound();
+        prompts = this.conversation.getPromptArrayLastRound(this.config);
       }
     }
 
@@ -2039,9 +2056,14 @@ export class LLMChatPipeline {
         }
       }
     }
+    if (uniqueImageUrls.size > 0 && this.image_embed === undefined) {
+      throw new CannotFindImageEmbedError();
+    }
+    this.imageDataCache.clear();
     await Promise.all(
       Array.from(uniqueImageUrls).map(async (url) => {
         const imgData = await getImageDataFromURL(url);
+        this.imageDataCache.set(url, imgData);
         imageDimensions.set(url, [imgData.height, imgData.width]);
       }),
     );
@@ -2053,7 +2075,12 @@ export class LLMChatPipeline {
       return this.computeImageEmbedSize(dims[0], dims[1]);
     };
 
-    // 2. Encode all prompts. Iterate through each message in the prompt array, where each
+    // 2. Resolve BOI/EOI tokens
+    const cfg = this.config.model_config;
+    const boiToken = cfg?.vision_start_token_id ?? cfg?.boi_token_index;
+    const eoiToken = cfg?.vision_end_token_id ?? cfg?.eoi_token_index;
+
+    // 3. Encode all prompts. Iterate through each message in the prompt array, where each
     // prompt can either be a string, or an array of a mixture of string and ImageURLs.
     let numPromptTokens = 0;
     for (let i = 0; i < prompts.length; i++) {
@@ -2070,20 +2097,8 @@ export class LLMChatPipeline {
             numPromptTokens += encoded.length;
             curTokens.push(...encoded);
           } else {
-            // Insert BOI wrapping if configured
-            const boiToken =
-              this.config.model_config?.boi_token_index ??
-              this.config.model_config?.vision_start_token_id;
+            // Insert BOI token before image if configured
             if (boiToken !== undefined) {
-              // Insert newline before BOI for models using legacy boi_token_index
-              if (
-                this.config.model_config?.boi_token_index !== undefined &&
-                this.config.model_config?.vision_start_token_id === undefined
-              ) {
-                const nlTokens = this.tokenizer.encode("\n");
-                curTokens.push(...nlTokens);
-                numPromptTokens += nlTokens.length;
-              }
               curTokens.push(boiToken);
               numPromptTokens += 1;
             }
@@ -2093,9 +2108,6 @@ export class LLMChatPipeline {
             numPromptTokens += getEmbedSize(curPromptContent);
             curTokens = [];
             // Insert EOI token after image if configured
-            const eoiToken =
-              this.config.model_config?.eoi_token_index ??
-              this.config.model_config?.vision_end_token_id;
             if (eoiToken !== undefined) {
               curTokens.push(eoiToken);
               numPromptTokens += 1;

--- a/src/support.ts
+++ b/src/support.ts
@@ -9,6 +9,7 @@ import {
 import {
   ModelNotFoundError,
   ModelNotLoadedError,
+  PrefillChunkSizeSmallerThanImageError,
   SpecifiedModelNotFoundError,
   ToolCallOutputInvalidTypeError,
   ToolCallOutputMissingFieldsError,
@@ -278,11 +279,12 @@ export function getModelIdToUse(
  * Chunk the inputData such that each chunk's total input length is smaller than prefill
  * chunk size.
  * @returns [the data chunks, the input length of each chunk]
- * @note precondition: if inputData has image in it, then prefillChunkSize >= IMAGE_EMBED_SIZE.
+ * @note precondition: if inputData has image in it, then prefillChunkSize >= imageEmbedSize.
  */
 export function getChunkedPrefillInputData(
   inputData: Array<Array<number> | ImageURL>,
   prefillChunkSize: number,
+  getImageEmbedSize: (image: ImageURL) => number,
 ): [Array<Array<number> | ImageURL>[], Array<number>] {
   const chunks: Array<Array<number> | ImageURL>[] = [];
   const chunkLens: Array<number> = [];
@@ -292,7 +294,13 @@ export function getChunkedPrefillInputData(
     let curData: Array<number> | ImageURL = inputData[i];
     const curDataLen = Array.isArray(curData)
       ? curData.length
-      : IMAGE_EMBED_SIZE;
+      : getImageEmbedSize(curData);
+    if (!Array.isArray(curData) && curDataLen > prefillChunkSize) {
+      throw new PrefillChunkSizeSmallerThanImageError(
+        prefillChunkSize,
+        curDataLen,
+      );
+    }
     // 1. curData can fit into this chunk
     if (curChunkLen + curDataLen <= prefillChunkSize) {
       curChunk.push(curData);
@@ -338,7 +346,7 @@ export function getChunkedPrefillInputData(
       chunkLens.push(curChunkLen);
       // 2.2.2. Then push image to the new chunk
       curChunk = [curData];
-      curChunkLen = IMAGE_EMBED_SIZE;
+      curChunkLen = curDataLen;
       if (curChunkLen === prefillChunkSize) {
         chunks.push([...curChunk]);
         chunkLens.push(curChunkLen);
@@ -404,9 +412,6 @@ export class CustomLock {
 
 // Image related
 type ImageURL = ChatCompletionContentPartImage.ImageURL;
-
-// TODO(Charlie): currently hardcoded for phi3.5-vision num_crops 16
-export const IMAGE_EMBED_SIZE = 1921;
 
 /**
  * Given a url, get the image data. The url can either start with `http` or `data:image`.

--- a/tests/conversation.test.ts
+++ b/tests/conversation.test.ts
@@ -247,7 +247,7 @@ describe("Test getConversationFromChatCompletionRequest with image", () => {
       config,
       true,
     );
-    expect(conv1.getPromptArray()).toEqual([
+    expect(conv1.getPromptArray(config)).toEqual([
       dummySystemPromptStr, // phi3_5-vision does not have system template
       [
         `<|user|>\n`,
@@ -271,7 +271,7 @@ describe("Test getConversationFromChatCompletionRequest with image", () => {
       true,
     );
     conv1.appendReplyHeader(Role.assistant);
-    expect(conv1.getPromptArray()).toEqual([
+    expect(conv1.getPromptArray(config)).toEqual([
       dummySystemPromptStr, // phi3_5-vision does not have system template
       [
         `<|user|>\n`,
@@ -290,7 +290,7 @@ describe("Test getConversationFromChatCompletionRequest with image", () => {
       ],
       `<|assistant|>\n`,
     ]);
-    expect(conv1.getPromptArrayLastRound()).toEqual([
+    expect(conv1.getPromptArrayLastRound(config)).toEqual([
       [
         `<|user|>\n`,
         { url: imageUrl2 } as ImageURL,

--- a/tests/llm_chat_pipeline.test.ts
+++ b/tests/llm_chat_pipeline.test.ts
@@ -201,10 +201,9 @@ function preparePrefillPipeline(): PipelineLike {
   const pipeline = createPipeline();
   pipeline["prefillTotalTime"] = 0;
   pipeline["prefillTotalTokens"] = 0;
-  pipeline["getInputData"] = jest.fn<() => [number[][], number]>(() => [
-    [[0]],
-    1,
-  ]);
+  pipeline["getInputData"] = jest.fn(
+    async (): Promise<[any[], number, any]> => [[[0]], 1, () => 0],
+  );
   pipeline["processNextToken"] = jest.fn();
   return pipeline;
 }
@@ -272,15 +271,15 @@ test("prefillStep compiles custom grammar when response type is grammar", async 
   expect(compileGrammarMock).toHaveBeenCalledWith("root ::= WORD");
 });
 
-test("getInputData uses cached prompts when KV cache filled", () => {
+test("getInputData uses cached prompts when KV cache filled", async () => {
   const pipeline = createPipeline();
   pipeline["tokenizer"].encode = jest.fn(() => Int32Array.from([1]));
   pipeline["conversation"].config.system_prefix_token_ids = undefined;
   pipeline["filledKVCacheLength"] = 0;
-  (pipeline as any).getInputData();
+  await (pipeline as any).getInputData();
   expect(pipeline["conversation"].getPromptArray).toHaveBeenCalled();
   pipeline["filledKVCacheLength"] = 1;
-  (pipeline as any).getInputData();
+  await (pipeline as any).getInputData();
   expect(pipeline["conversation"].getPromptArrayLastRound).toHaveBeenCalled();
 });
 
@@ -291,4 +290,75 @@ test("processNextToken ignores eos when requested", () => {
   expect(pipeline["stopTriggered"]).toBe(false);
   expect(pipeline["finishReason"]).toBeUndefined();
   expect(pipeline["outputIds"]).toContain(1);
+});
+
+describe("calculateResizeShape", () => {
+  test("square image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateResizeShape"](336, 336)).toEqual([1344, 1344]);
+  });
+
+  test("landscape image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateResizeShape"](1080, 1920)).toEqual([945, 1680]);
+  });
+
+  test("portrait image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateResizeShape"](1920, 1080)).toEqual([1194, 672]);
+  });
+});
+
+describe("calculateCropShape", () => {
+  test("square image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateCropShape"](336, 336)).toEqual([4, 4]);
+  });
+
+  test("landscape image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateCropShape"](1080, 1920)).toEqual([3, 5]);
+  });
+
+  test("portrait image", () => {
+    const pipeline = createPipeline();
+    expect(pipeline["calculateCropShape"](1920, 1080)).toEqual([4, 2]);
+  });
+});
+
+describe("computeImageEmbedSize", () => {
+  test("phi3_v square image", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
+    expect(pipeline["computeImageEmbedSize"](336, 336)).toBe(2509);
+  });
+
+  test("phi3_v landscape image", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
+    expect(pipeline["computeImageEmbedSize"](1080, 1920)).toBe(2353);
+  });
+
+  test("phi3_v portrait image", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
+    expect(pipeline["computeImageEmbedSize"](1920, 1080)).toBe(1357);
+  });
+
+  test("model with mm_tokens_per_image", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = {
+      model_type: "gemma3_v",
+      model_config: { mm_tokens_per_image: 256 },
+    } as any;
+    expect(pipeline["computeImageEmbedSize"](1080, 1920)).toBe(256);
+  });
+
+  test("unknown model without mm_tokens throws", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "unknown_model" } as any;
+    expect(() => pipeline["computeImageEmbedSize"](336, 336)).toThrow(
+      "Cannot determine image embed size",
+    );
+  });
 });

--- a/tests/llm_chat_pipeline.test.ts
+++ b/tests/llm_chat_pipeline.test.ts
@@ -312,6 +312,15 @@ describe("calculateResizeShape", () => {
     pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateResizeShape"](1920, 1080)).toEqual([1194, 672]);
   });
+
+  test("qwen3_5_vision fixed square resize", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = {
+      model_type: "qwen3_5_vision",
+      model_config: { image_size: 448 },
+    } as any;
+    expect(pipeline["calculateResizeShape"](1080, 1920)).toEqual([448, 448]);
+  });
 });
 
 describe("calculateCropShape", () => {
@@ -332,6 +341,15 @@ describe("calculateCropShape", () => {
     pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateCropShape"](1920, 1080)).toEqual([4, 2]);
   });
+
+  test("qwen3_5_vision single tile", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = {
+      model_type: "qwen3_5_vision",
+      model_config: { image_size: 448 },
+    } as any;
+    expect(pipeline["calculateCropShape"](1080, 1920)).toEqual([1, 1]);
+  });
 });
 
 describe("computeImageEmbedSize", () => {
@@ -351,6 +369,15 @@ describe("computeImageEmbedSize", () => {
     const pipeline = createPipeline();
     pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["computeImageEmbedSize"](1920, 1080)).toBe(1357);
+  });
+
+  test("qwen3_5_vision returns 196", () => {
+    const pipeline = createPipeline();
+    pipeline["config"] = {
+      model_type: "qwen3_5_vision",
+      model_config: { image_size: 448 },
+    } as any;
+    expect(pipeline["computeImageEmbedSize"](1080, 1920)).toBe(196);
   });
 
   test("model with mm_tokens_per_image", () => {

--- a/tests/llm_chat_pipeline.test.ts
+++ b/tests/llm_chat_pipeline.test.ts
@@ -83,6 +83,7 @@ function createPipeline(): PipelineLike {
     getPromptArrayLastRound: jest.fn(() => ["last"]),
     getPromptArrayTextCompletion: jest.fn(() => ["text"]),
   } as any;
+  pipeline["config"] = {} as any;
   pipeline["outputIds"] = [];
   pipeline["appearedTokensFreq"] = new Map<number, number>();
   pipeline["stopTokens"] = [];
@@ -142,6 +143,7 @@ function createPipeline(): PipelineLike {
   pipeline["tokenLogprobArray"] = [];
   pipeline["curRoundDecodingTotalTokens"] = 0;
   pipeline["curRoundDecodingTotalTime"] = 0;
+  pipeline["imageDataCache"] = new Map();
   return pipeline;
 }
 
@@ -293,35 +295,41 @@ test("processNextToken ignores eos when requested", () => {
 });
 
 describe("calculateResizeShape", () => {
-  test("square image", () => {
+  test("phi3_v square image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateResizeShape"](336, 336)).toEqual([1344, 1344]);
   });
 
-  test("landscape image", () => {
+  test("phi3_v landscape image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateResizeShape"](1080, 1920)).toEqual([945, 1680]);
   });
 
-  test("portrait image", () => {
+  test("phi3_v portrait image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateResizeShape"](1920, 1080)).toEqual([1194, 672]);
   });
 });
 
 describe("calculateCropShape", () => {
-  test("square image", () => {
+  test("phi3_v square image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateCropShape"](336, 336)).toEqual([4, 4]);
   });
 
-  test("landscape image", () => {
+  test("phi3_v landscape image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateCropShape"](1080, 1920)).toEqual([3, 5]);
   });
 
-  test("portrait image", () => {
+  test("phi3_v portrait image", () => {
     const pipeline = createPipeline();
+    pipeline["config"] = { model_type: "phi3_v" } as any;
     expect(pipeline["calculateCropShape"](1920, 1080)).toEqual([4, 2]);
   });
 });

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -1,6 +1,7 @@
 import { ChatOptions } from "../src/config";
 import {
   ModelNotLoadedError,
+  PrefillChunkSizeSmallerThanImageError,
   SpecifiedModelNotFoundError,
   UnclearModelToUseError,
 } from "../src/error";
@@ -329,6 +330,7 @@ describe("Test getChunkedPrefillInputData", () => {
   const prefillChunkSize = 2048;
   const image1 = { url: "url1" } as ImageURL;
   const image2 = { url: "url2" } as ImageURL;
+  const getImageEmbedSize = () => 1921;
 
   test("With image data", async () => {
     const inputData = [
@@ -336,7 +338,11 @@ describe("Test getChunkedPrefillInputData", () => {
       image1, // 1921 size
       rangeArr(0, 10),
     ];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [[rangeArr(0, 200)], [image1, rangeArr(0, 10)]];
     const expectedChunkLens = [200, 1931];
     expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
@@ -344,7 +350,11 @@ describe("Test getChunkedPrefillInputData", () => {
 
   test("Single image data", async () => {
     const inputData = [image1];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [[image1]];
     const expectedChunkLens = [1921];
     expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
@@ -352,7 +362,11 @@ describe("Test getChunkedPrefillInputData", () => {
 
   test("Two images", async () => {
     const inputData = [image1, image2];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [[image1], [image2]];
     const expectedChunkLens = [1921, 1921];
     expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
@@ -360,7 +374,11 @@ describe("Test getChunkedPrefillInputData", () => {
 
   test("Single token array that needs to be chunked", async () => {
     const inputData = [rangeArr(0, 4097)];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [
       [rangeArr(0, 2048)],
       [rangeArr(2048, 4096)],
@@ -372,7 +390,11 @@ describe("Test getChunkedPrefillInputData", () => {
 
   test("Single token array that does not need to be chunked", async () => {
     const inputData = [rangeArr(0, 2048)];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [[rangeArr(0, 2048)]];
     const expectedChunkLens = [2048];
     expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
@@ -384,7 +406,11 @@ describe("Test getChunkedPrefillInputData", () => {
       rangeArr(0, 2300),
       image2,
     ];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [
       [image1, rangeArr(0, 127)], // 127 = 2048 - 1921
       [rangeArr(127, 2175)], // 2175 = 127 + 2048
@@ -400,9 +426,42 @@ describe("Test getChunkedPrefillInputData", () => {
       rangeArr(0, 127),
       image2,
     ];
-    const chunks = getChunkedPrefillInputData(inputData, prefillChunkSize);
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getImageEmbedSize,
+    );
     const expectedChunks = [[image1, rangeArr(0, 127)], [image2]];
     const expectedChunkLens = [2048, 1921];
+    expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
+  });
+
+  test("Throws when image embed size exceeds prefill chunk size", () => {
+    const inputData = [image1];
+    expect(() =>
+      getChunkedPrefillInputData(inputData, 100, () => 1921),
+    ).toThrow(PrefillChunkSizeSmallerThanImageError);
+  });
+
+  test("Dynamic per-image embed sizes", () => {
+    const sizeMap: Record<string, number> = { url1: 500, url2: 1500 };
+    const getDynamicSize = (img: ImageURL) => sizeMap[img.url];
+    const inputData = [
+      rangeArr(0, 100),
+      image1, // 500
+      rangeArr(0, 50),
+      image2, // 1500
+    ];
+    const chunks = getChunkedPrefillInputData(
+      inputData,
+      prefillChunkSize,
+      getDynamicSize,
+    );
+    const expectedChunks = [
+      [rangeArr(0, 100), image1, rangeArr(0, 50)],
+      [image2],
+    ];
+    const expectedChunkLens = [650, 1500];
     expect(chunks).toEqual([expectedChunks, expectedChunkLens]);
   });
 });


### PR DESCRIPTION
Add `qwen3_5_v` model type handling for vision inference:

- `computeImageEmbedSize`: `(image_size / patch_size / spatial_merge_size)^2 = 196`
- `calculateResizeShape`: fixed square resize to `image_size` from `model_config`
- `calculateCropShape`: single tile (no tiling)

Stacked on #804 — merge that first, then this diff will be clean.

See: https://github.com/mlc-ai/mlc-llm/pull/3471