### PR TITLE
[Fix] Return OpenAI created timestamps in seconds

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -74,6 +74,10 @@ import { asyncLoadTokenizer } from "./cache_util";
 import { EmbeddingPipeline } from "./embedding";
 import { verifyIntegrity } from "./integrity";
 
+function getUnixTimestampSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
 /**
  * Creates `MLCEngine`, and loads `modelId` onto WebGPU.
  *
@@ -526,7 +530,7 @@ export class MLCEngine implements MLCEngineInterface {
     }
 
     // 1. Helper function that generates the chunk
-    const created = Date.now();
+    const created = getUnixTimestampSeconds();
     const id = crypto.randomUUID();
     this.interruptSignal = false;
     let prevMessageLength = 0; // to know where to start slicing the delta; does not count �
@@ -931,7 +935,7 @@ export class MLCEngine implements MLCEngineInterface {
         choices: choices,
         model: selectedModelId,
         object: "chat.completion",
-        created: Date.now(),
+        created: getUnixTimestampSeconds(),
         usage: {
           completion_tokens: completion_tokens,
           prompt_tokens: prompt_tokens,
@@ -1067,7 +1071,7 @@ export class MLCEngine implements MLCEngineInterface {
         choices: choices,
         model: selectedModelId,
         object: "text_completion",
-        created: Date.now(),
+        created: getUnixTimestampSeconds(),
         usage: {
           completion_tokens: completion_tokens,
           prompt_tokens: prompt_tokens,

--- a/tests/engine_integration.test.ts
+++ b/tests/engine_integration.test.ts
@@ -221,7 +221,7 @@ jest.mock("../src/embedding", () => {
 const MODEL_ID = "mock-model";
 const SECOND_MODEL_ID = "mock-model-2";
 const EMBED_MODEL_ID = "mock-embed";
-const FIXED_CREATED_DATE = new Date("2024-04-05T06:34:56.000Z");
+const FIXED_CREATED_DATE = new Date("2024-04-05T06:34:56.789Z");
 const FIXED_CREATED_SECONDS = 1712298896;
 const mockChatConfig: ChatConfig = {
   tokenizer_files: ["tokenizer.json"],

--- a/tests/engine_integration.test.ts
+++ b/tests/engine_integration.test.ts
@@ -15,7 +15,7 @@ import { LLMChatPipeline } from "../src/llm_chat";
 import { EmbeddingPipeline } from "../src/embedding";
 import { CustomLock } from "../src/support";
 import { UnclearModelToUseError } from "../src/error";
-import { jest, test, expect, describe } from "@jest/globals";
+import { jest, test, expect, describe, afterEach } from "@jest/globals";
 
 type ChatConfig = import("../src/config").ChatConfig;
 type Conversation = import("../src/conversation").Conversation;
@@ -221,6 +221,8 @@ jest.mock("../src/embedding", () => {
 const MODEL_ID = "mock-model";
 const SECOND_MODEL_ID = "mock-model-2";
 const EMBED_MODEL_ID = "mock-embed";
+const FIXED_CREATED_DATE = new Date("2024-04-05T06:34:56.000Z");
+const FIXED_CREATED_SECONDS = 1712298896;
 const mockChatConfig: ChatConfig = {
   tokenizer_files: ["tokenizer.json"],
   vocab_size: 10,
@@ -354,8 +356,13 @@ function createEngineWithEmbeddingPipeline() {
   return { engine, pipeline };
 }
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe("MLCEngine deterministic integration", () => {
   test("chatCompletion aggregates usage without WebGPU", async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_CREATED_DATE);
     const { engine, pipeline } = createEngineWithPipeline(3);
     const request: ChatCompletionRequest = {
       model: MODEL_ID,
@@ -371,12 +378,14 @@ describe("MLCEngine deterministic integration", () => {
     response.choices.forEach((choice) => {
       expect(choice.message?.content).toContain("What is new?");
     });
+    expect(response.created).toBe(FIXED_CREATED_SECONDS);
     expect(response.usage?.completion_tokens).toBe(6);
     expect(response.usage?.prompt_tokens).toBeGreaterThan(0);
     expect((pipeline as any).prefillCallCount).toBe(2);
   });
 
   test("completion echoes prompt when requested", async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_CREATED_DATE);
     const { engine } = createEngineWithPipeline(1);
     const request: CompletionCreateParams = {
       model: MODEL_ID,
@@ -388,6 +397,7 @@ describe("MLCEngine deterministic integration", () => {
 
     expect(response.choices).toHaveLength(1);
     expect(response.choices[0].text.startsWith("Alpha ")).toBe(true);
+    expect(response.created).toBe(FIXED_CREATED_SECONDS);
     expect(response.usage?.completion_tokens).toBe(1);
     expect(response.usage?.prompt_tokens).toBeGreaterThan(0);
   });
@@ -403,6 +413,7 @@ describe("MLCEngine deterministic integration", () => {
   });
 
   test("chatCompletion streaming yields chunks, final delta, and usage data", async () => {
+    jest.useFakeTimers().setSystemTime(FIXED_CREATED_DATE);
     const { engine } = createEngineWithPipeline(2);
     const request: ChatCompletionRequest = {
       model: MODEL_ID,
@@ -422,6 +433,9 @@ describe("MLCEngine deterministic integration", () => {
     }
     expect(chunks.length).toBeGreaterThanOrEqual(3);
     expect(chunks[0].choices[0].delta?.content).toContain("Stream please");
+    expect(
+      chunks.every((chunk) => chunk.created === FIXED_CREATED_SECONDS),
+    ).toBe(true);
     const finalChunk = chunks[chunks.length - 2];
     expect(finalChunk.choices[0].finish_reason).toEqual("stop");
     const usageChunk = chunks[chunks.length - 1];


### PR DESCRIPTION
## Summary

- add a shared helper for OpenAI-compatible Unix timestamps in seconds
- use it for chat completion, text completion, and streaming chunk `created` fields
- add deterministic engine integration coverage for non-streaming and streaming response timestamps

## Root cause

The OpenAI-compatible response types document `created` as a Unix timestamp in seconds, but `MLCEngine` was using `Date.now()`, which returns milliseconds.

Fixes #829

## Validation

- `npx jest tests/engine_integration.test.ts --runInBand --coverage=false`
- `npm run lint`
- `npm test -- --runInBand`