### PR TITLE
Reject NaN in generation parameter validation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -174,44 +174,29 @@ export function postInitAndCheckGenerationConfigValues(
   }
   if (
     _hasValue(config.frequency_penalty) &&
-    (Number.isNaN(config.frequency_penalty!) ||
-      config.frequency_penalty! < -2.0 ||
-      config.frequency_penalty! > 2.0)
+    !(config.frequency_penalty! >= -2.0 && config.frequency_penalty! <= 2.0)
   ) {
     throw new RangeError("frequency_penalty", -2.0, 2.0);
   }
   if (
     _hasValue(config.presence_penalty) &&
-    (Number.isNaN(config.presence_penalty!) ||
-      config.presence_penalty! < -2.0 ||
-      config.presence_penalty! > 2.0)
+    !(config.presence_penalty! >= -2.0 && config.presence_penalty! <= 2.0)
   ) {
     throw new RangeError("presence_penalty", -2.0, 2.0);
   }
   if (
     _hasValue(config.repetition_penalty) &&
-    (Number.isNaN(config.repetition_penalty!) ||
-      config.repetition_penalty! <= 0)
+    !(config.repetition_penalty! > 0)
   ) {
     throw new MinValueError("repetition_penalty", 0);
   }
-  if (
-    _hasValue(config.max_tokens) &&
-    (Number.isNaN(config.max_tokens!) || config.max_tokens! <= 0)
-  ) {
+  if (_hasValue(config.max_tokens) && !(config.max_tokens! > 0)) {
     throw new MinValueError("max_tokens", 0);
   }
-  if (
-    (_hasValue(config.top_p) &&
-      (Number.isNaN(config.top_p!) || config.top_p! <= 0)) ||
-    config.top_p! > 1
-  ) {
+  if (_hasValue(config.top_p) && !(config.top_p! > 0 && config.top_p! <= 1)) {
     throw new RangeError("top_p", 0, 1);
   }
-  if (
-    _hasValue(config.temperature) &&
-    (Number.isNaN(config.temperature!) || config.temperature! < 0)
-  ) {
+  if (_hasValue(config.temperature) && !(config.temperature! >= 0)) {
     throw new NonNegativeError("temperature");
   }
   // If only one of frequency or presence penatly is set, make the other one 0.0
@@ -235,7 +220,7 @@ export function postInitAndCheckGenerationConfigValues(
   if (_hasValue(config.logit_bias)) {
     for (const tokenID in config.logit_bias) {
       const bias = config.logit_bias[tokenID];
-      if (Number.isNaN(bias) || bias > 100 || bias < -100) {
+      if (!(bias >= -100 && bias <= 100)) {
         throw new RangeError(
           "logit_bias",
           -100,
@@ -255,11 +240,7 @@ export function postInitAndCheckGenerationConfigValues(
       throw new DependencyError("top_logprobs", "logprobs", true);
     }
     // top_logprobs should be in range [0,5]
-    if (
-      Number.isNaN(config.top_logprobs!) ||
-      config.top_logprobs! < 0 ||
-      config.top_logprobs! > 5
-    ) {
+    if (!(config.top_logprobs! >= 0 && config.top_logprobs! <= 5)) {
       throw new RangeError("top_logprobs", 0, 5, "Got " + config.top_logprobs);
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,7 @@ export interface MLCEngineConfig {
  *
  * Note that all values are optional. If unspecified, we use whatever values in `ChatConfig`
  * initialized during `MLCEngine.reload()`.
+ * Values with numeric range checks also reject `NaN`.
  */
 export interface GenerationConfig {
   // Only used in MLC
@@ -172,27 +173,45 @@ export function postInitAndCheckGenerationConfigValues(
     return value !== undefined && value !== null;
   }
   if (
-    config.frequency_penalty &&
-    (config.frequency_penalty < -2.0 || config.frequency_penalty > 2.0)
+    _hasValue(config.frequency_penalty) &&
+    (Number.isNaN(config.frequency_penalty!) ||
+      config.frequency_penalty! < -2.0 ||
+      config.frequency_penalty! > 2.0)
   ) {
     throw new RangeError("frequency_penalty", -2.0, 2.0);
   }
   if (
-    config.presence_penalty &&
-    (config.presence_penalty < -2.0 || config.presence_penalty > 2.0)
+    _hasValue(config.presence_penalty) &&
+    (Number.isNaN(config.presence_penalty!) ||
+      config.presence_penalty! < -2.0 ||
+      config.presence_penalty! > 2.0)
   ) {
     throw new RangeError("presence_penalty", -2.0, 2.0);
   }
-  if (_hasValue(config.repetition_penalty) && config.repetition_penalty! <= 0) {
+  if (
+    _hasValue(config.repetition_penalty) &&
+    (Number.isNaN(config.repetition_penalty!) ||
+      config.repetition_penalty! <= 0)
+  ) {
     throw new MinValueError("repetition_penalty", 0);
   }
-  if (_hasValue(config.max_tokens) && config.max_tokens! <= 0) {
+  if (
+    _hasValue(config.max_tokens) &&
+    (Number.isNaN(config.max_tokens!) || config.max_tokens! <= 0)
+  ) {
     throw new MinValueError("max_tokens", 0);
   }
-  if ((_hasValue(config.top_p) && config.top_p! <= 0) || config.top_p! > 1) {
+  if (
+    (_hasValue(config.top_p) &&
+      (Number.isNaN(config.top_p!) || config.top_p! <= 0)) ||
+    config.top_p! > 1
+  ) {
     throw new RangeError("top_p", 0, 1);
   }
-  if (_hasValue(config.temperature) && config.temperature! < 0) {
+  if (
+    _hasValue(config.temperature) &&
+    (Number.isNaN(config.temperature!) || config.temperature! < 0)
+  ) {
     throw new NonNegativeError("temperature");
   }
   // If only one of frequency or presence penatly is set, make the other one 0.0
@@ -216,7 +235,7 @@ export function postInitAndCheckGenerationConfigValues(
   if (_hasValue(config.logit_bias)) {
     for (const tokenID in config.logit_bias) {
       const bias = config.logit_bias[tokenID];
-      if (bias > 100 || bias < -100) {
+      if (Number.isNaN(bias) || bias > 100 || bias < -100) {
         throw new RangeError(
           "logit_bias",
           -100,
@@ -236,7 +255,11 @@ export function postInitAndCheckGenerationConfigValues(
       throw new DependencyError("top_logprobs", "logprobs", true);
     }
     // top_logprobs should be in range [0,5]
-    if (config.top_logprobs! < 0 || config.top_logprobs! > 5) {
+    if (
+      Number.isNaN(config.top_logprobs!) ||
+      config.top_logprobs! < 0 ||
+      config.top_logprobs! > 5
+    ) {
       throw new RangeError("top_logprobs", 0, 5, "Got " + config.top_logprobs);
     }
   }

--- a/src/llm_chat.ts
+++ b/src/llm_chat.ts
@@ -965,11 +965,8 @@ export class LLMChatPipeline {
 
     // Get max_tokens from generationConfig (specified by user in completion request)
     // If not specified, do not set a limit
-    let max_tokens = Infinity;
-    if (genConfig !== undefined && genConfig.max_tokens) {
-      max_tokens = genConfig.max_tokens;
-    }
-    if (max_tokens <= 0) {
+    const max_tokens = genConfig?.max_tokens ?? Infinity;
+    if (!(max_tokens > 0)) {
       throw new MinValueError("max_tokens", 0);
     }
 
@@ -1675,25 +1672,19 @@ export class LLMChatPipeline {
       }
     }
     // Check range validity
-    if (top_p <= 0 || top_p > 1) {
+    if (!(top_p > 0 && top_p <= 1)) {
       throw new RangeError("top_p", 0, 1);
     }
-    if (temperature < 0) {
+    if (!(temperature >= 0)) {
       throw new MinValueError("temperature", 0);
     }
-    if (repetition_penalty <= 0) {
+    if (!(repetition_penalty > 0)) {
       throw new MinValueError("repetition_penalty", 0);
     }
-    if (
-      frequency_penalty &&
-      (frequency_penalty < -2.0 || frequency_penalty > 2.0)
-    ) {
+    if (!(frequency_penalty >= -2.0 && frequency_penalty <= 2.0)) {
       throw new RangeError("frequency_penalty", -2.0, 2.0);
     }
-    if (
-      presence_penalty &&
-      (presence_penalty < -2.0 || presence_penalty > 2.0)
-    ) {
+    if (!(presence_penalty >= -2.0 && presence_penalty <= 2.0)) {
       throw new RangeError("presence_penalty", -2.0, 2.0);
     }
 

--- a/tests/generation_config.test.ts
+++ b/tests/generation_config.test.ts
@@ -99,3 +99,101 @@ describe("Check generation post init", () => {
     expect(genConfig.top_logprobs).toBe(2);
   });
 });
+
+describe("Reject NaN generation values", () => {
+  const nanCases: Array<[string, GenerationConfig, string]> = [
+    [
+      "frequency_penalty",
+      { frequency_penalty: Number.NaN },
+      "Make sure -2 < frequency_penalty <= 2.",
+    ],
+    [
+      "presence_penalty",
+      { presence_penalty: Number.NaN },
+      "Make sure -2 < presence_penalty <= 2.",
+    ],
+    [
+      "repetition_penalty",
+      { repetition_penalty: Number.NaN },
+      "Make sure `repetition_penalty` > 0.",
+    ],
+    ["max_tokens", { max_tokens: Number.NaN }, "Make sure `max_tokens` > 0."],
+    ["top_p", { top_p: Number.NaN }, "Make sure 0 < top_p <= 1."],
+    ["temperature", { temperature: Number.NaN }, "Make sure temperature >= 0."],
+    [
+      "top_logprobs",
+      { logprobs: true, top_logprobs: Number.NaN },
+      "Make sure 0 < top_logprobs <= 5.",
+    ],
+    [
+      "logit_bias value",
+      { logit_bias: { "1": Number.NaN } },
+      "Make sure -100 < logit_bias <= 100.",
+    ],
+  ];
+
+  test.each(nanCases)("rejects NaN in %s", (_name, config, message) => {
+    expect(() => postInitAndCheckGenerationConfigValues(config)).toThrow(
+      message,
+    );
+  });
+});
+
+describe("Preserve generation value semantics", () => {
+  test("accepts null, undefined, zero, and positive infinity where supported", () => {
+    const config: GenerationConfig = {
+      repetition_penalty: Number.POSITIVE_INFINITY,
+      temperature: Number.POSITIVE_INFINITY,
+      max_tokens: Number.POSITIVE_INFINITY,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      top_logprobs: 0,
+      logprobs: true,
+      top_p: null,
+      logit_bias: null,
+    };
+
+    expect(() => postInitAndCheckGenerationConfigValues(config)).not.toThrow();
+    expect(config.temperature).toBe(Number.POSITIVE_INFINITY);
+    expect(config.top_p).toBeNull();
+  });
+
+  test("accepts inclusive range endpoints", () => {
+    const config: GenerationConfig = {
+      frequency_penalty: -2,
+      presence_penalty: 2,
+      top_p: 1,
+      temperature: 0,
+      repetition_penalty: Number.MIN_VALUE,
+      max_tokens: 1,
+      logprobs: true,
+      top_logprobs: 5,
+      logit_bias: { "1": -100, "2": 100 },
+    };
+
+    expect(() => postInitAndCheckGenerationConfigValues(config)).not.toThrow();
+  });
+
+  test("keeps undefined generation values omitted", () => {
+    const config: GenerationConfig = {
+      repetition_penalty: undefined,
+      temperature: undefined,
+      max_tokens: undefined,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+      top_logprobs: undefined,
+      logit_bias: undefined,
+    };
+
+    postInitAndCheckGenerationConfigValues(config);
+    expect(config).toEqual({
+      repetition_penalty: undefined,
+      temperature: undefined,
+      max_tokens: undefined,
+      frequency_penalty: undefined,
+      presence_penalty: undefined,
+      top_logprobs: undefined,
+      logit_bias: undefined,
+    });
+  });
+});

--- a/tests/llm_chat_pipeline.test.ts
+++ b/tests/llm_chat_pipeline.test.ts
@@ -147,6 +147,31 @@ function createPipeline(): PipelineLike {
   return pipeline;
 }
 
+test.each([
+  ["frequency_penalty", "Make sure -2 < frequency_penalty <= 2."],
+  ["presence_penalty", "Make sure -2 < presence_penalty <= 2."],
+  ["repetition_penalty", "Make sure `repetition_penalty` > 0."],
+  ["top_p", "Make sure 0 < top_p <= 1."],
+  ["temperature", "Make sure `temperature` > 0."],
+])("rejects a NaN model default for %s", async (field, message) => {
+  const pipeline = createPipeline();
+  pipeline["config"] = {
+    frequency_penalty: 0,
+    presence_penalty: 0,
+    repetition_penalty: 1,
+    top_p: 1,
+    temperature: 1,
+    [field]: Number.NaN,
+  } as any;
+
+  await expect(
+    (LLMChatPipeline.prototype as any).sampleTokenFromLogits.call(
+      pipeline,
+      {} as any,
+    ),
+  ).rejects.toThrow(message);
+});
+
 test("processNextToken stops on stop token and updates conversation", () => {
   const pipeline = createPipeline();
   pipeline["stopTokens"] = [42];
@@ -182,10 +207,14 @@ test("processNextToken respects max_tokens and updates token frequency", () => {
   expect(pipeline["finishReason"]).toBe("length");
 });
 
-test("processNextToken throws when max_tokens is below zero", () => {
+test.each([
+  ["zero", 0],
+  ["below zero", -1],
+  ["NaN", Number.NaN],
+])("processNextToken rejects max_tokens when it is %s", (_name, value) => {
   const pipeline = createPipeline();
   expect(() =>
-    (pipeline as any).processNextToken(1, { max_tokens: -1 }),
+    (pipeline as any).processNextToken(1, { max_tokens: value }),
   ).toThrow(MinValueError);
 });
 


### PR DESCRIPTION
Generation parameter range checks let `NaN` through because comparisons with it are false. Invalid values can therefore reach generation instead of raising the existing validation errors.

Reject `NaN` in the range-checked parameters and logit biases, while preserving defaults, valid boundaries, and existing infinity handling. Add eight regressions and compatibility controls.

Validation on Node 24.11.1:

- `npm test -- --runInBand`: 17 suites, 216 tests passed, with coverage enabled.
- `npm run lint`: passed.
- `npm run build`: passed; Rollup warned about the external `ws` dependency.
- All eight NaN regressions fail against the unchanged upstream code.
