### PR TITLE
[Example] Add crash-resumable generation demo

### DIFF
--- a/examples/resumable-generation/.gitignore
+++ b/examples/resumable-generation/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+.env.local

--- a/examples/resumable-generation/README.md
+++ b/examples/resumable-generation/README.md
@@ -1,0 +1,97 @@
+# WebLLM Resumable Generation Example
+
+This example is a browser harness for testing crash-resumable generation with
+real WebGPU.
+
+It intentionally targets only:
+
+```text
+Qwen3-0.6B-q4f16_1-MLC
+```
+
+The weights/tokenizer come from WebLLM's prebuilt model config. Supply your own
+matching WebGPU model library; this example does not use a personal binary host.
+For KV recovery, the WASM must contain the TVM checkpoint primitives. Without
+those primitives, the core implementation falls back to token replay.
+
+Create `.env.local` in this directory (the URL must be accessible to the browser):
+
+```dotenv
+VITE_WEBLLM_MODEL_LIB_URL=https://your-model-host/Qwen3-0.6B-q4f16_1-webgpu.wasm
+# Optional: match your model's compile-time limits. These values describe the
+# small artifact used during validation, not requirements for every build.
+VITE_WEBLLM_CONTEXT_WINDOW_SIZE=512
+VITE_WEBLLM_PREFILL_CHUNK_SIZE=128
+```
+
+Restart Vite after changing these settings. Keep the same model library,
+weights, tokenizer, and configuration when resuming a saved session.
+
+## Run
+
+```bash
+cd examples/resumable-generation
+npm install
+npm run dev
+```
+
+Open the printed localhost URL in Chrome or Edge with WebGPU enabled.
+
+The example depends on the repo root through `file:../..`. Its `dev` and
+`build` scripts rebuild the root package first, then Vite serves the generated
+`lib/index.js`. This still exercises the current checkout, while avoiding raw
+TypeScript runtime export issues in Vite.
+
+## Manual Crash Test
+
+1. Keep `Dedicated Worker` selected.
+2. Click `Load`.
+3. Click `Start`.
+4. After several chunks appear, click `Reload Page` or close and reopen the tab.
+5. Click `Load`.
+6. Click `List Sessions`.
+7. Click `Resume Continue`.
+
+Expected results:
+
+- If no committed KV checkpoint existed yet, recovery should use
+  `token_replay`.
+- If a committed checkpoint existed, recovery should use `kv`.
+- In exact mode, exposed tokens are persisted first. In relaxed mode, a crash
+  can lose an unflushed suffix. Decoding can also revise a partial Unicode/text
+  suffix; use recovered text as authoritative rather than assuming text is
+  strictly append-only.
+
+## Automated Reload Test
+
+Enable `Reload after chunks`, set `Chunks`, then click `Start`. The page reloads
+itself after that many streamed chunks. After reload, click `Load`, then
+`Resume Continue`.
+
+## Validation Runner
+
+Click `Run Validation` to exercise real WebGPU resumability checks in worker
+mode:
+
+- Worker-mode streaming resume after an interrupted generation.
+- Same-session repeated resume by interrupting a resumed continuation and
+  resuming it again.
+- Session lock exclusion from a second worker client against the same OPFS
+  session.
+- Low-quota behavior when the browser reports less than 512 MiB free storage.
+
+The low-quota case reports `skip` on normal profiles with enough free quota.
+For a hard low-quota check, run the page in a constrained browser profile or
+manually fill origin storage, then rerun `Run Validation`. The expected behavior
+is that KV checkpointing is skipped while token journaling remains recoverable.
+
+For an exact cross-tab lock check, start a resumable generation in one tab,
+open this same page in a second tab, enter the same session ID, and click
+`Resume Continue`. The second tab should fail with
+`Resumable session is already active`.
+
+## Metrics
+
+`Dedicated Worker` mode matches the intended runtime path, but internal engine
+metrics live inside the worker. Switch to `Main Thread` mode if you need to
+inspect `lastResumableMetrics` directly from the page.

