### PR TITLE
[Version] Bump version to 0.2.83

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ npm install
 npm run build
 ```
 
-Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.82"` to `"@mlc-ai/web-llm": ../..`.
+Then, to test the effects of your code change in an example, inside `examples/get-started/package.json`, change from `"@mlc-ai/web-llm": "^0.2.83"` to `"@mlc-ai/web-llm": ../..`.
 
 Then run:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,8 +17,8 @@ copyright = "2023, %s" % author
 
 # Version information.
 
-version = "0.2.82"
-release = "0.2.82"
+version = "0.2.83"
+release = "0.2.83"
 
 extensions = [
     "sphinx_tabs.tabs",

--- a/examples/abort-reload/package.json
+++ b/examples/abort-reload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/cache-usage/package.json
+++ b/examples/cache-usage/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/chrome-extension-webgpu-service-worker/package.json
+++ b/examples/chrome-extension-webgpu-service-worker/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82",
+    "@mlc-ai/web-llm": "^0.2.83",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/chrome-extension/package.json
+++ b/examples/chrome-extension/package.json
@@ -17,7 +17,7 @@
     "url": "^0.11.1"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82",
+    "@mlc-ai/web-llm": "^0.2.83",
     "progressbar.js": "^1.1.0"
   }
 }

--- a/examples/embeddings/package.json
+++ b/examples/embeddings/package.json
@@ -15,7 +15,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82",
+    "@mlc-ai/web-llm": "^0.2.83",
     "langchain": "^0.3.37"
   }
 }

--- a/examples/function-calling/function-calling-manual/package.json
+++ b/examples/function-calling/function-calling-manual/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/function-calling/function-calling-openai/package.json
+++ b/examples/function-calling/function-calling-openai/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/get-started-latency-breakdown/package.json
+++ b/examples/get-started-latency-breakdown/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/get-started-web-worker/package.json
+++ b/examples/get-started-web-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/get-started/package.json
+++ b/examples/get-started/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/integrity-verification/package.json
+++ b/examples/integrity-verification/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/json-mode/package.json
+++ b/examples/json-mode/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/json-schema/package.json
+++ b/examples/json-schema/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/logit-processor/package.json
+++ b/examples/logit-processor/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/multi-models/package.json
+++ b/examples/multi-models/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/multi-round-chat/package.json
+++ b/examples/multi-round-chat/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/next-simple-chat/package.json
+++ b/examples/next-simple-chat/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82",
+    "@mlc-ai/web-llm": "^0.2.83",
     "@types/node": "20.3.3",
     "@types/react": "18.2.14",
     "@types/react-dom": "18.2.6",

--- a/examples/qwen3/package.json
+++ b/examples/qwen3/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/seed-to-reproduce/package.json
+++ b/examples/seed-to-reproduce/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/simple-chat-ts/package.json
+++ b/examples/simple-chat-ts/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/simple-chat-upload/package.json
+++ b/examples/simple-chat-upload/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/streaming/package.json
+++ b/examples/streaming/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/subgroups-usage/package.json
+++ b/examples/subgroups-usage/package.json
@@ -20,6 +20,6 @@
     "vm-browserify": "^1.1.2"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/subgroups-usage/src/subgroups_usage.ts
+++ b/examples/subgroups-usage/src/subgroups_usage.ts
@@ -8,6 +8,21 @@ function setLabel(id: string, text: string) {
   label.innerText = text;
 }
 
