### PR TITLE
fix(worker): persist recovered model state

### DIFF
--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -373,6 +373,8 @@ export class WebWorkerMLCEngineHandler {
           "Reloading engine in WebWorkerMLCEngineHandler.",
       );
       await this.engine.reload(expectedModelId, expectedChatOpts);
+      this.modelId = expectedModelId;
+      this.chatOpts = expectedChatOpts;
     }
   }
 }

--- a/tests/web_worker_handler.test.ts
+++ b/tests/web_worker_handler.test.ts
@@ -166,6 +166,18 @@ test("reloadIfUnmatched triggers reload when model lists differ", async () => {
   expect(reloadMock).not.toHaveBeenCalled();
 });
 
+test("reloadIfUnmatched records recovered worker state", async () => {
+  const handler = new WebWorkerMLCEngineHandler();
+  const chatOpts = [{ temperature: 0.5 }];
+
+  await handler.reloadIfUnmatched(["demo"], chatOpts);
+  await handler.reloadIfUnmatched(["demo"], chatOpts);
+
+  expect(reloadMock).toHaveBeenCalledTimes(1);
+  expect(handler.modelId).toEqual(["demo"]);
+  expect(handler.chatOpts).toBe(chatOpts);
+});
+
 test("unknown messages invoke onError and throw", () => {
   const handler = new WebWorkerMLCEngineHandler();
   const onError = jest.fn();


### PR DESCRIPTION
## Summary

- Fixes: After a web worker or service worker is restarted, the first request restores the model, but every subsequent request triggers another full model reload and repeats the associated startup latency.
- Root cause: WebWorkerMLCEngineHandler.reloadIfUnmatched reloads the backend when its state is missing, but does not record the successfully restored modelId and chatOpts, so the handler remains permanently out of sync with the frontend expectation.

## Regression evidence

- Before: `Node 24.11.1: npm test -- --coverage=false --runInBand --runTestsByPath tests/web_worker_handler.test.ts --testNamePattern="reloadIfUnmatched records recovered worker state"` exited `1`

- After: `Node 24.11.1: npm test -- --coverage=false --runInBand --runTestsByPath tests/web_worker_handler.test.ts --testNamePattern="reloadIfUnmatched records recovered worker state"` exited `0`

## Verification

- `Node 24.11.1: npm test -- --coverage=false --runInBand --runTestsByPath tests/web_worker_handler.test.ts tests/service_worker.test.ts`
- `Node 24.11.1: CI=true npm run test -- --ci --runInBand`
- `Node 24.11.1: npm run lint`
- `Node 24.11.1: npm run build && npm pack --dry-run`
- `Node 24.11.1: npm audit --omit=dev --audit-level=high`

## Scope

- 2 files changed, +14 / -0 lines

## Backward compatibility

- No public API changes. The handler records recovered state only after the backend reload succeeds, so a failed recovery remains retriable and explicit reload behavior is unchanged.