--- a/examples/resumable-generation/index.html
+++ b/examples/resumable-generation/index.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebLLM Resumable Generation</title>
+  </head>
+  <body>
+    <main class="app">
+      <header class="topbar">
+        <div>
+          <h1>Resumable Generation</h1>
+          <p id="environment">Checking browser support...</p>
+        </div>
+        <div class="status" id="status">Idle</div>
+      </header>
+
+      <section class="panel controls">
+        <div class="field wide">
+          <label>Model</label>
+          <div class="static-field" id="model-name"></div>
+        </div>
+        <div class="field wide">
+          <label>Runtime Wasm</label>
+          <a
+            class="static-link"
+            id="model-lib"
+            target="_blank"
+            rel="noreferrer"
+          ></a>
+        </div>
+        <div class="field">
+          <label for="engine-mode">Engine</label>
+          <select id="engine-mode">
+            <option value="worker">Dedicated Worker</option>
+            <option value="main">Main Thread</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="session-id">Session ID</label>
+          <input id="session-id" type="text" autocomplete="off" />
+        </div>
+        <div class="field">
+          <label for="checkpoint-interval">Checkpoint Tokens</label>
+          <input
+            id="checkpoint-interval"
+            type="number"
+            min="1"
+            step="1"
+            value="64"
+          />
+        </div>
+        <div class="field">
+          <label for="durability">Durability</label>
+          <select id="durability">
+            <option value="exact">Exact</option>
+            <option value="relaxed">Relaxed</option>
+          </select>
+        </div>
+        <label class="check">
+          <input id="checkpoint-prompt" type="checkbox" checked />
+          Prompt checkpoint
+        </label>
+        <label class="check">
+          <input id="strict-persistence" type="checkbox" />
+          Strict persistence
+        </label>
+        <label class="check">
+          <input id="auto-reload-enabled" type="checkbox" />
+          Reload after chunks
+        </label>
+        <div class="field small">
+          <label for="auto-reload-chunks">Chunks</label>
+          <input
+            id="auto-reload-chunks"
+            type="number"
+            min="1"
+            step="1"
+            value="8"
+          />
+        </div>
+      </section>
+
+      <section class="panel prompt-panel">
+        <div class="field wide">
+          <label for="prompt">Prompt</label>
+          <textarea id="prompt" rows="5"></textarea>
+        </div>
+        <div class="actions">
+          <button id="load-model">Load</button>
+          <button id="start">Start</button>
+          <button id="interrupt">Interrupt</button>
+          <button id="reload-page">Reload Page</button>
+          <button id="list-sessions">List Sessions</button>
+          <button id="resume-text">Text Restore</button>
+          <button id="resume-continue">Resume Continue</button>
+          <button id="delete-session">Delete Session</button>
+        </div>
+      </section>
+
+      <section class="panel validation-panel">
+        <div class="panel-title">Validation</div>
+        <div class="validation-actions">
+          <button id="run-validation">Run Validation</button>
+        </div>
+        <pre id="validation"></pre>
+      </section>
+
+      <section class="grid">
+        <div class="panel">
+          <div class="panel-title">Output</div>
+          <pre id="output"></pre>
+        </div>
+        <div class="panel">
+          <div class="panel-title">Sessions</div>
+          <pre id="sessions"></pre>
+        </div>
+        <div class="panel">
+          <div class="panel-title">Metrics</div>
+          <pre id="metrics"></pre>
+        </div>
+        <div class="panel">
+          <div class="panel-title">Log</div>
+          <pre id="log"></pre>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/resumable-generation/package.json
+++ b/examples/resumable-generation/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "webllm-resumable-generation-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:webllm": "npm --prefix ../.. run build",
+    "dev": "npm run build:webllm && vite --host 0.0.0.0",
+    "build": "npm run build:webllm && vite build",
+    "preview": "vite preview --host 0.0.0.0"
+  },
+  "dependencies": {
+    "@mlc-ai/web-llm": "file:../.."
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/examples/resumable-generation/src/main.ts
+++ b/examples/resumable-generation/src/main.ts
@@ -795,11 +795,12 @@ async function runValidationCase(
 ): Promise<ValidationCaseResult> {
   const started = performance.now();
   try {
+    const details = await fn();
     return {
       name,
       status: "pass",
       elapsedMs: performance.now() - started,
-      details: await fn(),
+      details,
     };
   } catch (err) {
     return {

--- a/examples/resumable-generation/src/main.ts
+++ b/examples/resumable-generation/src/main.ts
@@ -1,0 +1,967 @@
+import * as webllm from "@mlc-ai/web-llm";
+import "./style.css";
+
+type EngineMode = "worker" | "main";
+
+type ResumeResultLike = webllm.ResumeResult;
+
+const SESSION_KEY = "webllm-resumable-example/session-id";
+const OUTPUT_PREFIX = "webllm-resumable-example/output/";
+const MODE_KEY = "webllm-resumable-example/mode";
+const PROMPT_KEY = "webllm-resumable-example/prompt";
+const MODEL_ID = "Qwen3-0.6B-q4f16_1-MLC";
+const MODEL_LIB_URL = import.meta.env.VITE_WEBLLM_MODEL_LIB_URL?.trim() ?? "";
+
+const modelNameEl = element<HTMLDivElement>("model-name");
+const modelLibEl = element<HTMLAnchorElement>("model-lib");
+const engineModeSelect = element<HTMLSelectElement>("engine-mode");
+const sessionInput = element<HTMLInputElement>("session-id");
+const checkpointIntervalInput = element<HTMLInputElement>(
+  "checkpoint-interval",
+);
+const durabilitySelect = element<HTMLSelectElement>("durability");
+const checkpointPromptInput = element<HTMLInputElement>("checkpoint-prompt");
+const strictPersistenceInput = element<HTMLInputElement>("strict-persistence");
+const autoReloadEnabledInput = element<HTMLInputElement>("auto-reload-enabled");
+const autoReloadChunksInput = element<HTMLInputElement>("auto-reload-chunks");
+const promptInput = element<HTMLTextAreaElement>("prompt");
+const outputPre = element<HTMLPreElement>("output");
+const sessionsPre = element<HTMLPreElement>("sessions");
+const metricsPre = element<HTMLPreElement>("metrics");
+const validationPre = element<HTMLPreElement>("validation");
+const logPre = element<HTMLPreElement>("log");
+const statusEl = element<HTMLDivElement>("status");
+const environmentEl = element<HTMLParagraphElement>("environment");
+
+let engine: any;
+let worker: Worker | undefined;
+let loadedModel: string | undefined;
+let loadedMode: EngineMode | undefined;
+let streaming = false;
+let validationRunning = false;
+let currentOutput = "";
+
+type ValidationStatus = "pass" | "fail" | "skip";
+
+interface ValidationCaseResult {
+  name: string;
+  status: ValidationStatus;
+  elapsedMs: number;
+  details?: unknown;
+}
+
+function element<T extends HTMLElement>(id: string): T {
+  const node = document.getElementById(id);
+  if (node === null) {
+    throw new Error(`Missing element: ${id}`);
+  }
+  return node as T;
+}
+
+function setStatus(status: string): void {
+  statusEl.textContent = status;
+}
+
+function logLine(line: string, data?: unknown): void {
+  const timestamp = new Date().toLocaleTimeString();
+  const suffix = data === undefined ? "" : `\n${JSON.stringify(data, null, 2)}`;
+  logPre.textContent = `${timestamp} ${line}${suffix}\n${logPre.textContent}`;
+}
+
+function currentSessionId(): string {
+  const sessionId = sessionInput.value.trim();
+  if (sessionId === "") {
+    throw new Error("Session ID is required.");
+  }
+  return sessionId;
+}
+
+function selectedMode(): EngineMode {
+  return engineModeSelect.value === "main" ? "main" : "worker";
+}
+
+function configuredSize(
+  value: string | undefined,
+  name: string,
+): number | undefined {
+  if (!value?.trim()) return undefined;
+  const size = Number(value);
+  if (!Number.isSafeInteger(size) || size <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return size;
+}
+
+function resumableAppConfig(): webllm.AppConfig {
+  if (!MODEL_LIB_URL) {
+    throw new Error(
+      "Set VITE_WEBLLM_MODEL_LIB_URL to a compatible Qwen3 model WASM URL before loading. See README.md.",
+    );
+  }
+  const baseConfig = webllm.prebuiltAppConfig;
+  const modelRecord = baseConfig.model_list.find(
+    (record) => record.model_id === MODEL_ID,
+  );
+  if (modelRecord === undefined) {
+    throw new Error(`Cannot find model record for ${MODEL_ID}.`);
+  }
+  // The selected model library differs from the prebuilt artifact. Keep the
+  // weight/tokenizer integrity metadata, but do not apply the old WASM hash.
+  const integrity = modelRecord.integrity
+    ? { ...modelRecord.integrity, model_lib: undefined }
+    : undefined;
+  const context = configuredSize(
+    import.meta.env.VITE_WEBLLM_CONTEXT_WINDOW_SIZE,
+    "VITE_WEBLLM_CONTEXT_WINDOW_SIZE",
+  );
+  const prefill = configuredSize(
+    import.meta.env.VITE_WEBLLM_PREFILL_CHUNK_SIZE,
+    "VITE_WEBLLM_PREFILL_CHUNK_SIZE",
+  );
+  return {
+    ...baseConfig,
+    model_list: [
+      {
+        ...modelRecord,
+        integrity,
+        model_lib: MODEL_LIB_URL,
+        overrides: {
+          ...modelRecord.overrides,
+          ...(context === undefined ? {} : { context_window_size: context }),
+          ...(prefill === undefined ? {} : { prefill_chunk_size: prefill }),
+        },
+      },
+    ],
+  };
+}
+
+function saveSessionState(): void {
+  const sessionId = sessionInput.value.trim();
+  if (sessionId !== "") {
+    localStorage.setItem(SESSION_KEY, sessionId);
+    localStorage.setItem(`${OUTPUT_PREFIX}${sessionId}`, currentOutput);
+  }
+  localStorage.setItem(MODE_KEY, selectedMode());
+  localStorage.setItem(PROMPT_KEY, promptInput.value);
+}
+
+function restoreSessionState(): void {
+  const sessionId = localStorage.getItem(SESSION_KEY) ?? `manual-${Date.now()}`;
+  sessionInput.value = sessionId;
+  currentOutput = localStorage.getItem(`${OUTPUT_PREFIX}${sessionId}`) ?? "";
+  outputPre.textContent = currentOutput;
+
+  const savedPrompt = localStorage.getItem(PROMPT_KEY);
+  promptInput.value =
+    savedPrompt ??
+    "Write a long numbered list of practical browser debugging steps. Include at least 300 short items.";
+
+  const savedMode = localStorage.getItem(MODE_KEY);
+  if (savedMode === "main" || savedMode === "worker") {
+    engineModeSelect.value = savedMode;
+  }
+}
+
+function renderModelInfo(): void {
+  modelNameEl.textContent = MODEL_ID;
+  modelLibEl.href = MODEL_LIB_URL;
+  modelLibEl.textContent = MODEL_LIB_URL || "Not configured (see README.md)";
+}
+
+async function updateEnvironment(): Promise<void> {
+  const webgpu = "gpu" in navigator ? "WebGPU available" : "No WebGPU";
+  const context = window.isSecureContext ? "secure context" : "not secure";
+  let storage = "storage estimate unavailable";
+  try {
+    const estimate = await navigator.storage?.estimate?.();
+    if (
+      typeof estimate?.quota === "number" &&
+      typeof estimate.usage === "number"
+    ) {
+      const free = Math.max(0, estimate.quota - estimate.usage);
+      storage = `${formatBytes(free)} free of ${formatBytes(estimate.quota)}`;
+    }
+  } catch {
+    storage = "storage estimate failed";
+  }
+  environmentEl.textContent = `${webgpu}, ${context}, ${storage}`;
+}
+
+function formatBytes(bytes: number): string {
+  const mib = bytes / (1024 * 1024);
+  if (mib < 1024) {
+    return `${mib.toFixed(1)} MiB`;
+  }
+  return `${(mib / 1024).toFixed(2)} GiB`;
+}
+
+async function loadModel(): Promise<void> {
+  const mode = selectedMode();
+  if (engine !== undefined && loadedModel === MODEL_ID && loadedMode === mode) {
+    return;
+  }
+
+  await unloadEngine();
+  setStatus("Loading model");
+  logLine(`Loading ${MODEL_ID} in ${mode} mode`, {
+    modelLib: MODEL_LIB_URL,
+  });
+
+  const initProgressCallback = (progress: unknown) => {
+    const text =
+      typeof (progress as { text?: unknown })?.text === "string"
+        ? (progress as { text: string }).text
+        : "Loading model";
+    setStatus(text);
+  };
+
+  if (mode === "worker") {
+    worker = new Worker(new URL("./worker.ts", import.meta.url), {
+      type: "module",
+    });
+    engine = await (webllm as any).CreateWebWorkerMLCEngine(worker, MODEL_ID, {
+      appConfig: resumableAppConfig(),
+      initProgressCallback,
+    });
+  } else {
+    engine = await (webllm as any).CreateMLCEngine(MODEL_ID, {
+      appConfig: resumableAppConfig(),
+      initProgressCallback,
+    });
+  }
+
+  loadedModel = MODEL_ID;
+  loadedMode = mode;
+  setStatus("Model loaded");
+  logLine("Model loaded", {
+    model: MODEL_ID,
+    modelLib: MODEL_LIB_URL,
+    mode,
+  });
+  saveSessionState();
+  renderMetrics();
+}
+
+async function unloadEngine(): Promise<void> {
+  try {
+    await engine?.unload?.();
+  } finally {
+    worker?.terminate();
+    worker = undefined;
+    engine = undefined;
+    loadedModel = undefined;
+    loadedMode = undefined;
+  }
+}
+
+async function startGeneration(): Promise<void> {
+  if (streaming) {
+    return;
+  }
+  await loadModel();
+
+  const sessionId = currentSessionId();
+  currentOutput = "";
+  outputPre.textContent = "";
+  saveSessionState();
+
+  const checkpointIntervalTokens = Number(checkpointIntervalInput.value);
+  const reloadAfterChunks = Number(autoReloadChunksInput.value);
+  const request = {
+    model: MODEL_ID,
+    messages: [{ role: "user", content: promptInput.value }],
+    stream: true,
+    seed: 1234,
+    max_tokens: 512,
+    extra_body: {
+      resumable: {
+        enabled: true,
+        sessionId,
+        checkpointIntervalTokens,
+        checkpointPrompt: checkpointPromptInput.checked,
+        durabilityMode: durabilitySelect.value,
+        strictPersistence: strictPersistenceInput.checked,
+      },
+    },
+  };
+
+  streaming = true;
+  setStatus("Streaming");
+  logLine("Starting resumable generation", request.extra_body.resumable);
+  try {
+    const chunks = await engine.chat.completions.create(request);
+    let chunkCount = 0;
+    for await (const chunk of chunks) {
+      const delta = chunk.choices?.[0]?.delta?.content ?? "";
+      if (delta !== "") {
+        currentOutput += delta;
+        outputPre.textContent = currentOutput;
+        outputPre.scrollTop = outputPre.scrollHeight;
+        saveSessionState();
+      }
+      chunkCount += 1;
+      if (
+        autoReloadEnabledInput.checked &&
+        Number.isFinite(reloadAfterChunks) &&
+        chunkCount >= reloadAfterChunks
+      ) {
+        logLine(`Reloading after ${chunkCount} chunks`);
+        saveSessionState();
+        location.reload();
+        return;
+      }
+    }
+    setStatus("Finished");
+    logLine("Generation finished");
+  } catch (err) {
+    setStatus("Generation failed");
+    logLine("Generation failed", errorJson(err));
+    throw err;
+  } finally {
+    streaming = false;
+    renderMetrics();
+    await listSessions().catch(() => undefined);
+  }
+}
+
+async function interruptGeneration(): Promise<void> {
+  if (engine === undefined) {
+    return;
+  }
+  await engine.interruptGenerate?.();
+  logLine("Interrupt requested");
+}
+
+async function listSessions(): Promise<void> {
+  await loadModel();
+  const sessions = await engine.listResumableSessions();
+  sessionsPre.textContent = JSON.stringify(sessions, null, 2);
+  logLine("Listed resumable sessions");
+}
+
+async function restoreTextOnly(): Promise<void> {
+  await loadModel();
+  const result = (await engine.resumeChatCompletion(
+    currentSessionId(),
+  )) as ResumeResultLike;
+  renderResumeResult(result);
+  logLine("Text restore complete", result);
+}
+
+async function resumeAndContinue(): Promise<void> {
+  await loadModel();
+  setStatus("Resuming");
+  const restored = (await engine.resumeChatCompletion(
+    currentSessionId(),
+  )) as ResumeResultLike;
+  renderResumeResult(restored);
+  const result = await engine.resumeChatCompletion(currentSessionId(), {
+    continueGeneration: true,
+    stream: true,
+  });
+  if (isAsyncIterable(result)) {
+    for await (const chunk of result) {
+      const delta = chunk.choices?.[0]?.delta?.content ?? "";
+      currentOutput += delta;
+      outputPre.textContent = currentOutput;
+      saveSessionState();
+    }
+  } else {
+    renderResumeResult(result as ResumeResultLike);
+  }
+  setStatus("Resume complete");
+  renderMetrics();
+  await listSessions().catch(() => undefined);
+}
+
+interface ValidationRequestOptions {
+  maxTokens?: number;
+  checkpointIntervalTokens?: number;
+  checkpointPrompt?: boolean;
+  strictPersistence?: boolean;
+}
+
+interface InterruptedValidationSession {
+  firstOutput: string;
+  chunks: number;
+  deltas: number;
+}
+
+interface ResumeValidationSession {
+  recoveredText: string;
+  deltaText: string;
+  chunks: number;
+  deltas: number;
+  interrupted: boolean;
+  recoveryMode: string;
+  streamed: boolean;
+  nonStreamResult?: unknown;
+}
+
+const LOW_QUOTA_THRESHOLD_BYTES = 512 * 1024 * 1024;
+
+function validationSessionId(label: string): string {
+  return `validation-${label}-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function validationPrompt(label: string): string {
+  return [
+    `Validation case: ${label}.`,
+    "Write a long numbered checklist for debugging browser-based LLM inference.",
+    "Use short concrete items, continue until you have produced at least 180 items, and do not stop early.",
+  ].join(" ");
+}
+
+function validationRequest(
+  sessionId: string,
+  prompt: string,
+  options: ValidationRequestOptions = {},
+): Record<string, unknown> {
+  return {
+    model: MODEL_ID,
+    messages: [{ role: "user", content: prompt }],
+    stream: true,
+    seed: 1234,
+    max_tokens: options.maxTokens ?? 384,
+    extra_body: {
+      resumable: {
+        enabled: true,
+        sessionId,
+        checkpointIntervalTokens: options.checkpointIntervalTokens ?? 32,
+        checkpointPrompt: options.checkpointPrompt ?? true,
+        durabilityMode: "exact",
+        strictPersistence: options.strictPersistence ?? false,
+      },
+    },
+  };
+}
+
+async function resetValidationSession(sessionId: string): Promise<void> {
+  await engine?.deleteResumableSession?.(sessionId).catch(() => undefined);
+  localStorage.removeItem(`${OUTPUT_PREFIX}${sessionId}`);
+}
+
+async function drainIterator(iterator: AsyncIterator<any>): Promise<void> {
+  while (!(await iterator.next()).done) {
+    // Keep consuming so generator finally blocks release session/model locks.
+  }
+}
+
+async function startInterruptedValidationSession(
+  sessionId: string,
+  prompt: string,
+  chunksBeforeInterrupt = 1,
+): Promise<InterruptedValidationSession> {
+  const chunks = await engine.chat.completions.create(
+    validationRequest(sessionId, prompt),
+  );
+  if (!isAsyncIterable(chunks)) {
+    throw new Error("Expected streaming validation generation.");
+  }
+  const iterator = chunks[Symbol.asyncIterator]();
+  let firstOutput = "";
+  let chunkCount = 0;
+  let deltaCount = 0;
+
+  while (true) {
+    const next = await iterator.next();
+    if (next.done) {
+      throw new Error("Generation finished before validation interrupt.");
+    }
+    chunkCount += 1;
+    const delta = next.value.choices?.[0]?.delta?.content ?? "";
+    if (delta === "") {
+      continue;
+    }
+    firstOutput += delta;
+    deltaCount += 1;
+    if (deltaCount >= chunksBeforeInterrupt) {
+      await engine.interruptGenerate?.();
+      await drainIterator(iterator);
+      return { firstOutput, chunks: chunkCount, deltas: deltaCount };
+    }
+  }
+}
+
+async function resumeValidationSession(
+  sessionId: string,
+  options: { interruptAfterDeltas?: number } = {},
+): Promise<ResumeValidationSession> {
+  const restored = (await engine.resumeChatCompletion(
+    sessionId,
+  )) as ResumeResultLike;
+  const continuation = await engine.resumeChatCompletion(sessionId, {
+    continueGeneration: true,
+    stream: true,
+  });
+  if (!isAsyncIterable(continuation)) {
+    return {
+      recoveredText: restored.recoveredText,
+      deltaText: "",
+      chunks: 0,
+      deltas: 0,
+      interrupted: false,
+      recoveryMode: restored.recoveryMode,
+      streamed: false,
+      nonStreamResult: continuation,
+    };
+  }
+
+  const iterator = continuation[Symbol.asyncIterator]();
+  let deltaText = "";
+  let chunkCount = 0;
+  let deltaCount = 0;
+  let interrupted = false;
+
+  while (true) {
+    const next = await iterator.next();
+    if (next.done) {
+      break;
+    }
+    chunkCount += 1;
+    const delta = next.value.choices?.[0]?.delta?.content ?? "";
+    if (delta === "") {
+      continue;
+    }
+    deltaText += delta;
+    deltaCount += 1;
+    if (
+      options.interruptAfterDeltas !== undefined &&
+      deltaCount >= options.interruptAfterDeltas
+    ) {
+      await engine.interruptGenerate?.();
+      interrupted = true;
+      break;
+    }
+  }
+  if (interrupted) {
+    await drainIterator(iterator);
+  }
+
+  return {
+    recoveredText: restored.recoveredText,
+    deltaText,
+    chunks: chunkCount,
+    deltas: deltaCount,
+    interrupted,
+    recoveryMode: restored.recoveryMode,
+    streamed: true,
+  };
+}
+
+async function findValidationSession(sessionId: string): Promise<unknown> {
+  const sessions = await engine.listResumableSessions();
+  return sessions.find(
+    (session: { sessionId?: unknown }) => session.sessionId === sessionId,
+  );
+}
+
+async function ensureWorkerModelLoaded(): Promise<void> {
+  engineModeSelect.value = "worker";
+  await loadModel();
+}
+
+async function validateWorkerStreamingResume(): Promise<unknown> {
+  await ensureWorkerModelLoaded();
+  const sessionId = validationSessionId("worker-stream");
+  let passed = false;
+  await resetValidationSession(sessionId);
+  try {
+    const interrupted = await startInterruptedValidationSession(
+      sessionId,
+      validationPrompt("worker streaming resume"),
+    );
+    const resumed = await resumeValidationSession(sessionId);
+    if (!resumed.streamed) {
+      throw new Error("Resume continuation did not return a stream.");
+    }
+    if (resumed.deltaText.length === 0) {
+      throw new Error("Resume stream produced no continuation text.");
+    }
+    passed = true;
+    return {
+      sessionId,
+      interrupted,
+      resumed: {
+        chunks: resumed.chunks,
+        deltas: resumed.deltas,
+        recoveryMode: resumed.recoveryMode,
+        recoveredChars: resumed.recoveredText.length,
+        deltaChars: resumed.deltaText.length,
+      },
+      session: await findValidationSession(sessionId),
+    };
+  } finally {
+    if (passed) {
+      await resetValidationSession(sessionId);
+    }
+  }
+}
+
+async function validateRepeatedResume(): Promise<unknown> {
+  await ensureWorkerModelLoaded();
+  const sessionId = validationSessionId("repeat-resume");
+  let passed = false;
+  await resetValidationSession(sessionId);
+  try {
+    const interrupted = await startInterruptedValidationSession(
+      sessionId,
+      validationPrompt("same-session repeated resume"),
+    );
+    const firstResume = await resumeValidationSession(sessionId, {
+      interruptAfterDeltas: 1,
+    });
+    if (!firstResume.streamed) {
+      throw new Error("First resume continuation did not return a stream.");
+    }
+    if (!firstResume.interrupted || firstResume.deltaText.length === 0) {
+      throw new Error("First resume did not interrupt after streaming text.");
+    }
+    const afterFirstResume = await findValidationSession(sessionId);
+    const secondResume = await resumeValidationSession(sessionId);
+    if (!secondResume.streamed) {
+      throw new Error("Second resume continuation did not return a stream.");
+    }
+    if (secondResume.deltaText.length === 0) {
+      throw new Error("Second resume produced no continuation text.");
+    }
+    passed = true;
+    return {
+      sessionId,
+      interrupted,
+      firstResume: {
+        chunks: firstResume.chunks,
+        deltas: firstResume.deltas,
+        deltaChars: firstResume.deltaText.length,
+        recoveryMode: firstResume.recoveryMode,
+      },
+      afterFirstResume,
+      secondResume: {
+        chunks: secondResume.chunks,
+        deltas: secondResume.deltas,
+        deltaChars: secondResume.deltaText.length,
+        recoveryMode: secondResume.recoveryMode,
+      },
+    };
+  } finally {
+    if (passed) {
+      await resetValidationSession(sessionId);
+    }
+  }
+}
+
+async function validateWorkerLockExclusion(): Promise<unknown> {
+  await ensureWorkerModelLoaded();
+  const sessionId = validationSessionId("worker-lock");
+  let passed = false;
+  await resetValidationSession(sessionId);
+  const chunks = await engine.chat.completions.create(
+    validationRequest(sessionId, validationPrompt("worker lock exclusion"), {
+      maxTokens: 384,
+    }),
+  );
+  if (!isAsyncIterable(chunks)) {
+    throw new Error("Expected streaming validation generation.");
+  }
+
+  const iterator = chunks[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("Generation finished before lock exclusion probe.");
+  }
+
+  const contenderWorker = new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  });
+  const contender = new (webllm as any).WebWorkerMLCEngine(contenderWorker, {
+    appConfig: resumableAppConfig(),
+  });
+
+  try {
+    let rejectedMessage = "";
+    try {
+      await contender.resumeChatCompletion(sessionId, {
+        continueGeneration: true,
+      });
+    } catch (err) {
+      rejectedMessage = err instanceof Error ? err.message : String(err);
+    }
+    if (!rejectedMessage.includes("Resumable session is already active")) {
+      throw new Error(
+        `Expected active-session lock rejection, got: ${rejectedMessage}`,
+      );
+    }
+    passed = true;
+    return {
+      sessionId,
+      firstChunkHadText:
+        (first.value.choices?.[0]?.delta?.content ?? "").length > 0,
+      rejectedMessage,
+    };
+  } finally {
+    await engine.interruptGenerate?.();
+    await drainIterator(iterator).catch((err) => {
+      logLine("Validation lock cleanup drain failed", errorJson(err));
+    });
+    await contender.unload?.().catch(() => undefined);
+    contenderWorker.terminate();
+    if (passed) {
+      await resetValidationSession(sessionId);
+    }
+  }
+}
+
+async function validateLowQuotaObserved(): Promise<ValidationCaseResult> {
+  const name = "low quota behavior";
+  const started = performance.now();
+  try {
+    const estimate = await navigator.storage?.estimate?.();
+    if (
+      typeof estimate?.quota !== "number" ||
+      typeof estimate.usage !== "number"
+    ) {
+      return {
+        name,
+        status: "skip",
+        elapsedMs: performance.now() - started,
+        details: "navigator.storage.estimate() is unavailable.",
+      };
+    }
+    const freeBytes = Math.max(0, estimate.quota - estimate.usage);
+    if (freeBytes >= LOW_QUOTA_THRESHOLD_BYTES) {
+      return {
+        name,
+        status: "skip",
+        elapsedMs: performance.now() - started,
+        details: {
+          freeBytes,
+          quotaBytes: estimate.quota,
+          thresholdBytes: LOW_QUOTA_THRESHOLD_BYTES,
+          reason:
+            "Browser quota is not low enough to exercise KV checkpoint skipping.",
+        },
+      };
+    }
+
+    await ensureWorkerModelLoaded();
+    const sessionId = validationSessionId("low-quota");
+    let passed = false;
+    await resetValidationSession(sessionId);
+    try {
+      const interrupted = await startInterruptedValidationSession(
+        sessionId,
+        validationPrompt("low quota"),
+      );
+      const session = await findValidationSession(sessionId);
+      const restored = (await engine.resumeChatCompletion(
+        sessionId,
+      )) as ResumeResultLike;
+      if (restored.recoveredText.length === 0) {
+        throw new Error("Low-quota recovery produced no restored text.");
+      }
+      passed = true;
+      return {
+        name,
+        status: "pass",
+        elapsedMs: performance.now() - started,
+        details: {
+          sessionId,
+          freeBytes,
+          quotaBytes: estimate.quota,
+          interrupted,
+          recoveryMode: restored.recoveryMode,
+          restoredChars: restored.recoveredText.length,
+          session,
+        },
+      };
+    } finally {
+      if (passed) {
+        await resetValidationSession(sessionId);
+      }
+    }
+  } catch (err) {
+    return {
+      name,
+      status: "fail",
+      elapsedMs: performance.now() - started,
+      details: errorJson(err),
+    };
+  }
+}
+
+async function runValidationCase(
+  name: string,
+  fn: () => Promise<unknown>,
+): Promise<ValidationCaseResult> {
+  const started = performance.now();
+  try {
+    return {
+      name,
+      status: "pass",
+      elapsedMs: performance.now() - started,
+      details: await fn(),
+    };
+  } catch (err) {
+    return {
+      name,
+      status: "fail",
+      elapsedMs: performance.now() - started,
+      details: errorJson(err),
+    };
+  }
+}
+
+function renderValidationResults(results: ValidationCaseResult[]): void {
+  validationPre.textContent = JSON.stringify(results, null, 2);
+}
+
+async function runValidationSuite(): Promise<void> {
+  if (streaming || validationRunning) {
+    return;
+  }
+  validationRunning = true;
+  streaming = true;
+  const results: ValidationCaseResult[] = [];
+  try {
+    setStatus("Running validation");
+    validationPre.textContent = "Running validation...";
+
+    results.push(
+      await runValidationCase(
+        "worker mode streaming resume",
+        validateWorkerStreamingResume,
+      ),
+    );
+    renderValidationResults(results);
+
+    results.push(
+      await runValidationCase(
+        "same-session repeated resume",
+        validateRepeatedResume,
+      ),
+    );
+    renderValidationResults(results);
+
+    results.push(
+      await runValidationCase(
+        "worker lock exclusion",
+        validateWorkerLockExclusion,
+      ),
+    );
+    renderValidationResults(results);
+
+    results.push(await validateLowQuotaObserved());
+    renderValidationResults(results);
+
+    setStatus(
+      results.some((result) => result.status === "fail")
+        ? "Validation failed"
+        : "Validation complete",
+    );
+    logLine("Validation complete", results);
+  } finally {
+    streaming = false;
+    validationRunning = false;
+    renderMetrics();
+    await listSessions().catch(() => undefined);
+  }
+}
+
+async function deleteSession(): Promise<void> {
+  await loadModel();
+  const sessionId = currentSessionId();
+  await engine.deleteResumableSession(sessionId);
+  localStorage.removeItem(`${OUTPUT_PREFIX}${sessionId}`);
+  currentOutput = "";
+  outputPre.textContent = "";
+  sessionsPre.textContent = "";
+  renderMetrics();
+  logLine("Deleted session", { sessionId });
+}
+
+function isAsyncIterable(value: unknown): value is AsyncIterable<any> {
+  return (
+    value !== null && typeof value === "object" && Symbol.asyncIterator in value
+  );
+}
+
+function renderResumeResult(result: ResumeResultLike): void {
+  currentOutput = result.recoveredText;
+  outputPre.textContent = currentOutput;
+  saveSessionState();
+  renderMetrics();
+}
+
+function renderMetrics(): void {
+  const metrics = engine?.lastResumableMetrics;
+  if (metrics !== undefined) {
+    metricsPre.textContent = JSON.stringify(metrics, null, 2);
+    return;
+  }
+  metricsPre.textContent =
+    selectedMode() === "worker"
+      ? "Internal timing metrics are stored inside the worker engine. Switch to Main Thread mode if you need to inspect lastResumableMetrics from this page."
+      : "No resumable metrics recorded yet.";
+}
+
+function errorJson(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return {
+      name: err.name,
+      message: err.message,
+      stack: err.stack,
+    };
+  }
+  return { value: String(err) };
+}
+
+function bind(id: string, handler: () => Promise<void> | void): void {
+  element<HTMLButtonElement>(id).addEventListener("click", () => {
+    Promise.resolve(handler()).catch((err) => {
+      setStatus("Error");
+      logLine("Action failed", errorJson(err));
+    });
+  });
+}
+
+function bindStatePersistence(): void {
+  for (const node of [engineModeSelect, sessionInput, promptInput]) {
+    node.addEventListener("change", saveSessionState);
+  }
+  promptInput.addEventListener("input", saveSessionState);
+  sessionInput.addEventListener("input", () => {
+    const sessionId = sessionInput.value.trim();
+    currentOutput =
+      sessionId === ""
+        ? ""
+        : (localStorage.getItem(`${OUTPUT_PREFIX}${sessionId}`) ?? "");
+    outputPre.textContent = currentOutput;
+    saveSessionState();
+  });
+}
+
+async function init(): Promise<void> {
+  renderModelInfo();
+  restoreSessionState();
+  bindStatePersistence();
+  bind("load-model", loadModel);
+  bind("start", startGeneration);
+  bind("interrupt", interruptGeneration);
+  bind("reload-page", () => {
+    saveSessionState();
+    location.reload();
+  });
+  bind("list-sessions", listSessions);
+  bind("resume-text", restoreTextOnly);
+  bind("resume-continue", resumeAndContinue);
+  bind("delete-session", deleteSession);
+  bind("run-validation", runValidationSuite);
+  validationPre.textContent = "Not run.";
+  await updateEnvironment();
+  renderMetrics();
+}
+
+init().catch((err) => {
+  setStatus("Init failed");
+  logLine("Init failed", errorJson(err));
+});

--- a/examples/resumable-generation/src/style.css
+++ b/examples/resumable-generation/src/style.css
@@ -1,0 +1,233 @@
+:root {
+  color: #111827;
+  background: #f4f7fb;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 1px solid #9aa7b7;
+  background: #ffffff;
+  color: #111827;
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button:hover {
+  border-color: #315f99;
+  background: #f8fbff;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.app {
+  max-width: 1360px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+h1 {
+  font-size: 28px;
+  line-height: 1.15;
+  margin: 0 0 6px;
+}
+
+p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.status {
+  border: 1px solid #c2ccd8;
+  background: #ffffff;
+  min-width: 160px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-align: center;
+}
+
+.panel {
+  border: 1px solid #d3dbe5;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: minmax(240px, 1.5fr) repeat(4, minmax(140px, 1fr));
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 12px;
+}
+
+.prompt-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 5px;
+}
+
+.field.small {
+  max-width: 110px;
+}
+
+.wide {
+  min-width: 240px;
+}
+
+label,
+.panel-title {
+  color: #374151;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+input,
+select,
+textarea,
+.static-field,
+.static-link {
+  border: 1px solid #b9c4d1;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  min-height: 36px;
+  padding: 7px 9px;
+}
+
+.static-field,
+.static-link {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.static-link {
+  color: #245b9b;
+  text-decoration: none;
+}
+
+.static-link:hover {
+  text-decoration: underline;
+}
+
+textarea {
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  white-space: nowrap;
+}
+
+.check input {
+  min-height: 0;
+}
+
+.actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.validation-panel {
+  margin-bottom: 12px;
+}
+
+.validation-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.9fr);
+  gap: 12px;
+}
+
+.panel-title {
+  margin-bottom: 8px;
+}
+
+pre {
+  margin: 0;
+  min-height: 180px;
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid #e1e7ef;
+  background: #f9fbfd;
+  border-radius: 6px;
+  padding: 10px;
+  color: #111827;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+@media (max-width: 960px) {
+  .controls,
+  .prompt-panel,
+  .grid,
+  .topbar {
+    grid-template-columns: 1fr;
+    display: grid;
+  }
+
+  .field.small {
+    max-width: none;
+  }
+
+  .status {
+    width: 100%;
+  }
+}

--- a/examples/resumable-generation/src/worker.ts
+++ b/examples/resumable-generation/src/worker.ts
@@ -1,0 +1,7 @@
+import { WebWorkerMLCEngineHandler } from "@mlc-ai/web-llm";
+
+const handler = new WebWorkerMLCEngineHandler();
+
+self.onmessage = (event: MessageEvent) => {
+  handler.onmessage(event);
+};

--- a/examples/resumable-generation/src/ws-browser-stub.ts
+++ b/examples/resumable-generation/src/ws-browser-stub.ts
@@ -1,0 +1,13 @@
+export default class NodeWebSocketStub {
+  constructor() {
+    throw new Error("Node ws is not available in the browser.");
+  }
+}
+
+export class WebSocketServer {
+  constructor() {
+    throw new Error("Node ws server is not available in the browser.");
+  }
+}
+
+export const Server = WebSocketServer;

--- a/examples/resumable-generation/tsconfig.json
+++ b/examples/resumable-generation/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["DOM", "WebWorker", "ES2022"],
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/resumable-generation/vite.config.ts
+++ b/examples/resumable-generation/vite.config.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+import { defineConfig } from "vite";
+
+const wsStub = path.resolve(__dirname, "src/ws-browser-stub.ts");
+
+export default defineConfig({
+  server: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
+  preview: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
+  resolve: {
+    alias: {
+      ws: wsStub,
+    },
+  },
+  optimizeDeps: {
+    exclude: ["@mlc-ai/web-llm"],
+    esbuildOptions: {
+      alias: {
+        ws: wsStub,
+      },
+    },
+  },
+  worker: {
+    format: "es",
+  },
+});


### PR DESCRIPTION
Adds a Qwen3 example for saving a generation session, reloading or reopening the page, and restoring the saved text before continuing. Supports dedicated-worker and main-thread execution, KV checkpoint recovery, token replay, exact and relaxed persistence, and session listing and deletion. The model WASM URL is configurable. KV recovery requires a checkpoint-capable model library while token replay works without one.