### PR TITLE
[Fix] Safely render example text and prevent HTML sink regressions

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -43,6 +43,16 @@ module.exports = defineConfig([{
     "rules": {
         "no-undef": "off",
         "@typescript-eslint/no-unused-vars": "off",
+        "no-restricted-syntax": ["error", {
+            selector: "AssignmentExpression[left.property.name='innerHTML']",
+            message: "Render example text with textContent or DOM nodes instead of innerHTML.",
+        }, {
+            selector: "AssignmentExpression[left.property.name='outerHTML']",
+            message: "Render example text with textContent or DOM nodes instead of outerHTML.",
+        }, {
+            selector: "CallExpression[callee.property.name='insertAdjacentHTML']",
+            message: "Build example DOM nodes directly instead of parsing strings with insertAdjacentHTML.",
+        }],
     },
 }, globalIgnores([
     "**/dist",

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -38,6 +38,13 @@ module.exports = defineConfig([{
         "@typescript-eslint/no-non-null-assertion": "off",
     },
 }, {
+    files: ["examples/**/*.js", "examples/**/*.ts"],
+
+    "rules": {
+        "no-undef": "off",
+        "@typescript-eslint/no-unused-vars": "off",
+    },
+}, {
     files: [
         "examples/**/*.js",
         "examples/**/*.jsx",
@@ -46,8 +53,6 @@ module.exports = defineConfig([{
     ],
 
     "rules": {
-        "no-undef": "off",
-        "@typescript-eslint/no-unused-vars": "off",
         "no-restricted-syntax": ["error", {
             selector: "AssignmentExpression[left.property.name='innerHTML']",
             message: "Render example text with textContent or DOM nodes instead of innerHTML.",

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -38,7 +38,12 @@ module.exports = defineConfig([{
         "@typescript-eslint/no-non-null-assertion": "off",
     },
 }, {
-    files: ["examples/**/*.js", "examples/**/*.ts"],
+    files: [
+        "examples/**/*.js",
+        "examples/**/*.jsx",
+        "examples/**/*.ts",
+        "examples/**/*.tsx",
+    ],
 
     "rules": {
         "no-undef": "off",
@@ -52,6 +57,9 @@ module.exports = defineConfig([{
         }, {
             selector: "CallExpression[callee.property.name='insertAdjacentHTML']",
             message: "Build example DOM nodes directly instead of parsing strings with insertAdjacentHTML.",
+        }, {
+            selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+            message: "Render example text as JSX text or DOM nodes instead of dangerouslySetInnerHTML.",
         }],
     },
 }, globalIgnores([

--- a/examples/chrome-extension-webgpu-service-worker/src/content.js
+++ b/examples/chrome-extension-webgpu-service-worker/src/content.js
@@ -1,6 +1,6 @@
 // Only the content script is able to access the DOM
 chrome.runtime.onConnect.addListener(function (port) {
   port.onMessage.addListener(function (msg) {
-    port.postMessage({ contents: document.body.innerHTML });
+    port.postMessage({ contents: document.body.innerText });
   });
 });

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.css
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.css
@@ -159,6 +159,7 @@ p {
 
 #answer {
   color: #333333;
+  white-space: pre-wrap;
 }
 
 #answerWrapper {

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -20,6 +20,10 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const queryInput = document.getElementById("query-input")!;
 const submitButton = document.getElementById("submit-button")!;
+const answerElement = document.getElementById("answer")!;
+const answerWrapper = document.getElementById("answerWrapper")!;
+const loadingIndicator = document.getElementById("loading-indicator")!;
+const copyAnswerButton = document.getElementById("copyAnswer")!;
 
 let isLoadingParams = false;
 
@@ -75,6 +79,15 @@ queryInput.addEventListener("keyup", () => {
   }
 });
 
+copyAnswerButton.addEventListener("click", copyAnswer);
+
+function copyAnswer() {
+  navigator.clipboard
+    .writeText(answerElement.textContent ?? "")
+    .then(() => console.log("Answer text copied to clipboard"))
+    .catch((err) => console.error("Could not copy text: ", err));
+}
+
 // If user presses enter, click submit button
 queryInput.addEventListener("keyup", (event) => {
   if (event.code === "Enter") {
@@ -91,11 +104,11 @@ async function handleClick() {
   chatHistory.push({ role: "user", content: message });
 
   // Clear the answer
-  document.getElementById("answer")!.textContent = "";
+  answerElement.textContent = "";
   // Hide the answer
-  document.getElementById("answerWrapper")!.style.display = "none";
+  answerWrapper.style.display = "none";
   // Show the loading indicator
-  document.getElementById("loading-indicator")!.style.display = "block";
+  loadingIndicator.style.display = "block";
 
   // Send the chat completion message to the engine
   let curMessage = "";
@@ -119,18 +132,8 @@ submitButton.addEventListener("click", handleClick);
 
 function updateAnswer(answer: string) {
   // Show answer
-  document.getElementById("answerWrapper")!.style.display = "block";
-  document.getElementById("answer")!.textContent = answer;
-  // Add event listener to copy button
-  document.getElementById("copyAnswer")!.addEventListener("click", () => {
-    // Get the answer text
-    const answerText = answer;
-    // Copy the answer text to the clipboard
-    navigator.clipboard
-      .writeText(answerText)
-      .then(() => console.log("Answer text copied to clipboard"))
-      .catch((err) => console.error("Could not copy text: ", err));
-  });
+  answerWrapper.style.display = "block";
+  answerElement.textContent = answer;
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "2-digit",
@@ -142,7 +145,7 @@ function updateAnswer(answer: string) {
   // Update timestamp
   document.getElementById("timestamp")!.innerText = time;
   // Hide loading indicator
-  document.getElementById("loading-indicator")!.style.display = "none";
+  loadingIndicator.style.display = "none";
 }
 
 function fetchPageContents() {

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -91,7 +91,7 @@ async function handleClick() {
   chatHistory.push({ role: "user", content: message });
 
   // Clear the answer
-  document.getElementById("answer")!.innerHTML = "";
+  document.getElementById("answer")!.textContent = "";
   // Hide the answer
   document.getElementById("answerWrapper")!.style.display = "none";
   // Show the loading indicator
@@ -120,8 +120,7 @@ submitButton.addEventListener("click", handleClick);
 function updateAnswer(answer: string) {
   // Show answer
   document.getElementById("answerWrapper")!.style.display = "block";
-  const answerWithBreaks = answer.replace(/\n/g, "<br>");
-  document.getElementById("answer")!.innerHTML = answerWithBreaks;
+  document.getElementById("answer")!.textContent = answer;
   // Add event listener to copy button
   document.getElementById("copyAnswer")!.addEventListener("click", () => {
     // Get the answer text

--- a/examples/chrome-extension/src/popup.css
+++ b/examples/chrome-extension/src/popup.css
@@ -159,6 +159,7 @@ p {
 
 #answer {
   color: #333333;
+  white-space: pre-wrap;
 }
 
 #answerWrapper {

--- a/examples/chrome-extension/src/popup.ts
+++ b/examples/chrome-extension/src/popup.ts
@@ -35,6 +35,10 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 const queryInput = getElementAndCheck("query-input")!;
 const submitButton = getElementAndCheck("submit-button")!;
 const modelName = getElementAndCheck("model-name");
+const answerElement = getElementAndCheck("answer");
+const answerWrapper = getElementAndCheck("answerWrapper");
+const loadingIndicator = getElementAndCheck("loading-indicator");
+const copyAnswerButton = getElementAndCheck("copyAnswer");
 
 let context = "";
 let modelDisplayName = "";
@@ -133,6 +137,15 @@ queryInput.addEventListener("keyup", () => {
   }
 });
 
+copyAnswerButton.addEventListener("click", copyAnswer);
+
+function copyAnswer() {
+  navigator.clipboard
+    .writeText(answerElement.textContent ?? "")
+    .then(() => console.log("Answer text copied to clipboard"))
+    .catch((err) => console.error("Could not copy text: ", err));
+}
+
 // If user presses enter, click submit button
 queryInput.addEventListener("keyup", (event) => {
   if (event.code === "Enter") {
@@ -150,11 +163,11 @@ async function handleClick() {
   const message = (<HTMLInputElement>queryInput).value;
   console.log("message", message);
   // Clear the answer
-  document.getElementById("answer")!.textContent = "";
+  answerElement.textContent = "";
   // Hide the answer
-  document.getElementById("answerWrapper")!.style.display = "none";
+  answerWrapper.style.display = "none";
   // Show the loading indicator
-  document.getElementById("loading-indicator")!.style.display = "block";
+  loadingIndicator.style.display = "block";
 
   // Generate response
   let inp = message;
@@ -259,18 +272,8 @@ chrome.runtime.onMessage.addListener(({ answer, error }) => {
 
 function updateAnswer(answer: string) {
   // Show answer
-  document.getElementById("answerWrapper")!.style.display = "block";
-  document.getElementById("answer")!.textContent = answer;
-  // Add event listener to copy button
-  document.getElementById("copyAnswer")!.addEventListener("click", () => {
-    // Get the answer text
-    const answerText = answer;
-    // Copy the answer text to the clipboard
-    navigator.clipboard
-      .writeText(answerText)
-      .then(() => console.log("Answer text copied to clipboard"))
-      .catch((err) => console.error("Could not copy text: ", err));
-  });
+  answerWrapper.style.display = "block";
+  answerElement.textContent = answer;
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "2-digit",
@@ -282,7 +285,7 @@ function updateAnswer(answer: string) {
   // Update timestamp
   document.getElementById("timestamp")!.innerText = time;
   // Hide loading indicator
-  document.getElementById("loading-indicator")!.style.display = "none";
+  loadingIndicator.style.display = "none";
 }
 
 function fetchPageContents() {

--- a/examples/chrome-extension/src/popup.ts
+++ b/examples/chrome-extension/src/popup.ts
@@ -77,7 +77,7 @@ for (let i = 0; i < prebuiltAppConfig.model_list.length; ++i) {
   const model = prebuiltAppConfig.model_list[i];
   const opt = document.createElement("option");
   opt.value = model.model_id;
-  opt.innerHTML = model.model_id;
+  opt.textContent = model.model_id;
   opt.selected = false;
 
   // set initial selection as the initially selected model
@@ -150,7 +150,7 @@ async function handleClick() {
   const message = (<HTMLInputElement>queryInput).value;
   console.log("message", message);
   // Clear the answer
-  document.getElementById("answer")!.innerHTML = "";
+  document.getElementById("answer")!.textContent = "";
   // Hide the answer
   document.getElementById("answerWrapper")!.style.display = "none";
   // Show the loading indicator
@@ -260,8 +260,7 @@ chrome.runtime.onMessage.addListener(({ answer, error }) => {
 function updateAnswer(answer: string) {
   // Show answer
   document.getElementById("answerWrapper")!.style.display = "block";
-  const answerWithBreaks = answer.replace(/\n/g, "<br>");
-  document.getElementById("answer")!.innerHTML = answerWithBreaks;
+  document.getElementById("answer")!.textContent = answer;
   // Add event listener to copy button
   document.getElementById("copyAnswer")!.addEventListener("click", () => {
     // Get the answer text

--- a/examples/next-simple-chat/src/utils/chat_component.tsx
+++ b/examples/next-simple-chat/src/utils/chat_component.tsx
@@ -11,7 +11,7 @@ const ChatComponent = () => {
   const [chat_ui] = useState(new ChatUI(new MLCEngine()));
   const updateMessage = (kind: string, text: string, append: boolean) => {
     if (kind == "init") {
-      text = "[System Initalize] " + text;
+      text = "[System Initialize] " + text;
     }
     const msgCopy = [...messages];
     if (msgCopy.length == 0 || append) {
@@ -39,7 +39,7 @@ const ChatComponent = () => {
           {messages.map((value, index) => (
             <div key={index} className={`msg ${value.kind}-msg`}>
               <div className="msg-bubble">
-                <div className="msg-text">${value.text}</div>
+                <div className="msg-text">{value.text}</div>
               </div>
             </div>
           ))}

--- a/examples/simple-chat-ts/src/llm_chat.css
+++ b/examples/simple-chat-ts/src/llm_chat.css
@@ -107,6 +107,10 @@ s .chatui-header {
   margin-right: auto;
 }
 
+.msg-text {
+  white-space: pre-wrap;
+}
+
 .left-msg .msg-bubble {
   background-color: #343541;
   color: #ececec;

--- a/examples/simple-chat-ts/src/simple_chat.ts
+++ b/examples/simple-chat-ts/src/simple_chat.ts
@@ -194,7 +194,7 @@ class ChatUI {
 
   private appendMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
-      text = "[System Initalize] " + text;
+      text = "[System Initialize] " + text;
     }
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");

--- a/examples/simple-chat-ts/src/simple_chat.ts
+++ b/examples/simple-chat-ts/src/simple_chat.ts
@@ -1,6 +1,8 @@
 import appConfig from "./app-config";
 import * as webllm from "@mlc-ai/web-llm";
 
+type MessageKind = "left" | "right" | "init" | "error";
+
 function getElementAndCheck(id: string): HTMLElement {
   const element = document.getElementById(id);
   if (element == null) {
@@ -89,7 +91,7 @@ class ChatUI {
       const item = chatUI.config.model_list[i];
       const opt = document.createElement("option");
       opt.value = item.model_id;
-      opt.innerHTML = item.model_id;
+      opt.textContent = item.model_id;
       opt.selected = i == 0;
       if (
         (restrictModels &&
@@ -174,45 +176,34 @@ class ChatUI {
   }
 
   // Internal helper functions
-  private appendMessage(kind, text) {
+  private createMessageElement(kind: MessageKind, text: string): HTMLElement {
+    const message = document.createElement("div");
+    message.className = `msg ${kind}-msg`;
+
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+
+    const messageText = document.createElement("div");
+    messageText.className = "msg-text";
+    messageText.textContent = text;
+
+    bubble.append(messageText);
+    message.append(bubble);
+    return message;
+  }
+
+  private appendMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
       text = "[System Initalize] " + text;
     }
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
     }
-    const msg = `
-      <div class="msg ${kind}-msg">
-        <div class="msg-bubble">
-          <div class="msg-text">${text}</div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
+    this.uiChat.append(this.createMessageElement(kind, text));
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
-  // Special care for user input such that we treat it as pure text instead of html
-  private appendUserMessage(text: string) {
-    if (this.uiChat === undefined) {
-      throw Error("cannot find ui chat");
-    }
-    const msg = `
-      <div class="msg right-msg">
-        <div class="msg-bubble">
-          <div class="msg-text"></div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
-    // Recurse three times to get `msg-text`
-    const msgElement = this.uiChat.lastElementChild?.lastElementChild
-      ?.lastElementChild as HTMLElement;
-    msgElement.insertAdjacentText("beforeend", text);
-    this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
-  }
-
-  private updateLastMessage(kind, text) {
+  private updateLastMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
       text = "[System Initialize] " + text;
     }
@@ -224,20 +215,14 @@ class ChatUI {
     const msg = matches[matches.length - 1];
     const msgText = msg.getElementsByClassName("msg-text");
     if (msgText.length != 1) throw Error("Expect msg-text");
-    if (msgText[0].innerHTML == text) return;
-    const list = text.split("\n").map((t) => {
-      const item = document.createElement("div");
-      item.textContent = t;
-      return item;
-    });
-    msgText[0].innerHTML = "";
-    list.forEach((item) => msgText[0].append(item));
+    if (msgText[0].textContent == text) return;
+    msgText[0].textContent = text;
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
   private resetChatHistory() {
     this.chatHistory = [];
-    const clearTags = ["left", "right", "init", "error"];
+    const clearTags: MessageKind[] = ["left", "right", "init", "error"];
     for (const tag of clearTags) {
       // need to unpack to list so the iterator don't get affected by mutation
       const matches = [...this.uiChat.getElementsByClassName(`msg ${tag}-msg`)];
@@ -246,7 +231,7 @@ class ChatUI {
       }
     }
     if (this.uiChatInfoLabel !== undefined) {
-      this.uiChatInfoLabel.innerHTML = "";
+      this.uiChatInfoLabel.textContent = "";
     }
   }
 
@@ -289,7 +274,7 @@ class ChatUI {
       return;
     }
 
-    this.appendUserMessage(prompt);
+    this.appendMessage("right", prompt);
     this.uiChatInput.value = "";
     this.uiChatInput.setAttribute("placeholder", "Generating...");
 
@@ -322,7 +307,7 @@ class ChatUI {
         }
       }
       if (usage) {
-        this.uiChatInfoLabel.innerHTML =
+        this.uiChatInfoLabel.textContent =
           `prompt_tokens: ${usage.prompt_tokens}, ` +
           `completion_tokens: ${usage.completion_tokens}, ` +
           `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +

--- a/examples/simple-chat-upload/src/llm_chat.css
+++ b/examples/simple-chat-upload/src/llm_chat.css
@@ -107,6 +107,10 @@ s .chatui-header {
   margin-right: auto;
 }
 
+.msg-text {
+  white-space: pre-wrap;
+}
+
 .left-msg .msg-bubble {
   background-color: #343541;
   color: #ececec;

--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -194,7 +194,7 @@ class ChatUI {
 
   private appendMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
-      text = "[System Initalize] " + text;
+      text = "[System Initialize] " + text;
     }
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
@@ -205,7 +205,7 @@ class ChatUI {
 
   private updateLastMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
-      text = "[System Initalize] " + text;
+      text = "[System Initialize] " + text;
     }
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");

--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -1,6 +1,8 @@
 import appConfig from "./app-config";
 import * as webllm from "@mlc-ai/web-llm";
 
+type MessageKind = "left" | "right" | "init" | "error";
+
 function getElementAndCheck(id: string): HTMLElement {
   const element = document.getElementById(id);
   if (element == null) {
@@ -89,7 +91,7 @@ class ChatUI {
       const item = chatUI.config.model_list[i];
       const opt = document.createElement("option");
       opt.value = item.model_id;
-      opt.innerHTML = item.model_id;
+      opt.textContent = item.model_id;
       opt.selected = i == 0;
       if (
         (restrictModels &&
@@ -174,25 +176,34 @@ class ChatUI {
   }
 
   // Internal helper functions
-  private appendMessage(kind, text) {
+  private createMessageElement(kind: MessageKind, text: string): HTMLElement {
+    const message = document.createElement("div");
+    message.className = `msg ${kind}-msg`;
+
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+
+    const messageText = document.createElement("div");
+    messageText.className = "msg-text";
+    messageText.textContent = text;
+
+    bubble.append(messageText);
+    message.append(bubble);
+    return message;
+  }
+
+  private appendMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
       text = "[System Initalize] " + text;
     }
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
     }
-    const msg = `
-      <div class="msg ${kind}-msg">
-        <div class="msg-bubble">
-          <div class="msg-text">${text}</div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
+    this.uiChat.append(this.createMessageElement(kind, text));
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
-  private updateLastMessage(kind, text) {
+  private updateLastMessage(kind: MessageKind, text: string) {
     if (kind == "init") {
       text = "[System Initalize] " + text;
     }
@@ -204,20 +215,14 @@ class ChatUI {
     const msg = matches[matches.length - 1];
     const msgText = msg.getElementsByClassName("msg-text");
     if (msgText.length != 1) throw Error("Expect msg-text");
-    if (msgText[0].innerHTML == text) return;
-    const list = text.split("\n").map((t) => {
-      const item = document.createElement("div");
-      item.textContent = t;
-      return item;
-    });
-    msgText[0].innerHTML = "";
-    list.forEach((item) => msgText[0].append(item));
+    if (msgText[0].textContent == text) return;
+    msgText[0].textContent = text;
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
   private resetChatHistory() {
     this.chatHistory = [];
-    const clearTags = ["left", "right", "init", "error"];
+    const clearTags: MessageKind[] = ["left", "right", "init", "error"];
     for (const tag of clearTags) {
       // need to unpack to list so the iterator don't get affected by mutation
       const matches = [...this.uiChat.getElementsByClassName(`msg ${tag}-msg`)];
@@ -226,7 +231,7 @@ class ChatUI {
       }
     }
     if (this.uiChatInfoLabel !== undefined) {
-      this.uiChatInfoLabel.innerHTML = "";
+      this.uiChatInfoLabel.textContent = "";
     }
   }
 
@@ -296,7 +301,7 @@ class ChatUI {
         }
       }
       if (usage) {
-        this.uiChatInfoLabel.innerHTML =
+        this.uiChatInfoLabel.textContent =
           `prompt_tokens: ${usage.prompt_tokens}, ` +
           `completion_tokens: ${usage.completion_tokens}, ` +
           `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +


### PR DESCRIPTION
## Summary

Closes #833.

This PR removes HTML-rendering sinks from the examples, fixes adjacent example bugs found during review, and adds lint enforcement so the same class of mistake does not come back through copy/paste.

## Issues Addressed

1. **User/model text rendered through HTML sinks**

   The affected examples rendered strings through `innerHTML` or `insertAdjacentHTML(...)`. That parses HTML-looking model output, user prompts, or page-derived text as markup instead of displaying it as text.

   Fixed by rendering with `textContent`, JSX text, or directly-created DOM nodes.

2. **Recurring copy/paste pattern from prior examples**

   This was not a new isolated mistake. PR #370 fixed `simple-chat` to treat user input as text, then `simple-chat-upload` later reintroduced the raw HTML template path. This PR turns the fix into an examples-wide rule instead of relying on reviewers to notice the pattern again.

3. **Lint prevention gap for React examples**

   The examples include TSX files, so the guard needs to cover React examples too. The examples-only ESLint rule now applies to JS, JSX, TS, and TSX files and rejects:

   - `innerHTML` assignments
   - `outerHTML` assignments
   - `insertAdjacentHTML()` calls
   - React `dangerouslySetInnerHTML`

4. **Raw page HTML passed as Chrome extension context**

   The WebGPU service-worker Chrome extension content script sent `document.body.innerHTML` as active-tab context. The sibling extension already uses `document.body.innerText`. This PR switches the WebGPU example to visible text too, matching the plain-text trust boundary.

5. **Duplicate copy-answer listeners during streaming**

   In both Chrome extension popup examples, `updateAnswer()` registered a new `copyAnswer` click listener. Since streamed responses call `updateAnswer()` repeatedly, this could add many duplicate listeners. This PR registers the listener once and reads the current answer text at click time.

6. **Adjacent example correctness issues**

   While fixing the affected examples, this PR also fixes:

   - `[System Initalize]` -> `[System Initialize]`
   - the Next simple chat component rendering literal `${value.text}` instead of the message text

## Not Included

This PR does not add an HTML sanitizer because these examples do not need to render model-provided HTML. The safer default for examples is to display generated and user-provided strings as plain text. A future example that intentionally renders sanitized HTML should make that trust boundary explicit.

## Validation

- `npm run lint`
- negative ESLint probe confirmed `dangerouslySetInnerHTML` is rejected for `examples/**/*.tsx`
- `npm test -- --runInBand`
- `npm run build` passes with the existing Rollup `ws` external warning
- GitHub CI is green for build, lint, test, dependency-review, and npm-audit; CodeQL is skipped as before