### PR TITLE
[Build] Fix browser bundling of node: prefixed imports

### DIFF
--- a/cleanup-index-js.sh
+++ b/cleanup-index-js.sh
@@ -15,17 +15,18 @@ sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/"\"MLC_DUMMY
 # Replace with \"MLC_DUMMY_PATH\"
 sed -e s/"new (require('u' + 'rl').URL)('file:' + __filename).href"/'\\\"MLC_DUMMY_PATH\\\"'/g -i.backup lib/index.js.map
 
-# Replace "import require$$3 from 'perf_hooks';" with a string "const require$$3 = "MLC_DUMMY_REQUIRE_VAR""
+# Replace "import require$$N from 'perf_hooks';" with "const require$$N = "MLC_DUMMY_REQUIRE_VAR""
 # This is to prevent `perf_hooks` not found error
 # For more see https://github.com/mlc-ai/web-llm/issues/258 and https://github.com/mlc-ai/web-llm/issues/127
-sed -e s/"import require\$\$3 from 'perf_hooks';"/"const require\$\$3 = \"MLC_DUMMY_REQUIRE_VAR\""/g -i.backup lib/index.js
+# Use a regex to match any variable number (require$$0, require$$1, etc.)
+sed -E -i.backup "s/import (require\\\$\\\$[0-9]+) from 'perf_hooks';/const \1 = \"MLC_DUMMY_REQUIRE_VAR\"/g" lib/index.js
 # Similarly replace `const performanceNode = require(\"perf_hooks\")` with `const performanceNode = \"MLC_DUMMY_REQUIRE_VAR\"`
 sed -e s/'require(\\\"perf_hooks\\\")'/'\\\"MLC_DUMMY_REQUIRE_VAR\\\"'/g -i.backup lib/index.js.map
 
 # Below is added when we include dependency @mlc-ai/web-runtime, rather than using local tvm_home
-# Replace "import require$$4 from 'ws'" with a string "const require$$3 = "MLC_DUMMY_REQUIRE_VAR""
+# Replace "import require$$N from 'ws'" with "const require$$N = "MLC_DUMMY_REQUIRE_VAR""
 # This is to prevent error `Cannot find module 'ws'`
-sed -e s/"import require\$\$4 from 'ws';"/"const require\$\$4 = \"MLC_DUMMY_REQUIRE_VAR\""/g -i.backup lib/index.js
+sed -E -i.backup "s/import (require\\\$\\\$[0-9]+) from 'ws';/const \1 = \"MLC_DUMMY_REQUIRE_VAR\"/g" lib/index.js
 # Similarly replace `const WebSocket = require(\"ws\")` with `const WebSocket = \"MLC_DUMMY_REQUIRE_VAR\"`
 sed -e s/'require(\\\"ws\\\")'/'\\\"MLC_DUMMY_REQUIRE_VAR\\\"'/g -i.backup lib/index.js.map
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ export default {
     },
   ],
   plugins: [
-    ignore(["fs", "path", "crypto"]),
+    ignore(["fs", "path", "crypto", "node:fs", "node:path", "node:crypto"]),
     nodeResolve({ browser: true }),
     commonjs({
       ignoreDynamicRequires: true,


### PR DESCRIPTION
## Summary
- Add `node:fs`, `node:path`, `node:crypto` to the rollup ignore list so dependencies using Node's `node:`-prefixed module specifiers are properly excluded from the browser bundle.
- Make the `cleanup-index-js.sh` sed patterns for `perf_hooks` and `ws` use a regex for the variable number (`require$$[0-9]+`) instead of hardcoding `require$$3`/`require$$4`, since the numbering shifts when the ignore list changes.

## Motivation
Modern Node.js dependencies increasingly use `node:` prefixed imports (e.g. `node:fs` instead of `fs`). The existing rollup ignore list only handled the unprefixed variants, causing `node:fs` and `node:crypto` to leak into the browser bundle. This breaks downstream bundlers (esbuild, Parcel, etc.) that target browsers.

The cleanup script's hardcoded variable numbers (`require$$3`, `require$$4`) were also fragile — any change to the ignore list or dependency order would shift the numbering and silently break the `perf_hooks`/`ws` replacements.

## Test plan
- [x] `npm run build` succeeds
- [x] Built `lib/index.js` contains no `node:fs`, `node:crypto`, or `perf_hooks` imports