### PR TITLE
[Fix] Release model locks and clean up cancelled completion streams

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -81,6 +81,30 @@ function getUnixTimestampSeconds(): number {
   return Math.floor(Date.now() / 1000);
 }
 
+function countTrailingReplacementChar(value: string): number {
+  let count = 0;
+  for (let i = value.length - 1; i >= 0; i--) {
+    if (value.charAt(i) !== "�") {
+      return count;
+    }
+    count++;
+  }
+  return count;
+}
+
+interface StreamGenerationState {
+  id: string;
+  created: number;
+  prevMessageLength: number;
+}
+
+interface StreamContinuationOptions {
+  emitCurrent?: boolean;
+  skipEmptyDelta?: boolean;
+  completionTokenOffset?: number;
+  beforeFinalChunk?: () => Promise<void>;
+}
+
 /**
  * Creates `MLCEngine`, and loads `modelId` onto WebGPU.
  *
@@ -478,6 +502,239 @@ export class MLCEngine implements MLCEngineInterface {
     return pipeline.getMessage();
   }
 
+  private makeStreamDeltaChunk(
+    request: ChatCompletionRequestStreaming | CompletionCreateParamsStreaming,
+    model: string,
+    pipeline: LLMChatPipeline,
+    state: StreamGenerationState,
+    skipEmptyDelta = false,
+  ): ChatCompletionChunk | Completion | undefined {
+    const curMessage = pipeline.getMessage();
+    if (countTrailingReplacementChar(curMessage) % 4 !== 0) {
+      return undefined;
+    }
+
+    const deltaMessage = curMessage.slice(state.prevMessageLength);
+    state.prevMessageLength = curMessage.length;
+    if (skipEmptyDelta && deltaMessage === "") {
+      return undefined;
+    }
+
+    const logprobs = request.logprobs
+      ? ({
+          content: pipeline.getTokenLogprobArray().slice(-1),
+        } as ChatCompletionChunk.Choice.Logprobs)
+      : null;
+    if ("messages" in request) {
+      return {
+        id: state.id,
+        choices: [
+          {
+            delta: { content: deltaMessage, role: "assistant" },
+            finish_reason: null,
+            index: 0,
+            logprobs,
+          },
+        ],
+        model,
+        object: "chat.completion.chunk",
+        created: state.created,
+      };
+    }
+    return {
+      id: state.id,
+      choices: [
+        {
+          text: deltaMessage,
+          finish_reason: null,
+          index: 0,
+          logprobs,
+        },
+      ],
+      model,
+      object: "text_completion",
+      created: state.created,
+    };
+  }
+
+  private makeStreamFinalChunk(
+    request: ChatCompletionRequestStreaming | CompletionCreateParamsStreaming,
+    model: string,
+    pipeline: LLMChatPipeline,
+    state: StreamGenerationState,
+  ): ChatCompletionChunk | Completion {
+    let finishReason = pipeline.getFinishReason()!;
+    const isChatCompletion = "messages" in request;
+    const isFunctionCalling =
+      isChatCompletion && request.tools !== undefined && request.tools !== null;
+    let toolCalls: Array<ChatCompletionChunk.Choice.Delta.ToolCall> | undefined;
+    if (pipeline.getFinishReason() === "stop" && isFunctionCalling) {
+      finishReason = "tool_calls";
+      toolCalls = getToolCallFromOutputMessage(
+        pipeline.getMessage(),
+        /*isStreaming=*/ true,
+      ) as Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
+    }
+
+    if (isChatCompletion) {
+      return {
+        id: state.id,
+        choices: [
+          {
+            delta: isFunctionCalling
+              ? {
+                  role: "assistant",
+                  tool_calls: toolCalls,
+                }
+              : {},
+            finish_reason: finishReason,
+            index: 0,
+          },
+        ],
+        model,
+        object: "chat.completion.chunk",
+        created: state.created,
+      };
+    }
+    return {
+      id: state.id,
+      choices: [
+        {
+          text: "",
+          finish_reason: finishReason,
+          index: 0,
+        },
+      ],
+      model,
+      object: "text_completion",
+      created: state.created,
+    };
+  }
+
+  private makeStreamUsageChunk(
+    request: ChatCompletionRequestStreaming | CompletionCreateParamsStreaming,
+    model: string,
+    pipeline: LLMChatPipeline,
+    state: StreamGenerationState,
+    completionTokenOffset: number,
+    timeReceived: number,
+  ): ChatCompletionChunk | Completion | undefined {
+    if (request.stream_options?.include_usage !== true) {
+      return undefined;
+    }
+    const usedGrammar =
+      "response_format" in request &&
+      (request.response_format?.type === "grammar" ||
+        request.response_format?.type === "json_object");
+    const completionTokens =
+      pipeline.getCurRoundDecodingTotalTokens() + completionTokenOffset;
+    const promptTokens = pipeline.getCurRoundPrefillTotalTokens();
+    const prefillTime = pipeline.getCurRoundPrefillTotalTime();
+    const decodeTime = pipeline.getCurRoundDecodingTotalTime();
+    const defaultExtra = {
+      e2e_latency_s: (Date.now() - timeReceived) / 1000,
+      prefill_tokens_per_s: pipeline.getCurRoundPrefillTokensPerSec(),
+      decode_tokens_per_s: pipeline.getCurRoundDecodingTokensPerSec(),
+      time_to_first_token_s: prefillTime,
+      time_per_output_token_s: decodeTime / completionTokens,
+      latencyBreakdown: request.extra_body?.enable_latency_breakdown
+        ? pipeline.getCurRoundLatencyBreakdown()
+        : undefined,
+    };
+    const usage: CompletionUsage = {
+      completion_tokens: completionTokens,
+      prompt_tokens: promptTokens,
+      total_tokens: completionTokens + promptTokens,
+      extra: usedGrammar
+        ? {
+            ...defaultExtra,
+            grammar_init_s: pipeline.getCurRoundGrammarInitTotalTime(),
+            grammar_per_token_s:
+              pipeline.getCurRoundGrammarPerTokenTotalTime() / completionTokens,
+          }
+        : defaultExtra,
+    };
+
+    if ("messages" in request) {
+      return {
+        id: state.id,
+        choices: [],
+        usage,
+        model,
+        object: "chat.completion.chunk",
+        created: state.created,
+      };
+    }
+    return {
+      id: state.id,
+      choices: [],
+      usage,
+      model,
+      object: "text_completion",
+      created: state.created,
+    };
+  }
+
+  private async *streamCurrentGeneration(
+    request: ChatCompletionRequestStreaming | CompletionCreateParamsStreaming,
+    model: string,
+    pipeline: LLMChatPipeline,
+    genConfig: GenerationConfig,
+    timeReceived: number,
+    state: StreamGenerationState,
+    decodeStep: () => Promise<void>,
+    opts: StreamContinuationOptions = {},
+  ): AsyncGenerator<ChatCompletionChunk | Completion, void, void> {
+    if (opts.emitCurrent === true) {
+      const chunk = this.makeStreamDeltaChunk(
+        request,
+        model,
+        pipeline,
+        state,
+        opts.skipEmptyDelta,
+      );
+      if (chunk !== undefined) {
+        yield chunk;
+      }
+    }
+
+    while (!pipeline.stopped()) {
+      if (this.interruptSignal) {
+        pipeline.triggerStop();
+        break;
+      }
+      await decodeStep();
+      const chunk = this.makeStreamDeltaChunk(
+        request,
+        model,
+        pipeline,
+        state,
+        opts.skipEmptyDelta,
+      );
+      if (chunk !== undefined) {
+        yield chunk;
+      }
+    }
+
+    if (request.seed !== null && request.seed !== undefined) {
+      pipeline.setSeed(Date.now());
+    }
+    await opts.beforeFinalChunk?.();
+    yield this.makeStreamFinalChunk(request, model, pipeline, state);
+
+    const usageChunk = this.makeStreamUsageChunk(
+      request,
+      model,
+      pipeline,
+      state,
+      opts.completionTokenOffset ?? 0,
+      timeReceived,
+    );
+    if (usageChunk !== undefined) {
+      yield usageChunk;
+    }
+  }
+
   /**
    * Similar to `_generate()`; but instead of using callback, we use an async iterable.
    */