+function toSg32ModelLib(modelLib: string): string {
+  const modelLibUrl = new URL(modelLib);
+  const pathParts = modelLibUrl.pathname.split("/");
+  const wasmFileIndex = pathParts.length - 1;
+  const variantDirIndex = wasmFileIndex - 1;
+  if (variantDirIndex < 0 || pathParts[variantDirIndex] !== "base") {
+    throw Error(
+      `Expected model_lib path variant directory to be "base": ${modelLib}`,
+    );
+  }
+  pathParts[variantDirIndex] = "sg32";
+  modelLibUrl.pathname = pathParts.join("/");
+  return modelLibUrl.toString();
+}
+
 async function main() {
   const initProgressCallback = (report: webllm.InitProgressReport) => {
     setLabel("init-label", report.text);
@@ -34,7 +49,7 @@ async function main() {
   console.log("supportsSubgroups: ", supportsSubgroups);
   // Option 1: If we do not specify appConfig, we use `prebuiltAppConfig` defined in `config.ts`
   const modelRecord = webllm.prebuiltAppConfig.model_list.find(
-    (entry) => entry.model_id === selectedModel,
+    (entry: webllm.AppConfig.model) => entry.model_id === selectedModel,
   );
   const appConfig =
     supportsSubgroups && modelRecord !== undefined
@@ -42,10 +57,7 @@ async function main() {
           model_list: [
             {
               ...modelRecord,
-              model_lib: modelRecord.model_lib.replace(
-                /\.wasm$/,
-                "-subgroups.wasm",
-              ),
+              model_lib: toSg32ModelLib(modelRecord.model_lib),
             },
           ],
         }
@@ -82,9 +94,8 @@ async function main() {
   //   ],
   // };
   // if (supportsSubgroups) {
-  //   appConfig.model_list[0].model_lib = appConfig.model_list[0].model_lib.replace(
-  //     /\.wasm$/,
-  //     "-subgroups.wasm",
+  //   appConfig.model_list[0].model_lib = toSg32ModelLib(
+  //     appConfig.model_list[0].model_lib,
   //   );
   // }
   // const engine: webllm.MLCEngineInterface = await webllm.CreateMLCEngine(

--- a/examples/subgroups-usage/src/subgroups_usage.ts
+++ b/examples/subgroups-usage/src/subgroups_usage.ts
@@ -49,7 +49,7 @@ async function main() {
   console.log("supportsSubgroups: ", supportsSubgroups);
   // Option 1: If we do not specify appConfig, we use `prebuiltAppConfig` defined in `config.ts`
   const modelRecord = webllm.prebuiltAppConfig.model_list.find(
-    (entry: webllm.AppConfig.model) => entry.model_id === selectedModel,
+    (entry: webllm.ModelRecord) => entry.model_id === selectedModel,
   );
   const appConfig =
     supportsSubgroups && modelRecord !== undefined

--- a/examples/text-completion/package.json
+++ b/examples/text-completion/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/examples/vision-model/package.json
+++ b/examples/vision-model/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mlc-ai/web-llm",
-      "version": "0.2.82",
+      "version": "0.2.83",
       "license": "Apache-2.0",
       "dependencies": {
         "loglevel": "^1.9.1"
@@ -539,21 +539,21 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -717,25 +717,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -876,9 +890,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1315,9 +1329,9 @@
       }
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.1.tgz",
-      "integrity": "sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==",
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
+      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1478,9 +1492,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
       "cpu": [
         "arm"
       ],
@@ -1492,9 +1506,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -1506,9 +1520,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -1520,9 +1534,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -1534,9 +1548,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
       "cpu": [
         "arm64"
       ],
@@ -1548,9 +1562,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -1562,9 +1576,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -1576,9 +1590,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
       ],
@@ -1590,9 +1604,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -1604,9 +1618,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -1618,9 +1632,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
       "cpu": [
         "loong64"
       ],
@@ -1632,9 +1646,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
       ],
@@ -1646,9 +1660,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -1660,9 +1674,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1674,9 +1688,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
       "cpu": [
         "riscv64"
       ],
@@ -1688,9 +1702,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1702,9 +1716,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -1716,9 +1730,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -1730,9 +1744,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -1744,9 +1758,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
       "cpu": [
         "x64"
       ],
@@ -1758,9 +1772,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -1772,9 +1786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -1786,9 +1800,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
       "cpu": [
         "ia32"
       ],
@@ -1800,9 +1814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -1814,9 +1828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
       "cpu": [
         "x64"
       ],
@@ -1828,9 +1842,9 @@
       ]
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "dev": true,
       "license": "MIT"
     },
@@ -1845,9 +1859,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1998,13 +2012,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -2046,20 +2060,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
-      "integrity": "sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/type-utils": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2069,9 +2083,9 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.57.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -2085,17 +2099,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.2.tgz",
-      "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2107,18 +2121,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.2.tgz",
-      "integrity": "sha512-FuH0wipFywXRTHf+bTTjNyuNQQsQC3qh/dYzaM4I4W0jrCqjCVuUh99+xd9KamUfmCGPvbO8NDngo/vsnNVqgw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.57.2",
-        "@typescript-eslint/types": "^8.57.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2129,18 +2143,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.2.tgz",
-      "integrity": "sha512-snZKH+W4WbWkrBqj4gUNRIGb/jipDW3qMqVJ4C9rzdFc+wLwruxk+2a5D+uoFcKPAqyqEnSb4l2ULuZf95eSkw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2151,9 +2165,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.2.tgz",
-      "integrity": "sha512-3Lm5DSM+DCowsUOJC+YqHHnKEfFh5CoGkj5Z31NQSNF4l5wdOwqGn99wmwN/LImhfY3KJnmordBq/4+VDe2eKw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2164,21 +2178,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.2.tgz",
-      "integrity": "sha512-Co6ZCShm6kIbAM/s+oYVpKFfW7LBc6FXoPXjTRQ449PPNBY8U0KZXuevz5IFuuUj2H9ss40atTaf9dlGLzbWZg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2189,13 +2203,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.2.tgz",
-      "integrity": "sha512-/iZM6FnM4tnx9csuTxspMW4BOSegshwX5oBDznJ7S4WggL7Vczz5d2W11ecc4vRrQMQHXRSxzrCsyG5EsPPTbA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2207,21 +2221,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.2.tgz",
-      "integrity": "sha512-2MKM+I6g8tJxfSmFKOnHv2t8Sk3T6rF20A1Puk0svLK+uVapDZB/4pfAeB7nE83uAZrU6OxW+HmOd5wHVdXwXA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.57.2",
-        "@typescript-eslint/tsconfig-utils": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/visitor-keys": "8.57.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2231,7 +2245,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
@@ -2258,13 +2272,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2287,16 +2301,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.2.tgz",
-      "integrity": "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.57.2",
-        "@typescript-eslint/types": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2307,17 +2321,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.2.tgz",
-      "integrity": "sha512-zhahknjobV2FiD6Ee9iLbS7OV9zi10rG26odsQdfBO/hjSzUQbkIYgda+iNKK1zNiW2ey+Lf8MU5btN17V3dUw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.57.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2649,9 +2663,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2878,9 +2892,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2891,9 +2905,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2915,9 +2929,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2936,11 +2950,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3025,9 +3039,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
       "dev": true,
       "funding": [
         {
@@ -3245,9 +3259,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
       "dev": true,
       "license": "ISC"
     },
@@ -3279,6 +3293,16 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -3877,13 +3901,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3945,9 +3969,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5214,9 +5238,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5396,9 +5420,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5657,12 +5681,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -5722,9 +5747,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5739,31 +5764,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
     },
@@ -6055,13 +6080,13 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6071,14 +6096,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6121,19 +6146,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -6150,7 +6175,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -6258,16 +6283,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.57.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.2.tgz",
-      "integrity": "sha512-VEPQ0iPgWO/sBaZOU1xo4nuNdODVOajPnTIbog2GKYr31nIlZ0fWPoCQgGfF3ETyBl1vn63F/p50Um9Z4J8O8A==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.57.2",
-        "@typescript-eslint/parser": "8.57.2",
-        "@typescript-eslint/typescript-estree": "8.57.2",
-        "@typescript-eslint/utils": "8.57.2"
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6278,7 +6303,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {
@@ -6317,9 +6342,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlc-ai/web-llm",
-  "version": "0.2.82",
+  "version": "0.2.83",
   "description": "Hardware accelerated language model chats on browsers",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -763,6 +763,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Phi-4-mini-instruct-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 3437.58,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -775,6 +776,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Phi-4-mini-instruct-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 4220.59,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1102,6 +1104,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/gemma3-1b-it-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 711.07,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1116,6 +1119,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/OLMo-2-1124-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 6479.01,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1129,6 +1133,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/OLMo-2-1124-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 9086.02,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1142,6 +1147,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/OLMo-2-0425-1B-Instruct-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 1776.75,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1155,6 +1161,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/OLMo-2-0425-1B-Instruct-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2453.51,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1287,6 +1294,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-0.8B-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 1629.49,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1300,6 +1308,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-0.8B-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 1894.19,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1313,6 +1322,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-0.8B-q0f16_cs1k-webgpu.wasm",
+      vram_required_MB: 2660.27,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1326,6 +1336,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-2B-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2245.44,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1339,6 +1350,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-2B-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2591.55,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1352,6 +1364,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-4B-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 3867.82,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1365,6 +1378,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-4B-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 4680.36,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1378,6 +1392,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-9B-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 6433.01,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1391,6 +1406,7 @@ export const prebuiltAppConfig: AppConfig = {
         modelLibURLPrefix +
         modelVersion +
         "/Qwen3.5-9B-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 7544.74,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1867,6 +1883,91 @@ export const prebuiltAppConfig: AppConfig = {
       low_resource_required: true,
       overrides: {
         context_window_size: 1024,
+      },
+    },
+    // Ministral 3
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Base-2512-q4f16_1-MLC",
+      model_id: "Ministral-3-3B-Base-2512-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Base-2512-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2863.69,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Base-2512-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Base-2512-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Base-2512-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 3532.37,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Reasoning-2512-q4f16_1-MLC",
+      model_id: "Ministral-3-3B-Reasoning-2512-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Reasoning-2512-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2863.69,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Reasoning-2512-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 3532.37,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Instruct-2512-BF16-q4f16_1-MLC",
+      model_id: "Ministral-3-3B-Instruct-2512-BF16-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Instruct-2512-BF16-q4f16_1_cs1k-webgpu.wasm",
+      vram_required_MB: 2863.69,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Instruct-2512-BF16-q4f32_1_cs1k-webgpu.wasm",
+      vram_required_MB: 3532.37,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
       },
     },
     // BELOW ARE MODELS OF OLDER VERSIONS OR NOT AS PRACTICAL
