### PR TITLE
Fix XSS vulnerabilities in example apps

### DIFF
--- a/examples/chrome-extension-webgpu-service-worker/src/content.js
+++ b/examples/chrome-extension-webgpu-service-worker/src/content.js
@@ -1,6 +1,6 @@
 // Only the content script is able to access the DOM
 chrome.runtime.onConnect.addListener(function (port) {
   port.onMessage.addListener(function (msg) {
-    port.postMessage({ contents: document.body.innerHTML });
+    port.postMessage({ contents: document.body.innerText });
   });
 });

--- a/examples/chrome-extension-webgpu-service-worker/src/popup.ts
+++ b/examples/chrome-extension-webgpu-service-worker/src/popup.ts
@@ -91,7 +91,7 @@ async function handleClick() {
   chatHistory.push({ role: "user", content: message });
 
   // Clear the answer
-  document.getElementById("answer")!.innerHTML = "";
+  document.getElementById("answer")!.textContent = "";
   // Hide the answer
   document.getElementById("answerWrapper")!.style.display = "none";
   // Show the loading indicator
@@ -120,18 +120,9 @@ submitButton.addEventListener("click", handleClick);
 function updateAnswer(answer: string) {
   // Show answer
   document.getElementById("answerWrapper")!.style.display = "block";
-  const answerWithBreaks = answer.replace(/\n/g, "<br>");
-  document.getElementById("answer")!.innerHTML = answerWithBreaks;
-  // Add event listener to copy button
-  document.getElementById("copyAnswer")!.addEventListener("click", () => {
-    // Get the answer text
-    const answerText = answer;
-    // Copy the answer text to the clipboard
-    navigator.clipboard
-      .writeText(answerText)
-      .then(() => console.log("Answer text copied to clipboard"))
-      .catch((err) => console.error("Could not copy text: ", err));
-  });
+  const answerEl = document.getElementById("answer")!;
+  answerEl.style.whiteSpace = "pre-wrap";
+  answerEl.textContent = answer;
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "2-digit",
@@ -145,6 +136,15 @@ function updateAnswer(answer: string) {
   // Hide loading indicator
   document.getElementById("loading-indicator")!.style.display = "none";
 }
+
+// Register copy listener once
+document.getElementById("copyAnswer")!.addEventListener("click", () => {
+  const answerText = document.getElementById("answer")!.textContent ?? "";
+  navigator.clipboard
+    .writeText(answerText)
+    .then(() => console.log("Answer text copied to clipboard"))
+    .catch((err) => console.error("Could not copy text: ", err));
+});
 
 function fetchPageContents() {
   chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {

--- a/examples/chrome-extension/src/popup.ts
+++ b/examples/chrome-extension/src/popup.ts
@@ -77,7 +77,7 @@ for (let i = 0; i < prebuiltAppConfig.model_list.length; ++i) {
   const model = prebuiltAppConfig.model_list[i];
   const opt = document.createElement("option");
   opt.value = model.model_id;
-  opt.innerHTML = model.model_id;
+  opt.textContent = model.model_id;
   opt.selected = false;
 
   // set initial selection as the initially selected model
@@ -150,7 +150,7 @@ async function handleClick() {
   const message = (<HTMLInputElement>queryInput).value;
   console.log("message", message);
   // Clear the answer
-  document.getElementById("answer")!.innerHTML = "";
+  document.getElementById("answer")!.textContent = "";
   // Hide the answer
   document.getElementById("answerWrapper")!.style.display = "none";
   // Show the loading indicator
@@ -260,18 +260,9 @@ chrome.runtime.onMessage.addListener(({ answer, error }) => {
 function updateAnswer(answer: string) {
   // Show answer
   document.getElementById("answerWrapper")!.style.display = "block";
-  const answerWithBreaks = answer.replace(/\n/g, "<br>");
-  document.getElementById("answer")!.innerHTML = answerWithBreaks;
-  // Add event listener to copy button
-  document.getElementById("copyAnswer")!.addEventListener("click", () => {
-    // Get the answer text
-    const answerText = answer;
-    // Copy the answer text to the clipboard
-    navigator.clipboard
-      .writeText(answerText)
-      .then(() => console.log("Answer text copied to clipboard"))
-      .catch((err) => console.error("Could not copy text: ", err));
-  });
+  const answerEl = document.getElementById("answer")!;
+  answerEl.style.whiteSpace = "pre-wrap";
+  answerEl.textContent = answer;
   const options: Intl.DateTimeFormatOptions = {
     month: "short",
     day: "2-digit",
@@ -285,6 +276,15 @@ function updateAnswer(answer: string) {
   // Hide loading indicator
   document.getElementById("loading-indicator")!.style.display = "none";
 }
+
+// Register copy listener once
+document.getElementById("copyAnswer")!.addEventListener("click", () => {
+  const answerText = document.getElementById("answer")!.textContent ?? "";
+  navigator.clipboard
+    .writeText(answerText)
+    .then(() => console.log("Answer text copied to clipboard"))
+    .catch((err) => console.error("Could not copy text: ", err));
+});
 
 function fetchPageContents() {
   chrome.tabs.query({ currentWindow: true, active: true }, function (tabs) {

--- a/examples/simple-chat-ts/src/simple_chat.ts
+++ b/examples/simple-chat-ts/src/simple_chat.ts
@@ -89,7 +89,7 @@ class ChatUI {
       const item = chatUI.config.model_list[i];
       const opt = document.createElement("option");
       opt.value = item.model_id;
-      opt.innerHTML = item.model_id;
+      opt.textContent = item.model_id;
       opt.selected = i == 0;
       if (
         (restrictModels &&
@@ -181,34 +181,33 @@ class ChatUI {
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
     }
-    const msg = `
-      <div class="msg ${kind}-msg">
-        <div class="msg-bubble">
-          <div class="msg-text">${text}</div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
+    const msgDiv = document.createElement("div");
+    msgDiv.className = `msg ${kind}-msg`;
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+    const msgText = document.createElement("div");
+    msgText.className = "msg-text";
+    msgText.textContent = text;
+    bubble.appendChild(msgText);
+    msgDiv.appendChild(bubble);
+    this.uiChat.appendChild(msgDiv);
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
-  // Special care for user input such that we treat it as pure text instead of html
   private appendUserMessage(text: string) {
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
     }
-    const msg = `
-      <div class="msg right-msg">
-        <div class="msg-bubble">
-          <div class="msg-text"></div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
-    // Recurse three times to get `msg-text`
-    const msgElement = this.uiChat.lastElementChild?.lastElementChild
-      ?.lastElementChild as HTMLElement;
-    msgElement.insertAdjacentText("beforeend", text);
+    const msgDiv = document.createElement("div");
+    msgDiv.className = "msg right-msg";
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+    const msgText = document.createElement("div");
+    msgText.className = "msg-text";
+    msgText.textContent = text;
+    bubble.appendChild(msgText);
+    msgDiv.appendChild(bubble);
+    this.uiChat.appendChild(msgDiv);
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
@@ -224,13 +223,13 @@ class ChatUI {
     const msg = matches[matches.length - 1];
     const msgText = msg.getElementsByClassName("msg-text");
     if (msgText.length != 1) throw Error("Expect msg-text");
-    if (msgText[0].innerHTML == text) return;
+    if (msgText[0].textContent == text) return;
     const list = text.split("\n").map((t) => {
       const item = document.createElement("div");
       item.textContent = t;
       return item;
     });
-    msgText[0].innerHTML = "";
+    msgText[0].textContent = "";
     list.forEach((item) => msgText[0].append(item));
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
@@ -246,7 +245,7 @@ class ChatUI {
       }
     }
     if (this.uiChatInfoLabel !== undefined) {
-      this.uiChatInfoLabel.innerHTML = "";
+      this.uiChatInfoLabel.textContent = "";
     }
   }
 
@@ -322,7 +321,7 @@ class ChatUI {
         }
       }
       if (usage) {
-        this.uiChatInfoLabel.innerHTML =
+        this.uiChatInfoLabel.textContent =
           `prompt_tokens: ${usage.prompt_tokens}, ` +
           `completion_tokens: ${usage.completion_tokens}, ` +
           `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +

--- a/examples/simple-chat-upload/src/simple_chat.ts
+++ b/examples/simple-chat-upload/src/simple_chat.ts
@@ -89,7 +89,7 @@ class ChatUI {
       const item = chatUI.config.model_list[i];
       const opt = document.createElement("option");
       opt.value = item.model_id;
-      opt.innerHTML = item.model_id;
+      opt.textContent = item.model_id;
       opt.selected = i == 0;
       if (
         (restrictModels &&
@@ -181,14 +181,16 @@ class ChatUI {
     if (this.uiChat === undefined) {
       throw Error("cannot find ui chat");
     }
-    const msg = `
-      <div class="msg ${kind}-msg">
-        <div class="msg-bubble">
-          <div class="msg-text">${text}</div>
-        </div>
-      </div>
-    `;
-    this.uiChat.insertAdjacentHTML("beforeend", msg);
+    const msgDiv = document.createElement("div");
+    msgDiv.className = `msg ${kind}-msg`;
+    const bubble = document.createElement("div");
+    bubble.className = "msg-bubble";
+    const msgText = document.createElement("div");
+    msgText.className = "msg-text";
+    msgText.textContent = text;
+    bubble.appendChild(msgText);
+    msgDiv.appendChild(bubble);
+    this.uiChat.appendChild(msgDiv);
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
 
@@ -204,13 +206,13 @@ class ChatUI {
     const msg = matches[matches.length - 1];
     const msgText = msg.getElementsByClassName("msg-text");
     if (msgText.length != 1) throw Error("Expect msg-text");
-    if (msgText[0].innerHTML == text) return;
+    if (msgText[0].textContent == text) return;
     const list = text.split("\n").map((t) => {
       const item = document.createElement("div");
       item.textContent = t;
       return item;
     });
-    msgText[0].innerHTML = "";
+    msgText[0].textContent = "";
     list.forEach((item) => msgText[0].append(item));
     this.uiChat.scrollTo(0, this.uiChat.scrollHeight);
   }
@@ -226,7 +228,7 @@ class ChatUI {
       }
     }
     if (this.uiChatInfoLabel !== undefined) {
-      this.uiChatInfoLabel.innerHTML = "";
+      this.uiChatInfoLabel.textContent = "";
     }
   }
 
@@ -296,7 +298,7 @@ class ChatUI {
         }
       }
       if (usage) {
-        this.uiChatInfoLabel.innerHTML =
+        this.uiChatInfoLabel.textContent =
           `prompt_tokens: ${usage.prompt_tokens}, ` +
           `completion_tokens: ${usage.completion_tokens}, ` +
           `prefill: ${usage.extra.prefill_tokens_per_s.toFixed(4)} tokens/sec, ` +


### PR DESCRIPTION
## Summary

Fixes #833 — examples render user/model text as HTML, allowing XSS.

- **simple-chat-ts**: `appendMessage()` and `appendUserMessage()` now build DOM nodes via `createElement` + `textContent` instead of interpolating text into HTML template strings with `insertAdjacentHTML`
- **simple-chat-upload**: Same `appendMessage()` fix. This example was missing the safe `appendUserMessage()` method — user input was passed through the unsafe HTML path (regression from commit `c6e6f1c`)
- **chrome-extension popup**: `updateAnswer()` uses `textContent` + CSS `white-space: pre-wrap` instead of `.replace(/\n/g, "<br>")` + `innerHTML`. Copy-button listener registered once at init instead of re-registering on every streaming chunk
- **chrome-extension-webgpu-service-worker popup**: Same `updateAnswer()` fix and copy listener dedup
- **chrome-extension-webgpu-service-worker content.js**: Send `document.body.innerText` instead of `innerHTML` to avoid forwarding raw page markup as LLM context
- **All files**: `opt.innerHTML = model_id` → `opt.textContent = model_id` for model selector options
- **All files**: `uiChatInfoLabel.innerHTML = ...` → `.textContent` for usage stats display

## Test plan

- [ ] Verify simple-chat-ts renders messages correctly with newlines preserved
- [ ] Verify model output containing `<script>`, `<img onerror=...>`, or other HTML tags is displayed as plain text
- [ ] Verify user input with HTML-like content is displayed as-is
- [ ] Verify copy button works (registered once, copies current answer)
- [ ] Verify chrome extension popup displays answers with line breaks via CSS whitespace
- [ ] Verify model selector dropdown still populates correctly