@@ -505,267 +762,40 @@ export class MLCEngine implements MLCEngineInterface {
     genConfig: GenerationConfig,
     timeReceived: number,
   ): AsyncGenerator<ChatCompletionChunk | Completion, void, void> {
-    // Since it is an async generator, we need to do fine-grained try-catch to ensure lock is
-    // released only when errors occur. Then release at the very end when no error occurs.
-    // TODO: This makes code less readable, is there a better way to do this?
+    // Acquire only when iteration starts, and release on completion, failure,
+    // or iterator return. Creating an unconsumed stream owns no model lock.
     const lock = this.loadedModelIdToLock.get(model)!;
-
-    // 0. Pre-processing
-    const isChatCompletion = "messages" in request;
-    const isFunctionCalling =
-      "tools" in request &&
-      request.tools !== undefined &&
-      request.tools !== null;
+    await lock.acquire();
     try {
+      const isChatCompletion = "messages" in request;
+      const isFunctionCalling = "tools" in request && request.tools != null;
       if (isFunctionCalling && !isChatCompletion) {
         throw new Error(
           "Expect `chat.completions` with tools, not `completions`.",
         );
       }
       postInitAndCheckGenerationConfigValues(genConfig);
-      if (request.seed !== null && request.seed !== undefined) {
-        pipeline.setSeed(request.seed);
-      }
-    } catch (err) {
-      await lock.release();
-      throw err;
-    }
-
-    // 1. Helper function that generates the chunk
-    const created = getUnixTimestampSeconds();
-    const id = crypto.randomUUID();
-    this.interruptSignal = false;
-    let prevMessageLength = 0; // to know where to start slicing the delta; does not count �
-
-    function _countTrailingReplacementChar(curMessage: string): number {
-      let cntr = 0;
-      for (let i = curMessage.length - 1; i >= 0; i--) {
-        if (curMessage.charAt(i) === "�") {
-          cntr += 1;
-        } else {
-          return cntr;
-        }
-      }
-      return cntr;
-    }
-
-    async function _getChunk(
-      selectedPipeline: LLMChatPipeline,
-    ): Promise<ChatCompletionChunk | Completion | undefined> {
-      // Remove the replacement character (U+FFFD) from the response to handle emojis.
-      // Each emoji is made up of multiples of 4 tokens; when truncated, it is displayed as �, so
-      // we skip this delta until a full emoji is rendered
-      // TODO(Charlie): This does not consider cases of � not being emoji, need to fix with Streamer
-      const curMessage = selectedPipeline.getMessage();
-      const numTrailingReplacementChar =
-        _countTrailingReplacementChar(curMessage);
-      if (numTrailingReplacementChar % 4 !== 0) {
-        return undefined;
-      }
-
-      const deltaMessage = curMessage.slice(prevMessageLength);
-      prevMessageLength = curMessage.length;
-      const logprobs = request.logprobs
-        ? ({
-            content: selectedPipeline.getTokenLogprobArray().slice(-1), // always the last entry
-          } as ChatCompletionChunk.Choice.Logprobs)
-        : null;
-      if (isChatCompletion) {
-        const chunk: ChatCompletionChunk = {
-          id: id,
-          choices: [
-            {
-              delta: { content: deltaMessage, role: "assistant" },
-              finish_reason: null, // not finished yet
-              index: 0,
-              logprobs: logprobs,
-            },
-          ],
-          model: model,
-          object: "chat.completion.chunk",
-          created: created,
-        };
-        return chunk;
-      } else {
-        const chunk: Completion = {
-          id: id,
-          choices: [
-            {
-              text: deltaMessage,
-              finish_reason: null, // not finished yet
-              index: 0,
-              logprobs: logprobs,
-            },
-          ],
-          model: model,
-          object: "text_completion",
-          created: created,
-        };
-        return chunk;
-      }
-    }
-
-    // 2. Auto-regressive loop
-    let curChunk;
-    try {
+      if (request.seed != null) pipeline.setSeed(request.seed);
+      const state: StreamGenerationState = {
+        id: crypto.randomUUID(),
+        created: getUnixTimestampSeconds(),
+        prevMessageLength: 0,
+      };
+      this.interruptSignal = false;
       await this.prefill(request, pipeline, chatConfig, genConfig);
-      curChunk = await _getChunk(pipeline); // prefill produces a chunk
-    } catch (err) {
+      yield* this.streamCurrentGeneration(
+        request,
+        model,
+        pipeline,
+        genConfig,
+        timeReceived,
+        state,
+        () => this.decode(pipeline, genConfig),
+        { emitCurrent: true },
+      );
+    } finally {
       await lock.release();
-      throw err;
     }
-    if (curChunk) {
-      yield curChunk;
-    }
-
-    while (!pipeline.stopped()) {
-      if (this.interruptSignal) {
-        // TODO: should we directly release lock here and return the async
-        // generator? Though no issue observed as of now with interruptGenerate()
-        pipeline.triggerStop();
-        break;
-      }
-      try {
-        await this.decode(pipeline, genConfig);
-        curChunk = await _getChunk(pipeline);
-      } catch (err) {
-        await lock.release();
-        throw err;
-      }
-      if (curChunk) {
-        yield curChunk;
-      }
-    }
-
-    // Reset seed -- we do not want this seed to affect future requests
-    if (request.seed !== null && request.seed !== undefined) {
-      pipeline.setSeed(Date.now());
-    }
-
-    // 3. Last chunk empty marking the end
-    // If function calling, use the last chunk to return tool_calls
-    let finish_reason = pipeline.getFinishReason()!;
-    let tool_calls:
-      | Array<ChatCompletionChunk.Choice.Delta.ToolCall>
-      | undefined;
-    try {
-      if (pipeline.getFinishReason() === "stop" && isFunctionCalling) {
-        // If stopped due to length or abort, cannot output return tool_calls field
-        finish_reason = "tool_calls";
-        const outputMessage = pipeline.getMessage();
-        tool_calls = getToolCallFromOutputMessage(
-          outputMessage,
-          /*isStreaming=*/ true,
-        ) as Array<ChatCompletionChunk.Choice.Delta.ToolCall>;
-      }
-    } catch (err) {
-      await lock.release();
-      throw err;
-    }
-
-    if (isChatCompletion) {
-      const lastChunk: ChatCompletionChunk = {
-        id: id,
-        choices: [
-          {
-            delta: isFunctionCalling
-              ? {
-                  role: "assistant",
-                  tool_calls: tool_calls,
-                }
-              : {},
-            finish_reason: finish_reason,
-            index: 0,
-          },
-        ],
-        model: model,
-        object: "chat.completion.chunk",
-        created: created,
-      };
-      yield lastChunk;
-    } else {
-      const lastChunk: Completion = {
-        id: id,
-        choices: [
-          {
-            text: "",
-            finish_reason: finish_reason,
-            index: 0,
-          },
-        ],
-        model: model,
-        object: "text_completion",
-        created: created,
-      };
-      yield lastChunk;
-    }
-
-    // 4. Usage chunk
-    if (request.stream_options?.include_usage) {
-      const usedGrammar =
-        "response_format" in request &&
-        (request.response_format?.type === "grammar" ||
-          request.response_format?.type === "json_object");
-      const completion_tokens = pipeline.getCurRoundDecodingTotalTokens();
-      const prompt_tokens = pipeline.getCurRoundPrefillTotalTokens();
-      const prefill_tokens_per_s = pipeline.getCurRoundPrefillTokensPerSec();
-      const decode_tokens_per_s = pipeline.getCurRoundDecodingTokensPerSec();
-      const grammar_init_s = pipeline.getCurRoundGrammarInitTotalTime();
-      const prefill_time = pipeline.getCurRoundPrefillTotalTime();
-      const decode_time = pipeline.getCurRoundDecodingTotalTime();
-      const grammar_per_token_s =
-        pipeline.getCurRoundGrammarPerTokenTotalTime();
-      const latencyBreakdown: LatencyBreakdown =
-        pipeline.getCurRoundLatencyBreakdown();
-
-      const defaultExtra = {
-        e2e_latency_s: (Date.now() - timeReceived) / 1000,
-        prefill_tokens_per_s: prefill_tokens_per_s,
-        decode_tokens_per_s: decode_tokens_per_s,
-        time_to_first_token_s: prefill_time,
-        time_per_output_token_s: decode_time / completion_tokens,
-        latencyBreakdown: request.extra_body?.enable_latency_breakdown
-          ? latencyBreakdown
-          : undefined,
-      };
-      const usage: CompletionUsage = {
-        completion_tokens: completion_tokens,
-        prompt_tokens: prompt_tokens,
-        total_tokens: completion_tokens + prompt_tokens,
-        extra: usedGrammar
-          ? {
-              ...defaultExtra,
-              ...{
-                grammar_init_s: grammar_init_s,
-                grammar_per_token_s: grammar_per_token_s / completion_tokens,
-              },
-            }
-          : defaultExtra,
-      };
-      if (isChatCompletion) {
-        const usageChunk: ChatCompletionChunk = {
-          id: id,
-          choices: [],
-          usage: usage,
-          model: model,
-          object: "chat.completion.chunk",
-          created: created,
-        };
-        yield usageChunk;
-      } else {
-        const usageChunk: Completion = {
-          id: id,
-          choices: [],
-          usage: usage,
-          model: model,
-          object: "text_completion",
-          created: created,
-        };
-        yield usageChunk;
-      }
-    }
-
-    await lock.release();
   }
 
   async interruptGenerate() {
@@ -824,10 +854,6 @@ export class MLCEngine implements MLCEngineInterface {
       enable_latency_breakdown: request.extra_body?.enable_latency_breakdown,
     };
 
-    // 0.5 Block wait until this pipeline finishes all previous requests
-    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
-    await lock.acquire();
-
     // 1. If request is streaming, return an AsyncIterable (an iterable version of `_generate()`)
     if (request.stream) {
       return this.asyncGenerate(
@@ -839,6 +865,10 @@ export class MLCEngine implements MLCEngineInterface {
         timeReceived,
       );
     }
+
+    // 0.5 Block wait until this pipeline finishes all previous requests
+    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
+    await lock.acquire();
 
     // Big try-finally to release lock in case of errors
     try {
@@ -1004,10 +1034,6 @@ export class MLCEngine implements MLCEngineInterface {
       ignore_eos: request.ignore_eos,
     };
 
-    // 0.5 Block wait until this pipeline finishes all previous requests
-    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
-    await lock.acquire();
-
     // 1. If request is streaming, return an AsyncIterable (an iterable version of `_generate()`)
     if (request.stream) {
       return this.asyncGenerate(
@@ -1019,6 +1045,10 @@ export class MLCEngine implements MLCEngineInterface {
         timeReceived,
       );
     }
+
+    // 0.5 Block wait until this pipeline finishes all previous requests
+    const lock = this.loadedModelIdToLock.get(selectedModelId)!;
+    await lock.acquire();
 
     // Big try-finally to release lock in case of errors
     try {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -716,9 +716,6 @@ export class MLCEngine implements MLCEngineInterface {
       }
     }
 
-    if (request.seed !== null && request.seed !== undefined) {
-      pipeline.setSeed(Date.now());
-    }
     await opts.beforeFinalChunk?.();
     yield this.makeStreamFinalChunk(request, model, pipeline, state);
 
@@ -766,6 +763,8 @@ export class MLCEngine implements MLCEngineInterface {
     // or iterator return. Creating an unconsumed stream owns no model lock.
     const lock = this.loadedModelIdToLock.get(model)!;
     await lock.acquire();
+    let seeded = false;
+    let prefilled = false;
     try {
       const isChatCompletion = "messages" in request;
       const isFunctionCalling = "tools" in request && request.tools != null;
@@ -775,7 +774,10 @@ export class MLCEngine implements MLCEngineInterface {
         );
       }
       postInitAndCheckGenerationConfigValues(genConfig);
-      if (request.seed != null) pipeline.setSeed(request.seed);
+      if (request.seed != null) {
+        pipeline.setSeed(request.seed);
+        seeded = true;
+      }
       const state: StreamGenerationState = {
         id: crypto.randomUUID(),
         created: getUnixTimestampSeconds(),
@@ -783,6 +785,7 @@ export class MLCEngine implements MLCEngineInterface {
       };
       this.interruptSignal = false;
       await this.prefill(request, pipeline, chatConfig, genConfig);
+      prefilled = true;
       yield* this.streamCurrentGeneration(
         request,
         model,
@@ -794,7 +797,13 @@ export class MLCEngine implements MLCEngineInterface {
         { emitCurrent: true },
       );
     } finally {
-      await lock.release();
+      try {
+        // Iterator return skips the decode loop's normal stop path.
+        if (prefilled && !pipeline.stopped()) pipeline.triggerStop();
+        if (seeded) pipeline.setSeed(Date.now());
+      } finally {
+        await lock.release();
+      }
     }
   }
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -31,6 +31,7 @@ type RequestKind =
   | "chatCompletionStreamInit"
   | "completionStreamInit"
   | "completionStreamNextChunk"
+  | "completionStreamReturn"
   | "customRequest"
   | "keepAlive"
   | "setLogLevel"
@@ -78,6 +79,7 @@ export interface ChatCompletionNonStreamingParams {
 export interface ChatCompletionStreamInitParams {
   request: ChatCompletionRequestStreaming;
   selectedModelId: string;
+  streamId: string;
   modelId: string[];
   chatOpts?: ChatOptions[];
 }
@@ -89,6 +91,7 @@ export interface CompletionNonStreamingParams {
 export interface CompletionStreamInitParams {
   request: CompletionCreateParamsStreaming;
   selectedModelId: string;
+  streamId: string;
   modelId: string[];
   chatOpts?: ChatOptions[];
 }
@@ -98,7 +101,7 @@ export interface EmbeddingParams {
   chatOpts?: ChatOptions[];
 }
 export interface CompletionStreamNextChunkParams {
-  selectedModelId: string;
+  streamId: string;
 }
 
 export interface CustomRequestParams {

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -684,47 +684,36 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
       return closePromise;
     };
 
-    const iterator: AsyncIterableIterator<ChatCompletionChunk | Completion> = {
-      next: async () => {
-        if (completed) {
-          return { done: true, value: undefined };
-        }
-        const msg: WorkerRequest = {
-          kind: "completionStreamNextChunk",
-          uuid: crypto.randomUUID(),
-          content: { streamId } as CompletionStreamNextChunkParams,
-        };
-        try {
-          const ret = await this.getPromise<
-            ChatCompletionChunk | Completion | void
-          >(msg);
+    const getPromise = this.getPromise.bind(this);
+    // Native generators serialize next/return/throw, including reads at EOF.
+    const iterator = (async function* () {
+      try {
+        while (true) {
+          const msg: WorkerRequest = {
+            kind: "completionStreamNextChunk",
+            uuid: crypto.randomUUID(),
+            content: { streamId } as CompletionStreamNextChunkParams,
+          };
+          const ret = await getPromise<ChatCompletionChunk | Completion | void>(
+            msg,
+          );
           if (typeof ret !== "object") {
             completed = true;
-            return { done: true, value: undefined };
+            return;
           }
-          return { done: false, value: ret };
-        } catch (err) {
-          await close().catch(() => undefined);
-          throw err;
+          yield ret;
         }
-      },
-      return: async () => {
+      } finally {
         await close();
-        return { done: true, value: undefined };
-      },
-      throw: async (err?: unknown) => {
-        await close().catch(() => undefined);
-        throw err;
-      },
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-    };
-    return iterator as AsyncGenerator<
-      ChatCompletionChunk | Completion,
-      void,
-      void
-    >;
+      }
+    })();
+
+    // A generator closed before its first next() never enters its finally.
+    const returnSource = iterator.return.bind(iterator);
+    const throwSource = iterator.throw.bind(iterator);
+    iterator.return = (value) => returnSource(value).finally(close);
+    iterator.throw = (err) => throwSource(err).finally(close);
+    return iterator;
   }
 
   async chatCompletion(

--- a/src/web_worker.ts
+++ b/src/web_worker.ts
@@ -72,10 +72,10 @@ export class WebWorkerMLCEngineHandler {
   chatOpts?: ChatOptions[];
 
   public engine: MLCEngine;
-  /** ChatCompletion and Completion share the same chunk generator. Each loaded model has its own. */
-  protected loadedModelIdToAsyncGenerator: Map<
+  /** ChatCompletion and Completion streams keyed by a request-unique id. */
+  protected streamIdToAsyncGenerator: Map<
     string,
-    AsyncGenerator<ChatCompletionChunk | Completion, void, void>
+    AsyncIterableIterator<ChatCompletionChunk | Completion>
   >;
 
   /**
@@ -83,9 +83,9 @@ export class WebWorkerMLCEngineHandler {
    */
   constructor() {
     this.engine = new MLCEngine();
-    this.loadedModelIdToAsyncGenerator = new Map<
+    this.streamIdToAsyncGenerator = new Map<
       string,
-      AsyncGenerator<ChatCompletionChunk | Completion, void, void>
+      AsyncIterableIterator<ChatCompletionChunk | Completion>
     >();
     this.engine.setInitProgressCallback((report: InitProgressReport) => {
       const msg: WorkerResponse = {
@@ -189,10 +189,7 @@ export class WebWorkerMLCEngineHandler {
           const curGenerator = (await this.engine.chatCompletion(
             params.request,
           )) as AsyncGenerator<ChatCompletionChunk, void, void>;
-          this.loadedModelIdToAsyncGenerator.set(
-            params.selectedModelId,
-            curGenerator,
-          );
+          this.streamIdToAsyncGenerator.set(params.streamId, curGenerator);
           onComplete?.(null);
           return null;
         });
@@ -220,10 +217,7 @@ export class WebWorkerMLCEngineHandler {
           const curGenerator = (await this.engine.completion(
             params.request,
           )) as AsyncGenerator<Completion, void, void>;
-          this.loadedModelIdToAsyncGenerator.set(
-            params.selectedModelId,
-            curGenerator,
-          );
+          this.streamIdToAsyncGenerator.set(params.streamId, curGenerator);
           onComplete?.(null);
           return null;
         });
@@ -235,8 +229,8 @@ export class WebWorkerMLCEngineHandler {
         // For any subsequent request, we return whatever `next()` yields
         this.handleTask(msg.uuid, async () => {
           const params = msg.content as CompletionStreamNextChunkParams;
-          const curGenerator = this.loadedModelIdToAsyncGenerator.get(
-            params.selectedModelId,
+          const curGenerator = this.streamIdToAsyncGenerator.get(
+            params.streamId,
           );
           if (curGenerator === undefined) {
             throw Error(
@@ -244,9 +238,33 @@ export class WebWorkerMLCEngineHandler {
             );
           }
           // Yield the next chunk
-          const { value } = await curGenerator.next();
-          onComplete?.(value);
-          return value;
+          try {
+            const { value, done } = await curGenerator.next();
+            if (done) {
+              this.streamIdToAsyncGenerator.delete(params.streamId);
+            }
+            onComplete?.(value);
+            return value;
+          } catch (err) {
+            this.streamIdToAsyncGenerator.delete(params.streamId);
+            throw err;
+          }
+        });
+        return;
+      }
+      case "completionStreamReturn": {
+        this.handleTask(msg.uuid, async () => {
+          const params = msg.content as CompletionStreamNextChunkParams;
+          const curGenerator = this.streamIdToAsyncGenerator.get(
+            params.streamId,
+          );
+          try {
+            await curGenerator?.return?.();
+          } finally {
+            this.streamIdToAsyncGenerator.delete(params.streamId);
+          }
+          onComplete?.(null);
+          return null;
         });
         return;
       }
@@ -288,7 +306,7 @@ export class WebWorkerMLCEngineHandler {
           // This may not be cleaned properly when one asyncGenerator finishes.
           // We only clear at unload(), which may not be called upon reload().
           // However, service_worker may skip reload(). Will leave as is for now.
-          this.loadedModelIdToAsyncGenerator.clear();
+          this.streamIdToAsyncGenerator.clear();
           onComplete?.(null);
           return null;
         });
@@ -641,30 +659,72 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
    * the worker which we yield. The last message is `void`, meaning the generator has nothing
    * to yield anymore.
    *
-   * @param selectedModelId: The model of whose async generator to call next() to get next chunk.
-   *   Needed because an engine can load multiple models.
+   * @param streamId: Request-unique identity of the worker-side iterator.
    *
    * @note ChatCompletion and Completion share the same chunk generator.
    */
-  async *asyncGenerate(
-    selectedModelId: string,
+  asyncGenerate(
+    streamId: string,
   ): AsyncGenerator<ChatCompletionChunk | Completion, void, void> {
-    // Every time it gets called, sends message to worker, asking for the next chunk
-    while (true) {
-      const msg: WorkerRequest = {
-        kind: "completionStreamNextChunk",
-        uuid: crypto.randomUUID(),
-        content: {
-          selectedModelId: selectedModelId,
-        } as CompletionStreamNextChunkParams,
-      };
-      const ret = await this.getPromise<ChatCompletionChunk>(msg);
-      // If the worker's generator reached the end, it would return a `void`
-      if (typeof ret !== "object") {
-        break;
-      }
-      yield ret;
-    }
+    let completed = false;
+    let closePromise: Promise<void> | undefined;
+    const close = (): Promise<void> => {
+      closePromise ??= (async () => {
+        if (completed) {
+          return;
+        }
+        completed = true;
+        const msg: WorkerRequest = {
+          kind: "completionStreamReturn",
+          uuid: crypto.randomUUID(),
+          content: { streamId } as CompletionStreamNextChunkParams,
+        };
+        await this.getPromise<null>(msg);
+      })();
+      return closePromise;
+    };
+
+    const iterator: AsyncIterableIterator<ChatCompletionChunk | Completion> = {
+      next: async () => {
+        if (completed) {
+          return { done: true, value: undefined };
+        }
+        const msg: WorkerRequest = {
+          kind: "completionStreamNextChunk",
+          uuid: crypto.randomUUID(),
+          content: { streamId } as CompletionStreamNextChunkParams,
+        };
+        try {
+          const ret = await this.getPromise<
+            ChatCompletionChunk | Completion | void
+          >(msg);
+          if (typeof ret !== "object") {
+            completed = true;
+            return { done: true, value: undefined };
+          }
+          return { done: false, value: ret };
+        } catch (err) {
+          await close().catch(() => undefined);
+          throw err;
+        }
+      },
+      return: async () => {
+        await close();
+        return { done: true, value: undefined };
+      },
+      throw: async (err?: unknown) => {
+        await close().catch(() => undefined);
+        throw err;
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    return iterator as AsyncGenerator<
+      ChatCompletionChunk | Completion,
+      void,
+      void
+    >;
   }
 
   async chatCompletion(
@@ -692,6 +752,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
     );
 
     if (request.stream) {
+      const streamId = crypto.randomUUID();
       // First let worker instantiate a generator
       const msg: WorkerRequest = {
         kind: "chatCompletionStreamInit",
@@ -699,6 +760,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
         content: {
           request: request,
           selectedModelId: selectedModelId,
+          streamId,
           modelId: this.modelId,
           chatOpts: this.chatOpts,
         },
@@ -706,7 +768,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
       await this.getPromise<null>(msg);
 
       // Then return an async chunk generator that resides on the client side
-      return this.asyncGenerate(selectedModelId) as AsyncGenerator<
+      return this.asyncGenerate(streamId) as AsyncGenerator<
         ChatCompletionChunk,
         void,
         void
@@ -751,6 +813,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
     );
 
     if (request.stream) {
+      const streamId = crypto.randomUUID();
       // First let worker instantiate a generator
       const msg: WorkerRequest = {
         kind: "completionStreamInit",
@@ -758,6 +821,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
         content: {
           request: request,
           selectedModelId: selectedModelId,
+          streamId,
           modelId: this.modelId,
           chatOpts: this.chatOpts,
         },
@@ -765,7 +829,7 @@ export class WebWorkerMLCEngine implements MLCEngineInterface {
       await this.getPromise<null>(msg);
 
       // Then return an async chunk generator that resides on the client side
-      return this.asyncGenerate(selectedModelId) as AsyncGenerator<
+      return this.asyncGenerate(streamId) as AsyncGenerator<
         Completion,
         void,
         void

--- a/tests/engine_integration.test.ts
+++ b/tests/engine_integration.test.ts
@@ -62,6 +62,7 @@ jest.mock("../src/llm_chat", () => {
     async asyncLoadWebGPUPipelines() {}
     dispose() {}
     async sync() {}
+    setSeed(_seed: number) {}
 
     getConversationObject() {
       return this.conversation;
@@ -470,18 +471,20 @@ describe("MLCEngine deterministic integration", () => {
 
 describe("ordinary stream lifecycle", () => {
   for (const endpoint of ["chat", "completion"] as const) {
-    const start = async (engine: MLCEngine) => {
+    const start = async (engine: MLCEngine, seed?: number) => {
       const stream =
         endpoint === "chat"
           ? await engine.chatCompletion({
               model: MODEL_ID,
               messages: [{ role: "user", content: "Stream" }],
               stream: true,
+              seed,
             })
           : await engine.completion({
               model: MODEL_ID,
               prompt: "Stream",
               stream: true,
+              seed,
             });
       return stream[Symbol.asyncIterator]();
     };
@@ -513,19 +516,72 @@ describe("ordinary stream lifecycle", () => {
       await next.return!();
     });
 
+    test(`${endpoint}: closing an unused seeded stream leaves pipeline state untouched`, async () => {
+      const { engine, pipeline } = createEngineWithPipeline(4);
+      const seed = jest.spyOn(pipeline, "setSeed");
+      const stop = jest.spyOn(pipeline, "triggerStop");
+      const iterator = await start(engine, 17);
+      await iterator.return!();
+      expect(seed).not.toHaveBeenCalled();
+      expect(stop).not.toHaveBeenCalled();
+    });
+
+    test(`${endpoint}: cancellation stops the reply and resets its seed before releasing the lock`, async () => {
+      jest.useFakeTimers().setSystemTime(FIXED_CREATED_DATE);
+      const { engine, pipeline } = createEngineWithPipeline(4);
+      const seed = jest.spyOn(pipeline, "setSeed");
+      const stop = jest.spyOn(pipeline, "triggerStop");
+      const lock = (engine as any).loadedModelIdToLock.get(MODEL_ID);
+      const release = jest.spyOn(lock, "release");
+      const iterator = await start(engine, 17);
+      await iterator.next();
+      await iterator.return!();
+      await iterator.return!();
+      expect(pipeline.stopped()).toBe(true);
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(seed.mock.calls).toEqual([[17], [FIXED_CREATED_DATE.getTime()]]);
+      expect(seed.mock.invocationCallOrder[1]).toBeLessThan(
+        release.mock.invocationCallOrder[0],
+      );
+      expect(stop.mock.invocationCallOrder[0]).toBeLessThan(
+        release.mock.invocationCallOrder[0],
+      );
+      const next = await start(engine);
+      await next.next();
+      await next.return!();
+      expect(seed).toHaveBeenCalledTimes(2);
+    });
+
+    test(`${endpoint}: normal completion resets the seed without aborting the reply`, async () => {
+      jest.useFakeTimers().setSystemTime(FIXED_CREATED_DATE);
+      const { engine, pipeline } = createEngineWithPipeline(2);
+      const seed = jest.spyOn(pipeline, "setSeed");
+      const stop = jest.spyOn(pipeline, "triggerStop");
+      const iterator = await start(engine, 17);
+      while (!(await iterator.next()).done) {}
+      expect(seed.mock.calls).toEqual([[17], [FIXED_CREATED_DATE.getTime()]]);
+      expect(stop).not.toHaveBeenCalled();
+    });
+
     for (const stage of ["prefill", "decode"] as const) {
       test(`${endpoint}: ${stage} failure releases the model lock`, async () => {
-        const { engine } = createEngineWithPipeline(4);
+        const { engine, pipeline } = createEngineWithPipeline(4);
+        const seed = jest.spyOn(pipeline, "setSeed");
+        const stop = jest.spyOn(pipeline, "triggerStop");
         const lock = (engine as any).loadedModelIdToLock.get(MODEL_ID);
         const release = jest.spyOn(lock, "release");
         const error = new Error("inference failed");
         const fail = jest
           .spyOn(engine as any, stage)
           .mockRejectedValueOnce(error);
-        const iterator = await start(engine);
+        const iterator = await start(engine, 17);
         if (stage === "decode") await iterator.next();
         await expect(iterator.next()).rejects.toBe(error);
         expect(release).toHaveBeenCalledTimes(1);
+        expect(seed).toHaveBeenCalledTimes(2);
+        expect(seed.mock.calls[0]).toEqual([17]);
+        expect(seed.mock.calls[1][0]).not.toBe(17);
+        expect(stop).toHaveBeenCalledTimes(stage === "decode" ? 1 : 0);
         fail.mockRestore();
         const next = await start(engine);
         expect(await next.next()).toMatchObject({ done: false });

--- a/tests/engine_integration.test.ts
+++ b/tests/engine_integration.test.ts
@@ -467,3 +467,89 @@ describe("MLCEngine deterministic integration", () => {
     expect(response.usage?.extra?.prefill_tokens_per_s).toBeGreaterThan(0);
   });
 });
+
+describe("ordinary stream lifecycle", () => {
+  for (const endpoint of ["chat", "completion"] as const) {
+    const start = async (engine: MLCEngine) => {
+      const stream =
+        endpoint === "chat"
+          ? await engine.chatCompletion({
+              model: MODEL_ID,
+              messages: [{ role: "user", content: "Stream" }],
+              stream: true,
+            })
+          : await engine.completion({
+              model: MODEL_ID,
+              prompt: "Stream",
+              stream: true,
+            });
+      return stream[Symbol.asyncIterator]();
+    };
+
+    test(`${endpoint}: unconsumed stream owns no lock, including return before next`, async () => {
+      const { engine } = createEngineWithPipeline(4);
+      const lock = (engine as any).loadedModelIdToLock.get(MODEL_ID);
+      const acquire = jest.spyOn(lock, "acquire");
+      const release = jest.spyOn(lock, "release");
+      const iterator = await start(engine);
+      expect(acquire).not.toHaveBeenCalled();
+      await iterator.return!();
+      expect(acquire).not.toHaveBeenCalled();
+      expect(release).not.toHaveBeenCalled();
+      expect(await iterator.next()).toMatchObject({ done: true });
+    });
+
+    test(`${endpoint}: return releases a started stream exactly once`, async () => {
+      const { engine } = createEngineWithPipeline(4);
+      const lock = (engine as any).loadedModelIdToLock.get(MODEL_ID);
+      const release = jest.spyOn(lock, "release");
+      const iterator = await start(engine);
+      await iterator.next();
+      await iterator.return!();
+      await iterator.return!();
+      expect(release).toHaveBeenCalledTimes(1);
+      const next = await start(engine);
+      expect(await next.next()).toMatchObject({ done: false });
+      await next.return!();
+    });
+
+    for (const stage of ["prefill", "decode"] as const) {
+      test(`${endpoint}: ${stage} failure releases the model lock`, async () => {
+        const { engine } = createEngineWithPipeline(4);
+        const lock = (engine as any).loadedModelIdToLock.get(MODEL_ID);
+        const release = jest.spyOn(lock, "release");
+        const error = new Error("inference failed");
+        const fail = jest
+          .spyOn(engine as any, stage)
+          .mockRejectedValueOnce(error);
+        const iterator = await start(engine);
+        if (stage === "decode") await iterator.next();
+        await expect(iterator.next()).rejects.toBe(error);
+        expect(release).toHaveBeenCalledTimes(1);
+        fail.mockRestore();
+        const next = await start(engine);
+        expect(await next.next()).toMatchObject({ done: false });
+        await next.return!();
+      });
+    }
+
+    test(`${endpoint}: concurrent iterators wait for the active stream`, async () => {
+      const { engine, pipeline } = createEngineWithPipeline(4);
+      const first = await start(engine);
+      const second = await start(engine);
+      await first.next();
+      let secondStarted = false;
+      const pending = second.next().then((value) => {
+        secondStarted = true;
+        return value;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(secondStarted).toBe(false);
+      expect(pipeline.prefillCallCount).toBe(1);
+      await first.return!();
+      expect(await pending).toMatchObject({ done: false });
+      expect(pipeline.prefillCallCount).toBe(2);
+      await second.return!();
+    });
+  }
+});

--- a/tests/engine_integration.test.ts
+++ b/tests/engine_integration.test.ts
@@ -62,7 +62,7 @@ jest.mock("../src/llm_chat", () => {
     async asyncLoadWebGPUPipelines() {}
     dispose() {}
     async sync() {}
-    setSeed(_seed: number) {}
+    setSeed() {}
 
     getConversationObject() {
       return this.conversation;
@@ -558,7 +558,9 @@ describe("ordinary stream lifecycle", () => {
       const seed = jest.spyOn(pipeline, "setSeed");
       const stop = jest.spyOn(pipeline, "triggerStop");
       const iterator = await start(engine, 17);
-      while (!(await iterator.next()).done) {}
+      while (!(await iterator.next()).done) {
+        // Consume through the final chunk so normal cleanup runs.
+      }
       expect(seed.mock.calls).toEqual([[17], [FIXED_CREATED_DATE.getTime()]]);
       expect(stop).not.toHaveBeenCalled();
     });

--- a/tests/web_worker_handler.test.ts
+++ b/tests/web_worker_handler.test.ts
@@ -102,6 +102,7 @@ test("chatCompletionStreamInit registers async generator", async () => {
     content: {
       modelId: ["demo"],
       selectedModelId: "demo",
+      streamId: "stream-demo",
       chatOpts: [],
       request: {
         model: "demo",
@@ -113,7 +114,7 @@ test("chatCompletionStreamInit registers async generator", async () => {
   handler.onmessage(message, jest.fn());
   await flushMicrotasks();
   expect(
-    (handler as any).loadedModelIdToAsyncGenerator.get("demo"),
+    (handler as any).streamIdToAsyncGenerator.get("stream-demo"),
   ).toBeDefined();
 });
 
@@ -209,6 +210,7 @@ class MockWorker {
     }));
     this.setResponder("embedding", () => ({ object: "list", data: [] }));
     this.setResponder("reload", () => null);
+    this.setResponder("completionStreamReturn", () => null);
   }
 
   setResponder(kind: string, responder: (msg: any) => any) {
@@ -275,18 +277,71 @@ test("completionStreamNextChunk returns data from stored generator", async () =>
   const generator = (async function* () {
     yield { object: "chunk" };
   })();
-  (handler as any).loadedModelIdToAsyncGenerator.set("demo", generator);
+  (handler as any).streamIdToAsyncGenerator.set("stream-demo", generator);
   const onComplete = jest.fn();
   handler.onmessage(
     {
       kind: "completionStreamNextChunk",
       uuid: "next",
-      content: { selectedModelId: "demo" },
+      content: { streamId: "stream-demo" },
     } as any,
     onComplete,
   );
   await flushMicrotasks();
   expect(onComplete).toHaveBeenCalledWith({ object: "chunk" });
+});
+
+test("completionStreamNextChunk removes a completed generator", async () => {
+  const handler = new WebWorkerMLCEngineHandler();
+  const generator = (async function* () {
+    yield { object: "chunk" };
+  })();
+  (handler as any).streamIdToAsyncGenerator.set("stream-done", generator);
+
+  for (const uuid of ["next-one", "next-done"]) {
+    handler.onmessage(
+      {
+        kind: "completionStreamNextChunk",
+        uuid,
+        content: { streamId: "stream-done" },
+      } as any,
+      jest.fn(),
+    );
+    await flushMicrotasks();
+  }
+
+  expect((handler as any).streamIdToAsyncGenerator.has("stream-done")).toBe(
+    false,
+  );
+});
+
+test("completionStreamReturn closes and removes a stored generator", async () => {
+  const handler = new WebWorkerMLCEngineHandler();
+  let closed = false;
+  const generator = (async function* () {
+    try {
+      yield { object: "chunk" };
+    } finally {
+      closed = true;
+    }
+  })();
+  await generator.next();
+  (handler as any).streamIdToAsyncGenerator.set("stream-cancel", generator);
+
+  handler.onmessage(
+    {
+      kind: "completionStreamReturn",
+      uuid: "return",
+      content: { streamId: "stream-cancel" },
+    } as any,
+    jest.fn(),
+  );
+  await flushMicrotasks();
+
+  expect(closed).toBe(true);
+  expect((handler as any).streamIdToAsyncGenerator.has("stream-cancel")).toBe(
+    false,
+  );
 });
 
 test("WebWorkerMLCEngine setAppConfig posts configuration message", () => {
@@ -324,5 +379,64 @@ test("WebWorkerMLCEngine info helpers resolve via worker messages", async () => 
   await flushMicrotasks();
   expect(worker.sent.some((msg) => msg.kind === "interruptGenerate")).toBe(
     true,
+  );
+});
+
+test.each(["chatCompletion", "completion"] as const)(
+  "WebWorkerMLCEngine gives concurrent %s streams distinct IDs",
+  async (endpoint) => {
+    const worker = new MockWorker();
+    const kind =
+      endpoint === "chatCompletion"
+        ? "chatCompletionStreamInit"
+        : "completionStreamInit";
+    worker.setResponder(kind, () => null);
+    const engine = new WebWorkerMLCEngine(worker as any);
+    engine.modelId = ["demo"];
+    const start = () =>
+      endpoint === "chatCompletion"
+        ? engine.chatCompletion({
+            model: "demo",
+            messages: [{ role: "user", content: "hello" }],
+            stream: true,
+          })
+        : engine.completion({ model: "demo", prompt: "hello", stream: true });
+    const first = (await start()) as AsyncIterableIterator<any>;
+    const second = (await start()) as AsyncIterableIterator<any>;
+    const ids = worker.sent
+      .filter((msg) => msg.kind === kind)
+      .map((msg) => msg.content.streamId);
+    expect(new Set(ids).size).toBe(2);
+    await first.return!();
+    await second.return!();
+    expect(
+      worker.sent
+        .filter((msg) => msg.kind === "completionStreamReturn")
+        .map((msg) => msg.content.streamId),
+    ).toEqual(ids);
+  },
+);
+
+test("WebWorkerMLCEngine return cancels an ordinary stream before first next", async () => {
+  const worker = new MockWorker();
+  worker.setResponder("chatCompletionStreamInit", () => null);
+  const engine = new WebWorkerMLCEngine(worker as any);
+  engine.modelId = ["demo"];
+
+  const stream = (await engine.chatCompletion({
+    model: "demo",
+    messages: [{ role: "user", content: "Cancel" }],
+    stream: true,
+  })) as AsyncIterableIterator<any>;
+  await stream.return!();
+
+  const init = worker.sent.find(
+    (msg) => msg.kind === "chatCompletionStreamInit",
+  );
+  expect(worker.sent).toContainEqual(
+    expect.objectContaining({
+      kind: "completionStreamReturn",
+      content: { streamId: init.content.streamId },
+    }),
   );
 });

--- a/tests/web_worker_handler.test.ts
+++ b/tests/web_worker_handler.test.ts
@@ -440,3 +440,99 @@ test("WebWorkerMLCEngine return cancels an ordinary stream before first next", a
     }),
   );
 });
+
+function connectWorkerStream(source: AsyncGenerator<any, void, void>) {
+  const handler = new WebWorkerMLCEngineHandler();
+  const worker = {
+    onmessage: (_event: any) => {
+      void _event;
+    },
+    postMessage: (msg: any) => {
+      setTimeout(() => handler.onmessage(msg), 0);
+    },
+  };
+  handler.postMessage = (msg) => worker.onmessage(msg);
+  (handler as any).streamIdToAsyncGenerator.set("ordered-stream", source);
+  const engine = new WebWorkerMLCEngine(worker);
+  return {
+    iterator: engine.asyncGenerate("ordered-stream"),
+    streams: (handler as any).streamIdToAsyncGenerator as Map<string, unknown>,
+  };
+}
+
+test("worker read-ahead returns done for every read beyond stream exhaustion", async () => {
+  const chunk = { object: "chat.completion.chunk", choices: [] };
+  const { iterator, streams } = connectWorkerStream(
+    (async function* () {
+      yield chunk;
+    })(),
+  );
+  await expect(
+    Promise.all([iterator.next(), iterator.next(), iterator.next()]),
+  ).resolves.toEqual([
+    { done: false, value: chunk },
+    { done: true, value: undefined },
+    { done: true, value: undefined },
+  ]);
+  expect(streams.size).toBe(0);
+});
+
+test("worker return waits for a pending read and closes the stream", async () => {
+  let unblock!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    unblock = resolve;
+  });
+  let closes = 0;
+  const chunk = { object: "chat.completion.chunk", choices: [] };
+  const { iterator, streams } = connectWorkerStream(
+    (async function* () {
+      try {
+        await gate;
+        yield chunk;
+        yield chunk;
+      } finally {
+        closes++;
+      }
+    })(),
+  );
+  const pending = iterator.next();
+  const returned = iterator.return();
+  await flushMicrotasks();
+  expect(closes).toBe(0);
+  unblock();
+  expect(await pending).toEqual({ done: false, value: chunk });
+  expect(await returned).toEqual({ done: true, value: undefined });
+  expect(await iterator.next()).toEqual({ done: true, value: undefined });
+  expect(closes).toBe(1);
+  expect(streams.size).toBe(0);
+});
+
+test("worker inference failure retires the stream and queued reads return done", async () => {
+  const { iterator, streams } = connectWorkerStream(
+    (async function* () {
+      yield { object: "chat.completion.chunk", choices: [] };
+      throw new Error("decode failed");
+    })(),
+  );
+  await iterator.next();
+  const failure = expect(iterator.next()).rejects.toBe("Error: decode failed");
+  const afterFailure = iterator.next();
+  await failure;
+  expect(await afterFailure).toEqual({ done: true, value: undefined });
+  expect(streams.size).toBe(0);
+});
+
+test("worker throw before first read closes the unused stream", async () => {
+  let started = false;
+  const { iterator, streams } = connectWorkerStream(
+    (async function* () {
+      started = true;
+      yield { object: "chat.completion.chunk", choices: [] };
+    })(),
+  );
+  const failure = new Error("consumer stopped");
+  await expect(iterator.throw(failure)).rejects.toBe(failure);
+  expect(await iterator.next()).toEqual({ done: true, value: undefined });
+  expect(started).toBe(false);
+  expect(streams.size).toBe(0);
+});


### PR DESCRIPTION
Fixes stream cleanup for chat and legacy completions. Previously, breaking out of a stream could leave the model lock held and block subsequent requests. Creating a stream without consuming it could also hold the lock indefinitely. 

The model lock is now acquired on the first iteration and released when the stream finishes, throws, or is closed. Early closure also finalizes the partial assistant reply and resets any request-specific seed.

Worker streams are tracked by a unique stream ID instead of the model ID, so separate requests cannot overwrite each other’s iterator. Closing the client iterator now closes the worker iterator too. Native async generators preserve ordering for overlapping `next()`, `return()`, and `throw()` calls.

Generation remains serialized per loaded model instance. Stream creation no longer reserves its place in the queue (iteration does). This does not add parallel generation on one model instance or introduce checkpointing.

The existing chunk-generation code is extracted into helpers for reuse by follow-up resumability work.