@@ -2472,79 +2573,6 @@ export const prebuiltAppConfig: AppConfig = {
         "/snowflake-arctic-embed-s-q0f32-ctx512_cs512_batch4-webgpu.wasm",
       vram_required_MB: 238.71,
       model_type: ModelType.embedding,
-    },
-    // Ministral 3
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Base-2512-q4f16_1-MLC",
-      model_id: "Ministral-3-3B-Base-2512-q4f16_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Base-2512-q4f16_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
-    },
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Base-2512-q4f32_1-MLC",
-      model_id: "Ministral-3-3B-Base-2512-q4f32_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Base-2512-q4f32_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
-    },
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Reasoning-2512-q4f16_1-MLC",
-      model_id: "Ministral-3-3B-Reasoning-2512-q4f16_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Reasoning-2512-q4f16_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
-    },
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
-      model_id: "Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Reasoning-2512-q4f32_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
-    },
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Instruct-2512-BF16-q4f16_1-MLC",
-      model_id: "Ministral-3-3B-Instruct-2512-BF16-q4f16_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Instruct-2512-BF16-q4f16_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
-    },
-    {
-      model:
-        "https://huggingface.co/mlc-ai/Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
-      model_id: "Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
-      model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Ministral-3-3B-Instruct-2512-BF16-q4f32_1_cs1k-webgpu.wasm",
-      overrides: {
-        context_window_size: 4096,
-      },
     },
   ],
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -305,7 +305,7 @@ export function getCacheBackend(appConfig: AppConfig): CacheBackend {
  * @note The model version does not have to match the npm version, since not each npm update
  * requires an update of the model libraries.
  */
-export const modelVersion = "v0_2_80";
+export const modelVersion = "v0_2_83/base";
 export const modelLibURLPrefix =
   "https://raw.githubusercontent.com/mlc-ai/binary-mlc-llm-libs/main/web-llm-models/";
 
@@ -336,7 +336,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-1B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-1B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1128.82,
       low_resource_required: true,
       overrides: {
@@ -349,34 +349,33 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-1B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-1B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 879.04,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // TODO: temporarily commenting out q0f32 models due to correctness issues
-    // {
-    //   model: "https://huggingface.co/mlc-ai/Llama-3.2-1B-Instruct-q0f32-MLC",
-    //   model_id: "Llama-3.2-1B-Instruct-q0f32-MLC",
-    //   model_lib:
-    //     modelLibURLPrefix +
-    //     modelVersion +
-    //     "/Llama-3.2-1B-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
-    //   vram_required_MB: 5106.26,
-    //   low_resource_required: true,
-    //   overrides: {
-    //     context_window_size: 4096,
-    //   },
-    // },
+    {
+      model: "https://huggingface.co/mlc-ai/Llama-3.2-1B-Instruct-q0f32-MLC",
+      model_id: "Llama-3.2-1B-Instruct-q0f32-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Llama-3.2-1B-Instruct-q0f32_cs1k-webgpu.wasm",
+      vram_required_MB: 5106.26,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
     {
       model: "https://huggingface.co/mlc-ai/Llama-3.2-1B-Instruct-q0f16-MLC",
       model_id: "Llama-3.2-1B-Instruct-q0f16-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-1B-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-1B-Instruct-q0f16_cs1k-webgpu.wasm",
       vram_required_MB: 2573.13,
       low_resource_required: true,
       overrides: {
@@ -389,7 +388,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-3B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-3B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2951.51,
       low_resource_required: true,
       overrides: {
@@ -402,7 +401,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-3B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-3B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2263.69,
       low_resource_required: true,
       overrides: {
@@ -416,7 +415,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5295.7,
       low_resource_required: true,
       overrides: {
@@ -429,7 +428,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4598.34,
       low_resource_required: true,
       overrides: {
@@ -442,7 +441,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6101.01,
       low_resource_required: false,
       overrides: {
@@ -455,7 +454,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 5001.0,
       low_resource_required: false,
       overrides: {
@@ -470,7 +469,7 @@ export const prebuiltAppConfig: AppConfig = {
     //   model_lib:
     //     modelLibURLPrefix +
     //     modelVersion +
-    //     "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+    //     "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
     //   low_resource_required: true,
     //   vram_required_MB: 1629.75,
     //   overrides: {
@@ -483,7 +482,7 @@ export const prebuiltAppConfig: AppConfig = {
     //   model_lib:
     //     modelLibURLPrefix +
     //     modelVersion +
-    //     "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+    //     "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
     //   low_resource_required: true,
     //   vram_required_MB: 1888.97,
     //   overrides: {
@@ -497,7 +496,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5106.67,
       overrides: {
@@ -511,7 +510,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5900.09,
       overrides: {
@@ -526,7 +525,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6101.01,
       low_resource_required: false,
       overrides: {
@@ -540,7 +539,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 5001.0,
       low_resource_required: false,
       overrides: {
@@ -555,7 +554,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4976.13,
       low_resource_required: false,
       overrides: {
@@ -569,7 +568,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6051.27,
       low_resource_required: false,
       overrides: {
@@ -583,7 +582,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4976.13,
       low_resource_required: false,
       overrides: {
@@ -597,7 +596,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6051.27,
       low_resource_required: false,
       overrides: {
@@ -610,7 +609,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-3B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-3B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2951.51,
       low_resource_required: true,
       overrides: {
@@ -623,7 +622,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3.2-3B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3.2-3B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2263.69,
       low_resource_required: true,
       overrides: {
@@ -636,7 +635,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5779.27,
       low_resource_required: false,
       overrides: {
@@ -649,7 +648,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4876.13,
       low_resource_required: false,
       overrides: {
@@ -663,7 +662,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4033.28,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -672,14 +671,14 @@ export const prebuiltAppConfig: AppConfig = {
         sliding_window_size: -1,
       },
     },
-    // Phi3.5-mini-instruct
+    // Phi-3.5-mini-instruct
     {
       model: "https://huggingface.co/mlc-ai/Phi-3.5-mini-instruct-q4f16_1-MLC",
       model_id: "Phi-3.5-mini-instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-mini-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 3672.07,
       low_resource_required: false,
       overrides: {
@@ -692,7 +691,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-mini-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5483.12,
       low_resource_required: false,
       overrides: {
@@ -705,7 +704,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-mini-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2520.07,
       low_resource_required: true,
       overrides: {
@@ -718,7 +717,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-mini-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3.5-mini-instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 3179.12,
       low_resource_required: true,
       overrides: {
@@ -733,7 +732,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-vision-instruct-q4f16_1-ctx4k_cs2k-webgpu.wasm",
+        "/Phi-3.5-vision-instruct-q4f16_1_cs2k-webgpu.wasm",
       vram_required_MB: 3952.18,
       low_resource_required: true,
       overrides: {
@@ -748,13 +747,38 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3.5-vision-instruct-q4f32_1-ctx4k_cs2k-webgpu.wasm",
+        "/Phi-3.5-vision-instruct-q4f32_1_cs2k-webgpu.wasm",
       vram_required_MB: 5879.84,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
       },
       model_type: ModelType.VLM,
+    },
+    // Phi-4-mini-instruct
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-4-mini-instruct-q4f16_1-MLC",
+      model_id: "Phi-4-mini-instruct-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-4-mini-instruct-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Phi-4-mini-instruct-q4f32_1-MLC",
+      model_id: "Phi-4-mini-instruct-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Phi-4-mini-instruct-q4f32_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
     },
     // Mistral variants
     {
@@ -764,7 +788,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -780,7 +804,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5619.27,
       low_resource_required: false,
       overrides: {
@@ -795,7 +819,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -811,7 +835,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -827,7 +851,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -842,7 +866,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Mistral-7B-Instruct-v0.3-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Mistral-7B-Instruct-v0.3-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4573.39,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -858,7 +882,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-1.7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-1.7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1774.19,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -872,7 +896,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-1.7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-1.7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2692.38,
       low_resource_required: true,
       overrides: {
@@ -886,7 +910,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-360M-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-360M-Instruct-q0f16_cs1k-webgpu.wasm",
       vram_required_MB: 871.99,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -900,7 +924,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-360M-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-360M-Instruct-q0f32_cs1k-webgpu.wasm",
       vram_required_MB: 1743.99,
       low_resource_required: true,
       overrides: {
@@ -913,7 +937,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-360M-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-360M-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 376.06,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -927,7 +951,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-360M-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-360M-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 579.61,
       low_resource_required: true,
       overrides: {
@@ -940,7 +964,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-135M-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-135M-Instruct-q0f16_cs1k-webgpu.wasm",
       vram_required_MB: 359.69,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -954,7 +978,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/SmolLM2-135M-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
+        "/SmolLM2-135M-Instruct-q0f32_cs1k-webgpu.wasm",
       vram_required_MB: 719.38,
       low_resource_required: true,
       overrides: {
@@ -968,7 +992,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1895.3,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -982,7 +1006,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2508.75,
       low_resource_required: false,
       overrides: {
@@ -995,7 +1019,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1583.3,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -1009,7 +1033,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1884.75,
       low_resource_required: true,
       overrides: {
@@ -1022,7 +1046,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-9b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-9b-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 6422.01,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -1036,7 +1060,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-9b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-9b-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 8383.33,
       low_resource_required: false,
       overrides: {
@@ -1050,7 +1074,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-jpn-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-jpn-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1895.3,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -1064,8 +1088,73 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2-2b-jpn-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2-2b-jpn-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2508.75,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/gemma3-1b-it-q4f16_1-MLC",
+      model_id: "gemma3-1b-it-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/gemma3-1b-it-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    // OLMo2
+    {
+      model:
+        "https://huggingface.co/mlc-ai/OLMo-2-1124-7B-Instruct-q4f16_1-MLC",
+      model_id: "OLMo-2-1124-7B-Instruct-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/OLMo-2-1124-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/OLMo-2-1124-7B-Instruct-q4f32_1-MLC",
+      model_id: "OLMo-2-1124-7B-Instruct-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/OLMo-2-1124-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/OLMo-2-0425-1B-Instruct-q4f16_1-MLC",
+      model_id: "OLMo-2-0425-1B-Instruct-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/OLMo-2-0425-1B-Instruct-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/OLMo-2-0425-1B-Instruct-q4f32_1-MLC",
+      model_id: "OLMo-2-0425-1B-Instruct-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/OLMo-2-0425-1B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1078,7 +1167,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3-0.6B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3-0.6B-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1403.34,
       low_resource_required: true,
       overrides: {
@@ -1091,7 +1180,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3-0.6B-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3-0.6B-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1924.98,
       low_resource_required: true,
       overrides: {
@@ -1102,36 +1191,31 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/Qwen3-0.6B-q0f16-MLC",
       model_id: "Qwen3-0.6B-q0f16-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Qwen3-0.6B-q0f16-ctx4k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/Qwen3-0.6B-q0f16_cs1k-webgpu.wasm",
       vram_required_MB: 2220.38,
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // TODO: temporarily commenting out q0f32 models due to correctness issues
-    // {
-    //   model: "https://huggingface.co/mlc-ai/Qwen3-0.6B-q0f32-MLC",
-    //   model_id: "Qwen3-0.6B-q0f32-MLC",
-    //   model_lib:
-    //     modelLibURLPrefix +
-    //     modelVersion +
-    //     "/Qwen3-0.6B-q0f32-ctx4k_cs1k-webgpu.wasm",
-    //   vram_required_MB: 3843.25,
-    //   low_resource_required: true,
-    //   overrides: {
-    //     context_window_size: 4096,
-    //   },
-    // },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3-0.6B-q0f32-MLC",
+      model_id: "Qwen3-0.6B-q0f32-MLC",
+      model_lib:
+        modelLibURLPrefix + modelVersion + "/Qwen3-0.6B-q0f32_cs1k-webgpu.wasm",
+      vram_required_MB: 3843.25,
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
     {
       model: "https://huggingface.co/mlc-ai/Qwen3-1.7B-q4f16_1-MLC",
       model_id: "Qwen3-1.7B-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3-1.7B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3-1.7B-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2036.66,
       low_resource_required: true,
       overrides: {
@@ -1144,7 +1228,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3-1.7B-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3-1.7B-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2635.44,
       low_resource_required: true,
       overrides: {
@@ -1155,9 +1239,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/Qwen3-4B-q4f16_1-MLC",
       model_id: "Qwen3-4B-q4f16_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Qwen3-4B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/Qwen3-4B-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 3431.59,
       low_resource_required: true,
       overrides: {
@@ -1168,9 +1250,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/Qwen3-4B-q4f32_1-MLC",
       model_id: "Qwen3-4B-q4f32_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Qwen3-4B-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/Qwen3-4B-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 4327.71,
       low_resource_required: true,
       overrides: {
@@ -1181,9 +1261,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/Qwen3-8B-q4f16_1-MLC",
       model_id: "Qwen3-8B-q4f16_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Qwen3-8B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/Qwen3-8B-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 5695.78,
       low_resource_required: false,
       overrides: {
@@ -1194,9 +1272,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/Qwen3-8B-q4f32_1-MLC",
       model_id: "Qwen3-8B-q4f32_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/Qwen3-8B-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/Qwen3-8B-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6852.55,
       low_resource_required: false,
       overrides: {
@@ -1210,7 +1286,33 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3.5-0.8B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3.5-0.8B-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-0.8B-q4f32_1-MLC",
+      model_id: "Qwen3.5-0.8B-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-0.8B-q4f32_1_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-0.8B-q0f16-MLC",
+      model_id: "Qwen3.5-0.8B-q0f16-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-0.8B-q0f16_cs1k-webgpu.wasm",
       low_resource_required: true,
       overrides: {
         context_window_size: 4096,
@@ -1223,7 +1325,72 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen3.5-2B-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen3.5-2B-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-2B-q4f32_1-MLC",
+      model_id: "Qwen3.5-2B-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-2B-q4f32_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-4B-q4f16_1-MLC",
+      model_id: "Qwen3.5-4B-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-4B-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-4B-q4f32_1-MLC",
+      model_id: "Qwen3.5-4B-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-4B-q4f32_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-9B-q4f16_1-MLC",
+      model_id: "Qwen3.5-9B-q4f16_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-9B-q4f16_1_cs1k-webgpu.wasm",
+      low_resource_required: false,
+      overrides: {
+        context_window_size: 4096,
+        max_history_size: 1,
+      },
+    },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen3.5-9B-q4f32_1-MLC",
+      model_id: "Qwen3.5-9B-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen3.5-9B-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
@@ -1237,7 +1404,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 944.62,
       overrides: {
@@ -1250,7 +1417,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1060.2,
       overrides: {
@@ -1263,34 +1430,33 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q0f16_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1624.12,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // TODO: temporarily commenting out q0f32 models due to correctness issues
-    // {
-    //   model: "https://huggingface.co/mlc-ai/Qwen2.5-0.5B-Instruct-q0f32-MLC",
-    //   model_id: "Qwen2.5-0.5B-Instruct-q0f32-MLC",
-    //   model_lib:
-    //     modelLibURLPrefix +
-    //     modelVersion +
-    //     "/Qwen2-0.5B-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
-    //   low_resource_required: true,
-    //   vram_required_MB: 2654.75,
-    //   overrides: {
-    //     context_window_size: 4096,
-    //   },
-    // },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen2.5-0.5B-Instruct-q0f32-MLC",
+      model_id: "Qwen2.5-0.5B-Instruct-q0f32-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-0.5B-Instruct-q0f32_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 2654.75,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
     {
       model: "https://huggingface.co/mlc-ai/Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
       model_id: "Qwen2.5-1.5B-Instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1629.75,
       overrides: {
@@ -1303,7 +1469,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1888.97,
       overrides: {
@@ -1316,7 +1482,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2.5-3B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2.5-3B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 2504.76,
       overrides: {
@@ -1329,7 +1495,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2.5-3B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2.5-3B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 2893.64,
       overrides: {
@@ -1342,7 +1508,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5106.67,
       overrides: {
@@ -1355,7 +1521,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5900.09,
       overrides: {
@@ -1370,7 +1536,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 944.62,
       overrides: {
@@ -1384,7 +1550,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1060.2,
       overrides: {
@@ -1398,28 +1564,27 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q0f16_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1624.12,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // TODO: temporarily commenting out q0f32 models due to correctness issues
-    // {
-    //   model:
-    //     "https://huggingface.co/mlc-ai/Qwen2.5-Coder-0.5B-Instruct-q0f32-MLC",
-    //   model_id: "Qwen2.5-Coder-0.5B-Instruct-q0f32-MLC",
-    //   model_lib:
-    //     modelLibURLPrefix +
-    //     modelVersion +
-    //     "/Qwen2-0.5B-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
-    //   low_resource_required: true,
-    //   vram_required_MB: 2654.75,
-    //   overrides: {
-    //     context_window_size: 4096,
-    //   },
-    // },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Qwen2.5-Coder-0.5B-Instruct-q0f32-MLC",
+      model_id: "Qwen2.5-Coder-0.5B-Instruct-q0f32-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-0.5B-Instruct-q0f32_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 2654.75,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
     {
       model:
         "https://huggingface.co/mlc-ai/Qwen2.5-Coder-1.5B-Instruct-q4f16_1-MLC",
@@ -1427,7 +1592,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 1629.75,
       overrides: {
@@ -1441,7 +1606,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 1888.97,
       overrides: {
@@ -1455,7 +1620,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2.5-3B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2.5-3B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 2504.76,
       overrides: {
@@ -1469,7 +1634,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2.5-3B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2.5-3B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 2893.64,
       overrides: {
@@ -1483,7 +1648,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5106.67,
       overrides: {
@@ -1497,7 +1662,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5900.09,
       overrides: {
@@ -1512,7 +1677,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1629.75,
       overrides: {
@@ -1526,7 +1691,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1888.97,
       overrides: {
@@ -1540,7 +1705,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2087.66,
       low_resource_required: false,
       overrides: {
@@ -1553,7 +1718,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2999.33,
       low_resource_required: false,
       overrides: {
@@ -1566,7 +1731,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1511.66,
       low_resource_required: true,
       overrides: {
@@ -1579,7 +1744,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/stablelm-2-zephyr-1_6b-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/stablelm-2-zephyr-1_6b-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1847.33,
       low_resource_required: true,
       overrides: {
@@ -1594,7 +1759,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2972.09,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -1609,7 +1774,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 3928.09,
       low_resource_required: false,
       overrides: {
@@ -1623,7 +1788,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2041.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -1638,7 +1803,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/RedPajama-INCITE-Chat-3B-v1-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2558.09,
       low_resource_required: true,
       overrides: {
@@ -1653,7 +1818,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 697.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -1668,7 +1833,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 839.98,
       low_resource_required: true,
       overrides: {
@@ -1682,7 +1847,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 675.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -1697,7 +1862,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v1.0-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 795.98,
       low_resource_required: true,
       overrides: {
@@ -1712,7 +1877,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3_1-70B-Instruct-q3f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3_1-70B-Instruct-q3f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 31153.13,
       low_resource_required: false,
       overrides: {
@@ -1726,7 +1891,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 944.62,
       overrides: {
@@ -1739,34 +1904,33 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-0.5B-Instruct-q0f16-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-0.5B-Instruct-q0f16_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1624.12,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // TODO: temporarily commenting out q0f32 models due to correctness issues
-    // {
-    //   model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q0f32-MLC",
-    //   model_id: "Qwen2-0.5B-Instruct-q0f32-MLC",
-    //   model_lib:
-    //     modelLibURLPrefix +
-    //     modelVersion +
-    //     "/Qwen2-0.5B-Instruct-q0f32-ctx4k_cs1k-webgpu.wasm",
-    //   low_resource_required: true,
-    //   vram_required_MB: 2654.75,
-    //   overrides: {
-    //     context_window_size: 4096,
-    //   },
-    // },
+    {
+      model: "https://huggingface.co/mlc-ai/Qwen2-0.5B-Instruct-q0f32-MLC",
+      model_id: "Qwen2-0.5B-Instruct-q0f32-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Qwen2-0.5B-Instruct-q0f32_cs1k-webgpu.wasm",
+      low_resource_required: true,
+      vram_required_MB: 2654.75,
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
     {
       model: "https://huggingface.co/mlc-ai/Qwen2-1.5B-Instruct-q4f16_1-MLC",
       model_id: "Qwen2-1.5B-Instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1629.75,
       overrides: {
@@ -1779,7 +1943,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1888.97,
       overrides: {
@@ -1792,7 +1956,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5106.67,
       overrides: {
@@ -1805,7 +1969,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5900.09,
       overrides: {
@@ -1820,7 +1984,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1629.75,
       overrides: {
@@ -1834,7 +1998,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-1.5B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-1.5B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: true,
       vram_required_MB: 1888.97,
       overrides: {
@@ -1847,7 +2011,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5106.67,
       overrides: {
@@ -1860,7 +2024,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Qwen2-7B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Qwen2-7B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       low_resource_required: false,
       vram_required_MB: 5900.09,
       overrides: {
@@ -1874,7 +2038,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5295.7,
       low_resource_required: true,
       overrides: {
@@ -1887,7 +2051,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4598.34,
       low_resource_required: true,
       overrides: {
@@ -1900,7 +2064,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 6101.01,
       low_resource_required: false,
       overrides: {
@@ -1913,7 +2077,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-8B-Instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-8B-Instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 5001.0,
       low_resource_required: false,
       overrides: {
@@ -1926,21 +2090,21 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-3-70B-Instruct-q3f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-3-70B-Instruct-q3f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 31153.13,
       low_resource_required: false,
       overrides: {
         context_window_size: 4096,
       },
     },
-    // Phi3-mini-instruct
+    // Phi-3-mini-instruct
     {
       model: "https://huggingface.co/mlc-ai/Phi-3-mini-4k-instruct-q4f16_1-MLC",
       model_id: "Phi-3-mini-4k-instruct-q4f16_1-MLC",
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 3672.07,
       low_resource_required: false,
       overrides: {
@@ -1953,7 +2117,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5483.12,
       low_resource_required: false,
       overrides: {
@@ -1966,7 +2130,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2520.07,
       low_resource_required: true,
       overrides: {
@@ -1979,7 +2143,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Phi-3-mini-4k-instruct-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Phi-3-mini-4k-instruct-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 3179.12,
       low_resource_required: true,
       overrides: {
@@ -1993,7 +2157,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 5284.01,
       low_resource_required: false,
       overrides: {
@@ -2006,7 +2170,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 4618.52,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -2020,7 +2184,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 9109.03,
       low_resource_required: false,
       overrides: {
@@ -2033,7 +2197,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-7b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-2-7b-chat-hf-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 6749.02,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -2047,7 +2211,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Llama-2-13b-chat-hf-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Llama-2-13b-chat-hf-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 11814.09,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -2062,7 +2226,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1476.52,
       low_resource_required: false,
       buffer_size_required_bytes: 262144000,
@@ -2077,7 +2241,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1750.66,
       low_resource_required: false,
       buffer_size_required_bytes: 262144000,
@@ -2091,7 +2255,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1476.52,
       low_resource_required: true,
       buffer_size_required_bytes: 262144000,
@@ -2106,7 +2270,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/gemma-2b-it-q4f32_1-ctx4k_cs1k-webgpu.wasm",
+        "/gemma-2b-it-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1750.66,
       low_resource_required: true,
       buffer_size_required_bytes: 262144000,
@@ -2119,9 +2283,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC",
       model_id: "phi-2-q4f16_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-2-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-2-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 3053.97,
       low_resource_required: false,
       required_features: ["shader-f16"],
@@ -2133,9 +2295,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC",
       model_id: "phi-2-q4f32_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-2-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-2-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 4032.48,
       low_resource_required: false,
       overrides: {
@@ -2146,9 +2306,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f16_1-MLC",
       model_id: "phi-2-q4f16_1-MLC-1k",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-2-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-2-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 2131.97,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -2160,9 +2318,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-2-q4f32_1-MLC",
       model_id: "phi-2-q4f32_1-MLC-1k",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-2-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-2-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 2740.48,
       low_resource_required: true,
       overrides: {
@@ -2174,9 +2330,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f16_1-MLC",
       model_id: "phi-1_5-q4f16_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-1_5-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1210.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -2188,9 +2342,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC",
       model_id: "phi-1_5-q4f32_1-MLC",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-1_5-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
       overrides: {
@@ -2201,9 +2353,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f16_1-MLC",
       model_id: "phi-1_5-q4f16_1-MLC-1k",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-1_5-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 1210.09,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -2215,9 +2365,7 @@ export const prebuiltAppConfig: AppConfig = {
       model: "https://huggingface.co/mlc-ai/phi-1_5-q4f32_1-MLC",
       model_id: "phi-1_5-q4f32_1-MLC-1k",
       model_lib:
-        modelLibURLPrefix +
-        modelVersion +
-        "/phi-1_5-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        modelLibURLPrefix + modelVersion + "/phi-1_5-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 1682.09,
       low_resource_required: true,
       overrides: {
@@ -2232,7 +2380,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 697.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -2247,7 +2395,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 839.98,
       low_resource_required: true,
       overrides: {
@@ -2261,7 +2409,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f16_1_cs1k-webgpu.wasm",
       vram_required_MB: 675.24,
       low_resource_required: true,
       required_features: ["shader-f16"],
@@ -2276,7 +2424,7 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1-ctx2k_cs1k-webgpu.wasm",
+        "/TinyLlama-1.1B-Chat-v0.4-q4f32_1_cs1k-webgpu.wasm",
       vram_required_MB: 795.98,
       low_resource_required: true,
       overrides: {
@@ -2333,7 +2481,19 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Ministral-3-3B-Base-2512-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Ministral-3-3B-Base-2512-q4f16_1_cs1k-webgpu.wasm",
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Base-2512-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Base-2512-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Base-2512-q4f32_1_cs1k-webgpu.wasm",
       overrides: {
         context_window_size: 4096,
       },
@@ -2345,7 +2505,19 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Ministral-3-3B-Reasoning-2512-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Ministral-3-3B-Reasoning-2512-q4f16_1_cs1k-webgpu.wasm",
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Reasoning-2512-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Reasoning-2512-q4f32_1_cs1k-webgpu.wasm",
       overrides: {
         context_window_size: 4096,
       },
@@ -2357,7 +2529,19 @@ export const prebuiltAppConfig: AppConfig = {
       model_lib:
         modelLibURLPrefix +
         modelVersion +
-        "/Ministral-3-3B-Instruct-2512-BF16-q4f16_1-ctx4k_cs1k-webgpu.wasm",
+        "/Ministral-3-3B-Instruct-2512-BF16-q4f16_1_cs1k-webgpu.wasm",
+      overrides: {
+        context_window_size: 4096,
+      },
+    },
+    {
+      model:
+        "https://huggingface.co/mlc-ai/Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
+      model_id: "Ministral-3-3B-Instruct-2512-BF16-q4f32_1-MLC",
+      model_lib:
+        modelLibURLPrefix +
+        modelVersion +
+        "/Ministral-3-3B-Instruct-2512-BF16-q4f32_1_cs1k-webgpu.wasm",
       overrides: {
         context_window_size: 4096,
       },

--- a/tests/scripts/sanity_checks/package.json
+++ b/tests/scripts/sanity_checks/package.json
@@ -15,6 +15,6 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82"
+    "@mlc-ai/web-llm": "^0.2.83"
   }
 }

--- a/utils/vram_requirements/package.json
+++ b/utils/vram_requirements/package.json
@@ -19,7 +19,7 @@
     "url": "^0.11.3"
   },
   "dependencies": {
-    "@mlc-ai/web-llm": "^0.2.82",
+    "@mlc-ai/web-llm": "^0.2.83",
     "@mlc-ai/web-runtime": "0.18.0-dev2"
   }
 }


### PR DESCRIPTION
- Upgrade to version 0.2.83
- Remove `ctx` from model list entries (except for embedding models)
- Uncomment `q0f32` models from model list
- Binaries are now available at `v0_2_83/base` with WASMs compiled with subgroup support available at `v0_2_83/sg32`
- Update `subgroups_usage.ts` example